### PR TITLE
fix: prevent fallback model from corrupting resumed session

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { run, runUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
-import { clearJobSchedule, loadJobs } from "../jobs";
+import { clearJobSchedule, loadJobs, snapshotJobFrontmatter } from "../jobs";
 import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
 import { getDayAndMinuteAtOffset } from "../timezone";
@@ -693,23 +693,30 @@ export async function start(args: string[] = []) {
     const now = new Date();
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
-        resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt))
-          .then((r) => {
-            if (job.notify === false) return;
-            if (job.notify === "error" && r.exitCode === 0) return;
-            forwardToTelegram(job.name, r);
-            forwardToDiscord(job.name, r);
-          })
-          .finally(async () => {
-            if (job.recurring) return;
-            try {
-              await clearJobSchedule(job.name);
-              console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
-            } catch (err) {
-              console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
-            }
-          });
+        snapshotJobFrontmatter(job.name)
+          .then((restoreFrontmatter) =>
+            resolvePrompt(job.prompt)
+              .then((prompt) => run(job.name, prompt))
+              .then(async (r) => {
+                const restored = await restoreFrontmatter();
+                if (restored) {
+                  console.log(`[${ts()}] Restored frontmatter for job: ${job.name}`);
+                }
+                if (job.notify === false) return;
+                if (job.notify === "error" && r.exitCode === 0) return;
+                forwardToTelegram(job.name, r);
+                forwardToDiscord(job.name, r);
+              })
+              .finally(async () => {
+                if (job.recurring) return;
+                try {
+                  await clearJobSchedule(job.name);
+                  console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
+                } catch (err) {
+                  console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
+                }
+              })
+          );
       }
     }
     updateState();

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -499,7 +499,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown"}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -511,7 +511,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown"}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -72,6 +72,59 @@ export async function loadJobs(): Promise<Job[]> {
   return jobs;
 }
 
+/**
+ * Snapshot a job file's frontmatter before execution.
+ * Returns a restore function that re-applies the original frontmatter
+ * if Claude overwrote or stripped it during the run.
+ */
+export async function snapshotJobFrontmatter(
+  jobName: string
+): Promise<() => Promise<boolean>> {
+  const path = join(JOBS_DIR, `${jobName}.md`);
+  let originalContent: string;
+  try {
+    originalContent = await Bun.file(path).text();
+  } catch {
+    return async () => false;
+  }
+
+  const originalMatch = originalContent.match(
+    /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/
+  );
+  if (!originalMatch) return async () => false;
+
+  const originalFrontmatter = originalMatch[1];
+
+  return async () => {
+    let currentContent: string;
+    try {
+      currentContent = await Bun.file(path).text();
+    } catch {
+      return false;
+    }
+
+    const currentMatch = currentContent.match(
+      /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/
+    );
+
+    // File completely mangled — restore entire original
+    if (!currentMatch) {
+      await Bun.write(path, originalContent);
+      return true;
+    }
+
+    // Frontmatter was modified — restore it, keep current body
+    if (currentMatch[1].trim() !== originalFrontmatter.trim()) {
+      const restoredBody = currentMatch[2].trim();
+      const restored = `---\n${originalFrontmatter}\n---\n${restoredBody}\n`;
+      await Bun.write(path, restored);
+      return true;
+    }
+
+    return false;
+  };
+}
+
 export async function clearJobSchedule(jobName: string): Promise<void> {
   const path = join(JOBS_DIR, `${jobName}.md`);
   const content = await Bun.file(path).text();

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession } from "./sessions";
+import { getSession, createSession, backupSession } from "./sessions";
 import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 
@@ -23,6 +23,7 @@ export interface RunResult {
 }
 
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
+const SIGNATURE_ERROR = /Invalid.*signature.*thinking block/i;
 
 // Serial queue — prevents concurrent --resume on the same session
 let queue: Promise<unknown> = Promise.resolve();
@@ -288,23 +289,58 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
     console.warn(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv);
