### PR TITLE
fix: broaden rate limit pattern to catch all known Claude messages

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,7 +22,7 @@ export interface RunResult {
   exitCode: number;
 }
 
-const RATE_LIMIT_PATTERN = /you(?:'|’)ve hit your limit/i;
+const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
 let queue: Promise<unknown> = Promise.resolve();


### PR DESCRIPTION
## Problem

The fallback model logic never triggered for users with exhausted monthly extra usage quota because the rate limit pattern only matched one specific message:

```ts
// Before
const RATE_LIMIT_PATTERN = /you(?:'|')ve hit your limit/i;
```

Claude Code emits at least two distinct rate limit messages:
- `"You've hit your limit"` — standard rate limit
- `"You're out of extra usage · resets Mar 12, 10am (UTC)"` — monthly extra usage exhausted

The second message was completely missed, so `extractRateLimitMessage` returned `null` and the fallback was never attempted.

There's also a secondary issue: the apostrophe in `you've` can be rendered as different Unicode characters depending on the terminal/platform. Using `.` instead of explicit quote chars makes the match robust against all variants.

## Fix

```ts
// After
const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
```

## Testing

Confirmed against real Claude Code output logs showing `"You're out of extra usage · resets Mar 12, 10am (UTC)"` with exit code 1 and no fallback being triggered.