### PR TITLE
feat: add Telegram message debounce support

### DIFF
--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -659,6 +659,77 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
   await callApi(config.token, "answerCallbackQuery", { callback_query_id: query.id }).catch(() => {});
 }
 
+// --- Debounce buffer ---
+
+interface DebouncedEntry {
+  messages: TelegramMessage[];
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const debounceBuffer = new Map<number, DebouncedEntry>();
+
+function flushDebounced(chatId: number): void {
+  const entry = debounceBuffer.get(chatId);
+  if (!entry || entry.messages.length === 0) {
+    debounceBuffer.delete(chatId);
+    return;
+  }
+  debounceBuffer.delete(chatId);
+
+  if (entry.messages.length === 1) {
+    handleMessage(entry.messages[0]).catch((err) => {
+      console.error(`[Telegram] Unhandled: ${err}`);
+    });
+    return;
+  }
+
+  const first = entry.messages[0];
+  const merged: TelegramMessage = {
+    message_id: first.message_id,
+    from: first.from,
+    reply_to_message: first.reply_to_message,
+    chat: first.chat,
+    message_thread_id: first.message_thread_id,
+    text: entry.messages
+      .map((m) => {
+        const { text } = getMessageTextAndEntities(m);
+        return text;
+      })
+      .filter(Boolean)
+      .join("\n"),
+    entities: first.entities,
+  };
+
+  for (const m of entry.messages) {
+    if (m.photo && m.photo.length > 0 && !merged.photo) merged.photo = m.photo;
+    if (m.voice && !merged.voice) merged.voice = m.voice;
+    if (m.audio && !merged.audio) merged.audio = m.audio;
+    if (m.document && !merged.document) merged.document = m.document;
+  }
+
+  const count = entry.messages.length;
+  debugLog(`Debounce flush: chat=${chatId} merged=${count} messages`);
+  console.log(`[Telegram] Debounced ${count} messages from chat ${chatId}`);
+
+  handleMessage(merged).catch((err) => {
+    console.error(`[Telegram] Unhandled: ${err}`);
+  });
+}
+
+function enqueueDebounced(message: TelegramMessage, debounceMs: number): void {
+  const chatId = message.chat.id;
+  const existing = debounceBuffer.get(chatId);
+
+  if (existing) {
+    clearTimeout(existing.timer);
+    existing.messages.push(message);
+    existing.timer = setTimeout(() => flushDebounced(chatId), debounceMs);
+  } else {
+    const timer = setTimeout(() => flushDebounced(chatId), debounceMs);
+    debounceBuffer.set(chatId, { messages: [message], timer });
+  }
+}
+
 // --- Polling loop ---
 
 let running = true;
@@ -680,6 +751,7 @@ async function poll(): Promise<void> {
 
   console.log("Telegram bot started (long polling)");
   console.log(`  Allowed users: ${config.allowedUserIds.length === 0 ? "all" : config.allowedUserIds.join(", ")}`);
+  if (config.debounceMs > 0) console.log(`  Debounce: ${config.debounceMs}ms`);
   if (telegramDebug) console.log("  Debug: enabled");
 
   while (running) {
@@ -704,9 +776,13 @@ async function poll(): Promise<void> {
           update.edited_channel_post,
         ].filter((m): m is TelegramMessage => Boolean(m));
         for (const incoming of incomingMessages) {
-          handleMessage(incoming).catch((err) => {
-            console.error(`[Telegram] Unhandled: ${err}`);
-          });
+          if (config.debounceMs > 0) {
+            enqueueDebounced(incoming, config.debounceMs);
+          } else {
+            handleMessage(incoming).catch((err) => {
+              console.error(`[Telegram] Unhandled: ${err}`);
+            });
+          }
         }
         if (update.my_chat_member) {
           handleMyChatMember(update.my_chat_member).catch((err) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [] },
+  telegram: { token: "", allowedUserIds: [], debounceMs: 0 },
   discord: { token: "", allowedUserIds: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
@@ -48,6 +48,9 @@ export interface HeartbeatConfig {
 export interface TelegramConfig {
   token: string;
   allowedUserIds: number[];
+  /** Debounce window in ms. Messages from the same chat arriving within this
+   *  window are merged into a single prompt. 0 = disabled (default). */
+  debounceMs: number;
 }
 
 export interface DiscordConfig {
@@ -148,6 +151,7 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
     telegram: {
       token: raw.telegram?.token ?? "",
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
+      debounceMs: Number.isFinite(raw.telegram?.debounceMs) ? Number(raw.telegram.debounceMs) : 0,
     },
     discord: {
       token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",


### PR DESCRIPTION
## Summary

- Adds configurable message debouncing for Telegram bot polling
- Messages from the same chat arriving within the debounce window are merged into a single prompt
- Controlled via `telegram.debounceMs` in settings.json (0 = disabled, default)

## Changes

**`src/config.ts`**
- Added `debounceMs` field to `TelegramConfig` interface
- Added parsing with `Number.isFinite` validation, defaults to 0
- Added to `DEFAULT_SETTINGS`

**`src/commands/telegram.ts`**
- Added per-chat debounce buffer (`Map<number, DebouncedEntry>`)
- When `debounceMs > 0`, incoming messages are buffered per-chat and flushed after the timer fires
- Text messages are merged via newline join; first photo/voice/document in a batch is kept
- When `debounceMs` is 0, behavior is unchanged (no debounce)

## Usage

```json
{
  "telegram": {
    "token": "...",
    "allowedUserIds": [123],
    "debounceMs": 3000
  }
}
```

## Test plan

- [ ] Set `debounceMs: 0` → verify messages process immediately (no behavior change)
- [ ] Set `debounceMs: 3000` → send multiple messages rapidly → verify they merge into one prompt
- [ ] Verify photo/voice/document from first message in batch is preserved
- [ ] Verify different chats debounce independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)