### PR TITLE
fix: graceful handling of Claude usage limits

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,7 +1,7 @@
 import { writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { fileURLToPath } from "url";
-import { run, runUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
+import { run, runUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate, isRateLimited, getRateLimitResetAt, wasRateLimitNotified, markRateLimitNotified } from "../runner";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs } from "../jobs";
@@ -538,6 +538,17 @@ export async function start(args: string[] = []) {
     );
 
     function tick() {
+      if (isRateLimited()) {
+        const resetAt = new Date(getRateLimitResetAt());
+        console.log(`[${ts()}] Heartbeat skipped (rate limited until ${resetAt.toISOString()})`);
+        if (!wasRateLimitNotified()) {
+          markRateLimitNotified();
+          const msg = `Usage limit hit. Pausing until ${resetAt.toUTCString()}. Heartbeats and jobs suspended.`;
+          forwardToTelegram("", { exitCode: 1, stdout: msg, stderr: "" });
+          forwardToDiscord("", { exitCode: 1, stdout: msg, stderr: "" });
+        }
+        return;
+      }
       if (isHeartbeatExcludedNow(currentSettings.heartbeat, currentSettings.timezoneOffsetMinutes)) {
         console.log(`[${ts()}] Heartbeat skipped (excluded window)`);
         nextHeartbeatAt = nextAllowedHeartbeatAt(
@@ -690,6 +701,7 @@ export async function start(args: string[] = []) {
   updateState();
 
   setInterval(() => {
+    if (isRateLimited()) return; // Skip all jobs while rate-limited
     const now = new Date();
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, isRateLimited, getRateLimitResetAt } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession } from "../sessions";
 import { transcribeAudioToText } from "../whisper";
@@ -545,6 +545,14 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   console.log(
     `[${new Date().toLocaleTimeString()}] Telegram ${label}${mediaSuffix}: "${text.slice(0, 60)}${text.length > 60 ? "..." : ""}"`
   );
+
+  // If rate-limited, reply immediately without calling Claude
+  if (isRateLimited()) {
+    const resetAt = new Date(getRateLimitResetAt());
+    const resetStr = resetAt.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", timeZone: "UTC" });
+    await sendMessage(config.token, chatId, `Usage limit reached. Resets at ${resetStr} UTC. I'll be back after that.`, threadId);
+    return;
+  }
 
   // Keep typing indicator alive while queued/running
   const typingInterval = setInterval(() => sendTyping(config.token, chatId, threadId), 4000);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,7 +22,55 @@ export interface RunResult {
   exitCode: number;
 }
 
-const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
+const RATE_LIMIT_PATTERN = /you(?:’|’)ve hit your limit/i;
+const RATE_LIMIT_RESET_PATTERN = /resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\(?\s*UTC\s*\)?/i;
+
+// --- Rate limit state ---
+let rateLimitResetAt: number = 0; // epoch ms; 0 = not rate-limited
+let rateLimitNotified: boolean = false;
+
+function parseRateLimitResetTime(text: string): number | null {
+  const match = text.match(RATE_LIMIT_RESET_PATTERN);
+  if (!match) return null;
+
+  let hours = Number(match[1]);
+  const minutes = match[2] ? Number(match[2]) : 0;
+  const ampm = match[3]?.toLowerCase();
+
+  if (ampm === "pm" && hours < 12) hours += 12;
+  if (ampm === "am" && hours === 12) hours = 0;
+
+  const now = new Date();
+  const reset = new Date(now);
+  reset.setUTCHours(hours, minutes, 0, 0);
+  // If the reset time is in the past, it means tomorrow
+  if (reset.getTime() <= now.getTime()) {
+    reset.setUTCDate(reset.getUTCDate() + 1);
+  }
+  return reset.getTime();
+}
+
+export function isRateLimited(): boolean {
+  if (rateLimitResetAt === 0) return false;
+  if (Date.now() >= rateLimitResetAt) {
+    rateLimitResetAt = 0;
+    rateLimitNotified = false;
+    return false;
+  }
+  return true;
+}
+
+export function getRateLimitResetAt(): number {
+  return rateLimitResetAt;
+}
+
+export function wasRateLimitNotified(): boolean {
+  return rateLimitNotified;
+}
+
+export function markRateLimitNotified(): void {
+  rateLimitNotified = true;
+}
 
 // Serial queue — prevents concurrent --resume on the same session
 let queue: Promise<unknown> = Promise.resolve();
@@ -301,6 +349,13 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
 
   if (rateLimitMessage) {
     stdout = rateLimitMessage;
+    // Set global rate limit state so daemon can pause heartbeats/jobs
+    const resetTime = parseRateLimitResetTime(rateLimitMessage);
+    rateLimitResetAt = resetTime ?? (Date.now() + 60 * 60_000); // fallback: 1 hour
+    rateLimitNotified = false;
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Rate limit detected. Reset at: ${new Date(rateLimitResetAt).toISOString()}`
+    );
   }
 
   // For new sessions, parse the JSON to extract session_id and result text


### PR DESCRIPTION
## Summary
- Detect Claude usage limits from CC output and parse the reset time
- Pause heartbeats, cron jobs, and telegram message processing during rate limit
- Send a single notification about the limit (not repeated every interval)
- Reply to Telegram messages with reset time instead of calling Claude
- Auto-resume when the limit resets

## Problem
When Claude hits a usage limit, the daemon kept firing heartbeats and bootstraps every interval, each generating a failed notification. This created notification spam and accumulated failed processes, contributing to OOM on resource-constrained servers.

## Changes
- `runner.ts`: Global rate limit state tracking, reset time parser, exported check functions
- `start.ts`: Rate limit check before heartbeat tick and cron job execution
- `telegram.ts`: Early return with human-readable message when rate-limited

## Test plan
- [ ] Verify rate limit detection from "You've hit your limit · resets Xpm (UTC)" message
- [ ] Verify heartbeats are skipped during rate limit window
- [ ] Verify single Telegram notification sent on limit detection
- [ ] Verify Telegram replies with reset time during limit
- [ ] Verify auto-resume after reset time passes
- [ ] Verify cron jobs are skipped during limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)