### PR TITLE
feat: add file/photo sending to Telegram bot

### DIFF
--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -2,8 +2,8 @@ import { ensureProjectClaudeMd, run, runUserMessage } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession } from "../sessions";
 import { transcribeAudioToText } from "../whisper";
-import { mkdir } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { mkdir, stat } from "node:fs/promises";
+import { extname, basename, join } from "node:path";
 
 // --- Markdown → Telegram HTML conversion (ported from nanobot) ---
 
@@ -322,6 +322,95 @@ async function sendReaction(token: string, chatId: number, messageId: number, em
   });
 }
 
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+
+function isImageExtension(filePath: string): boolean {
+  return IMAGE_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+async function sendFileDocument(
+  token: string,
+  chatId: number,
+  filePath: string,
+  caption?: string,
+  threadId?: number
+): Promise<void> {
+  const fileData = await Bun.file(filePath).arrayBuffer();
+  const fileName = basename(filePath);
+  const blob = new Blob([fileData]);
+  const form = new FormData();
+  form.append("chat_id", String(chatId));
+  form.append("document", blob, fileName);
+  if (caption) form.append("caption", caption);
+  if (threadId) form.append("message_thread_id", String(threadId));
+
+  const res = await fetch(`${API_BASE}${token}/sendDocument`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Telegram sendDocument: ${res.status} ${res.statusText} ${body}`);
+  }
+}
+
+async function sendPhotoFile(
+  token: string,
+  chatId: number,
+  filePath: string,
+  caption?: string,
+  threadId?: number
+): Promise<void> {
+  const fileData = await Bun.file(filePath).arrayBuffer();
+  const fileName = basename(filePath);
+  const blob = new Blob([fileData]);
+  const form = new FormData();
+  form.append("chat_id", String(chatId));
+  form.append("photo", blob, fileName);
+  if (caption) form.append("caption", caption);
+  if (threadId) form.append("message_thread_id", String(threadId));
+
+  const res = await fetch(`${API_BASE}${token}/sendPhoto`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Telegram sendPhoto: ${res.status} ${res.statusText} ${body}`);
+  }
+}
+
+async function sendLocalFile(
+  token: string,
+  chatId: number,
+  filePath: string,
+  caption?: string,
+  threadId?: number
+): Promise<void> {
+  if (isImageExtension(filePath)) {
+    await sendPhotoFile(token, chatId, filePath, caption, threadId);
+  } else {
+    await sendFileDocument(token, chatId, filePath, caption, threadId);
+  }
+}
+
+interface FileDirective {
+  path: string;
+}
+
+function extractFileDirectives(text: string): { cleanedText: string; files: FileDirective[] } {
+  const files: FileDirective[] = [];
+  const cleanedText = text
+    .replace(/\[file:(\/[^\]\r\n]+)\]/g, (_match, filePath) => {
+      files.push({ path: filePath.trim() });
+      return "";
+    })
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { cleanedText, files };
+}
+
 let botUsername: string | null = null;
 let botId: number | null = null;
 
@@ -603,12 +692,29 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     if (result.exitCode !== 0) {
       await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
     } else {
-      const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
+      const { cleanedText: afterReaction, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {
         await sendReaction(config.token, chatId, message.message_id, reactionEmoji).catch((err) => {
           console.error(`[Telegram] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
         });
       }
+
+      // Extract [file:/path/to/file] directives from response
+      const { cleanedText, files } = extractFileDirectives(afterReaction);
+
+      // Send files
+      for (const file of files) {
+        try {
+          await stat(file.path);
+          await sendLocalFile(config.token, chatId, file.path, undefined, threadId);
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.error(`[Telegram] Failed to send file ${file.path} for ${label}: ${errMsg}`);
+          await sendMessage(config.token, chatId, `Could not send file ${file.path}: ${errMsg}`, threadId);
+        }
+      }
+
+      // Send remaining text
       await sendMessage(config.token, chatId, cleanedText || "(empty response)", threadId);
     }
   } catch (err) {
@@ -730,7 +836,7 @@ async function poll(): Promise<void> {
 // --- Exports ---
 
 /** Send a message to a specific chat (used by heartbeat forwarding) */
-export { sendMessage };
+export { sendMessage, sendLocalFile, sendPhotoFile, sendFileDocument };
 
 process.on("SIGTERM", () => { running = false; });
 process.on("SIGINT", () => { running = false; });


### PR DESCRIPTION
## Summary

- Adds `[file:/path/to/file]` directive support in Claude's responses to send local files via Telegram
- Images (png, jpg, jpeg, gif, webp) are sent via `sendPhoto` API; all other files via `sendDocument` API
- Uses Bun's native `FormData` and `Blob` — zero new dependencies
- Graceful error handling: if a file doesn't exist or upload fails, sends an error message to the chat instead of crashing

## How it works

When Claude includes `[file:/absolute/path/to/file.png]` in its response:
1. The directive is extracted and stripped from the displayed text
2. The file extension determines whether to use `sendPhoto` or `sendDocument`
3. The file is uploaded via multipart/form-data to the Telegram Bot API
4. The remaining text is sent as a normal message

## Functions added

- `sendPhotoFile()` — uploads an image via Telegram's `sendPhoto` endpoint
- `sendFileDocument()` — uploads any file via Telegram's `sendDocument` endpoint
- `sendLocalFile()` — auto-routes to photo or document based on extension
- `extractFileDirectives()` — parses `[file:/path]` patterns from response text

## Test plan

- [x] Send a message that triggers Claude to respond with `[file:/path/to/image.png]` → image is sent as photo
- [x] Send a message with `[file:/path/to/doc.pdf]` → file is sent as document
- [x] Test with a non-existent path → error message sent gracefully
- [x] Test with multiple `[file:...]` directives in one response
- [x] Verify remaining text is still sent correctly after directives are stripped
- [x] Verify existing functionality (reactions, typing, etc.) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)