+    // Strip --resume to avoid mixing thinking block signatures from
+    // different providers in the same session history (see issue #18).
+    const fallbackArgs = args.filter(
+      (a) => a !== "--resume" && a !== existing?.sessionId
+    );
+    // Force text output for fallback one-shot calls
+    const fmtIdx = fallbackArgs.indexOf("--output-format");
+    if (fmtIdx !== -1 && fmtIdx + 1 < fallbackArgs.length) {
+      fallbackArgs[fmtIdx + 1] = "text";
+    }
+    exec = await runClaudeOnce(fallbackArgs, fallbackConfig.model, fallbackConfig.api, baseEnv);
     usedFallback = true;
   }
 
-  const rawStdout = exec.rawStdout;
-  const stderr = exec.stderr;
-  const exitCode = exec.exitCode;
+  let rawStdout = exec.rawStdout;
+  let stderr = exec.stderr;
+  let exitCode = exec.exitCode;
   let stdout = rawStdout;
   let sessionId = existing?.sessionId ?? "unknown";
+
+  // Auto-detect corrupted session from thinking block signature mismatch.
+  // Back up the broken session and retry with a fresh one (issue #18).
+  let recoveredSession = false;
+  if (exitCode !== 0 && !isNew && SIGNATURE_ERROR.test(rawStdout + stderr)) {
+    const backupName = await backupSession();
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Detected corrupted session (thinking block signature mismatch). Backed up to ${backupName}, retrying with fresh session...`
+    );
+    // Retry as a fresh one-shot call (no --resume, json output to capture new session_id)
+    const freshArgs = args.filter(
+      (a) => a !== "--resume" && a !== existing?.sessionId
+    );
+    const fmtIdx = freshArgs.indexOf("--output-format");
+    if (fmtIdx !== -1 && fmtIdx + 1 < freshArgs.length) {
+      freshArgs[fmtIdx + 1] = "json";
+    }
+    exec = await runClaudeOnce(freshArgs, primaryConfig.model, primaryConfig.api, baseEnv);
+    rawStdout = exec.rawStdout;
+    stderr = exec.stderr;
+    exitCode = exec.exitCode;
+    stdout = rawStdout;
+    recoveredSession = true;
+  }
+
   const rateLimitMessage = extractRateLimitMessage(rawStdout, stderr);
 
   if (rateLimitMessage) {
     stdout = rateLimitMessage;
   }
 
-  // For new sessions, parse the JSON to extract session_id and result text
-  if (!rateLimitMessage && isNew && exitCode === 0) {
+  // For new sessions (or recovered sessions), parse JSON to extract session_id
+  if (!rateLimitMessage && (isNew || recoveredSession) && exitCode === 0) {
     try {
       const json = JSON.parse(rawStdout);
       sessionId = json.session_id;


### PR DESCRIPTION
## Summary

Implements Option C from #18 — both prevention and recovery:

- **Prevention (Option A):** When falling back to an alternative API provider on rate limit, `--resume` and the session ID are stripped from the args. The fallback runs as a one-shot call, keeping the primary session history clean and avoiding thinking block signature mixing.

- **Recovery (Option B):** After any failed execution on a resumed session, stdout+stderr are checked against the signature error pattern. If detected, the corrupted session is automatically backed up and the call is retried with a fresh session.

- **Bonus:** `forwardToTelegram` and `forwardToDiscord` now fall back to `result.stdout` when `result.stderr` is empty, instead of showing "Unknown".

Fixes #18

## Test plan

- [ ] Configure primary + fallback with different `ANTHROPIC_BASE_URL`
- [ ] Trigger rate limit on primary — verify fallback runs without `--resume`
- [ ] Verify primary session remains usable after fallback fires
- [ ] Simulate corrupted session — verify auto-recovery kicks in, backs up old session, creates fresh one
- [ ] Verify Telegram/Discord error messages now show actual error text instead of "Unknown"