### PR TITLE
Add per-job notify field to control Telegram forwarding

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -635,7 +635,11 @@ export async function start(args: string[] = []) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
           .then((prompt) => run(job.name, prompt))
-          .then((r) => forwardToTelegram(job.name, r))
+          .then((r) => {
+            if (job.notify === false) return;
+            if (job.notify === "error" && r.exitCode === 0) return;
+            forwardToTelegram(job.name, r);
+          })
           .finally(async () => {
             if (job.recurring) return;
             try {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -8,6 +8,7 @@ export interface Job {
   schedule: string;
   prompt: string;
   recurring: boolean;
+  notify: true | false | "error";
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -41,7 +42,16 @@ function parseJobFile(name: string, content: string): Job | null {
     : "";
   const recurring = recurringRaw === "true" || recurringRaw === "yes" || recurringRaw === "1";
 
-  return { name, schedule, prompt, recurring };
+  const notifyLine = lines.find((l) => l.startsWith("notify:"));
+  const notifyRaw = notifyLine
+    ? parseFrontmatterValue(notifyLine.replace("notify:", "")).toLowerCase()
+    : "";
+  const notify: true | false | "error" =
+    notifyRaw === "false" || notifyRaw === "no" ? false
+    : notifyRaw === "error" ? "error"
+    : true;
+
+  return { name, schedule, prompt, recurring, notify };
 }
 
 export async function loadJobs(): Promise<Job[]> {


### PR DESCRIPTION
## Summary

- Adds optional `notify` field to job frontmatter (`true` | `false` | `"error"`)
- `true` (default): always forward output to Telegram (backward compatible)
- `false`: never forward (for silent housekeeping jobs like vault-sync)
- `"error"`: only forward on non-zero exit code

## Motivation

Recurring housekeeping jobs (e.g. vault-sync every 5 minutes) generate noise in Telegram. Prompt-based suppression is fragile — job names still get sent even when Claude produces no meaningful output. This adds declarative control at the job level.

## Changes

- `src/jobs.ts`: Added `notify` property to `Job` interface and parsing in `parseJobFile()`
- `src/commands/start.ts`: Conditional `forwardToTelegram()` based on `notify` field

## Usage

```yaml
---
schedule: "*/5 * * * *"
notify: false
---
Sync the vault...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)