### PR TITLE
fix: protect job frontmatter from being overwritten during execution

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { run, runUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
-import { clearJobSchedule, loadJobs } from "../jobs";
+import { clearJobSchedule, loadJobs, snapshotJobFrontmatter } from "../jobs";
 import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
 import { getDayAndMinuteAtOffset } from "../timezone";
@@ -693,23 +693,30 @@ export async function start(args: string[] = []) {
     const now = new Date();
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
-        resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt))
-          .then((r) => {
-            if (job.notify === false) return;
-            if (job.notify === "error" && r.exitCode === 0) return;
-            forwardToTelegram(job.name, r);
-            forwardToDiscord(job.name, r);
-          })
-          .finally(async () => {
-            if (job.recurring) return;
-            try {
-              await clearJobSchedule(job.name);
-              console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
-            } catch (err) {
-              console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
-            }
-          });
+        snapshotJobFrontmatter(job.name)
+          .then((restoreFrontmatter) =>
+            resolvePrompt(job.prompt)
+              .then((prompt) => run(job.name, prompt))
+              .then(async (r) => {
+                const restored = await restoreFrontmatter();
+                if (restored) {
+                  console.log(`[${ts()}] Restored frontmatter for job: ${job.name}`);
+                }
+                if (job.notify === false) return;
+                if (job.notify === "error" && r.exitCode === 0) return;
+                forwardToTelegram(job.name, r);
+                forwardToDiscord(job.name, r);
+              })
+              .finally(async () => {
+                if (job.recurring) return;
+                try {
+                  await clearJobSchedule(job.name);
+                  console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
+                } catch (err) {
+                  console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
+                }
+              })
+          );
       }
     }
     updateState();

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -72,6 +72,59 @@ export async function loadJobs(): Promise<Job[]> {
   return jobs;
 }
 
+/**
+ * Snapshot a job file's frontmatter before execution.
+ * Returns a restore function that re-applies the original frontmatter
+ * if Claude overwrote or stripped it during the run.
+ */
+export async function snapshotJobFrontmatter(
+  jobName: string
+): Promise<() => Promise<boolean>> {
+  const path = join(JOBS_DIR, `${jobName}.md`);
+  let originalContent: string;
+  try {
+    originalContent = await Bun.file(path).text();
+  } catch {
+    return async () => false;
+  }
+
+  const originalMatch = originalContent.match(
+    /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/
+  );
+  if (!originalMatch) return async () => false;
+
+  const originalFrontmatter = originalMatch[1];
+
+  return async () => {
+    let currentContent: string;
+    try {
+      currentContent = await Bun.file(path).text();
+    } catch {
+      return false;
+    }
+
+    const currentMatch = currentContent.match(
+      /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/
+    );
+
+    // File completely mangled — restore entire original
+    if (!currentMatch) {
+      await Bun.write(path, originalContent);
+      return true;
+    }
+
+    // Frontmatter was modified — restore it, keep current body
+    if (currentMatch[1].trim() !== originalFrontmatter.trim()) {
+      const restoredBody = currentMatch[2].trim();
+      const restored = `---\n${originalFrontmatter}\n---\n${restoredBody}\n`;
+      await Bun.write(path, restored);
+      return true;
+    }
+
+    return false;
+  };
+}
+
 export async function clearJobSchedule(jobName: string): Promise<void> {
   const path = join(JOBS_DIR, `${jobName}.md`);
   const content = await Bun.file(path).text();


### PR DESCRIPTION
## Summary

- Adds `snapshotJobFrontmatter()` to `jobs.ts` — takes a snapshot of the job file's YAML frontmatter before execution and returns a restore function
- Integrates snapshot/restore into the job execution loop in `start.ts` — if Claude modifies or strips the frontmatter during a run, it is automatically restored
- Handles edge cases: file deleted, frontmatter completely mangled, or body content changed by Claude (preserves updated body, restores only frontmatter)
- Logs a message when restoration occurs for debugging

Fixes #1

## Test plan

- [ ] Create a job with `schedule` and `recurring` frontmatter
- [ ] Run the job and verify frontmatter remains intact
- [ ] Manually strip frontmatter from a job file mid-run to simulate the bug, verify it gets restored
- [ ] Verify one-shot jobs still clear their schedule correctly after execution