### PR TITLE
feat: register skill commands in Telegram bot menu

### DIFF
--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -2,7 +2,7 @@ import { ensureProjectClaudeMd, run, runUserMessage } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession } from "../sessions";
 import { transcribeAudioToText } from "../whisper";
-import { resolveSkillPrompt } from "../skills";
+import { resolveSkillPrompt, listSkills } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
 
@@ -681,6 +681,37 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
   await callApi(config.token, "answerCallbackQuery", { callback_query_id: query.id }).catch(() => {});
 }
 
+// --- Bot command menu registration ---
+
+async function registerBotCommands(token: string): Promise<void> {
+  try {
+    const skills = await listSkills();
+    const commands = [
+      { command: "start", description: "Show welcome message" },
+      { command: "reset", description: "Reset session and start fresh" },
+    ];
+    for (const skill of skills) {
+      // Telegram commands: 1-32 chars, lowercase a-z, 0-9, underscores only
+      const cmd = skill.name
+        .toLowerCase()
+        .replace(/[-.:]/g, "_")
+        .replace(/[^a-z0-9_]/g, "")
+        .slice(0, 32);
+      if (!cmd || cmd === "start" || cmd === "reset") continue;
+      if (cmd.length > 30) continue;
+      const desc = skill.description.length >= 3
+        ? skill.description.slice(0, 256)
+        : `Run ${skill.name} skill`;
+      commands.push({ command: cmd, description: desc });
+    }
+    if (commands.length > 100) commands.length = 100;
+    await callApi(token, "setMyCommands", { commands });
+    console.log(`  Commands registered: ${commands.length} (${commands.map((c) => "/" + c.command).join(", ")})`);
+  } catch (err) {
+    console.error(`[Telegram] Failed to register commands: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
 // --- Polling loop ---
 
 let running = true;
@@ -703,6 +734,9 @@ async function poll(): Promise<void> {
   console.log("Telegram bot started (long polling)");
   console.log(`  Allowed users: ${config.allowedUserIds.length === 0 ? "all" : config.allowedUserIds.join(", ")}`);
   if (telegramDebug) console.log("  Debug: enabled");
+
+  // Register available skills as bot command menu (non-blocking)
+  registerBotCommands(config.token).catch(() => {});
 
   while (running) {
     try {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,7 +1,106 @@
 import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join } from "node:path";
 import { homedir } from "node:os";
+
+export interface SkillInfo {
+  name: string;
+  description: string;
+}
+
+// List all available skills with name + short description.
+// Scans project, global, and plugin skill directories.
+export async function listSkills(): Promise<SkillInfo[]> {
+  const home = homedir();
+  const projectSkillsDir = join(process.cwd(), ".claude", "skills");
+  const globalSkillsDir = join(home, ".claude", "skills");
+  const pluginsDir = join(home, ".claude", "plugins");
+  const seen = new Set<string>();
+  const skills: SkillInfo[] = [];
+
+  await collectSkillsFromDir(projectSkillsDir, null, seen, skills);
+  await collectSkillsFromDir(globalSkillsDir, null, seen, skills);
+
+  const cachePath = join(pluginsDir, "cache");
+  if (existsSync(cachePath)) {
+    try {
+      const pluginDirs = await readdir(cachePath, { withFileTypes: true });
+      for (const pd of pluginDirs) {
+        if (!pd.isDirectory()) continue;
+        const pluginCacheDir = join(cachePath, pd.name);
+        const subDirs = await readdir(pluginCacheDir, { withFileTypes: true }).catch(() => []);
+        for (const sub of subDirs) {
+          if (!sub.isDirectory()) continue;
+          const innerDir = join(pluginCacheDir, sub.name);
+          const verDirs = await readdir(innerDir, { withFileTypes: true }).catch(() => []);
+          for (const ver of verDirs) {
+            if (!ver.isDirectory()) continue;
+            await collectSkillsFromDir(join(innerDir, ver.name, "skills"), pd.name, seen, skills);
+          }
+          await collectSkillsFromDir(join(innerDir, "skills"), pd.name, seen, skills);
+        }
+      }
+    } catch {
+      // cache dir not readable
+    }
+  }
+
+  return skills;
+}
+
+async function collectSkillsFromDir(
+  dir: string,
+  pluginName: string | null,
+  seen: Set<string>,
+  skills: SkillInfo[],
+): Promise<void> {
+  if (!existsSync(dir)) return;
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillPath = join(dir, entry.name, "SKILL.md");
+      if (!existsSync(skillPath)) continue;
+
+      let content: string;
+      try {
+        content = await readFile(skillPath, "utf8");
+      } catch {
+        continue;
+      }
+      if (!content.trim()) continue;
+
+      const name = pluginName ? `${pluginName}_${entry.name}` : entry.name;
+      if (seen.has(name)) continue;
+      seen.add(name);
+
+      skills.push({ name, description: extractDescription(content) });
+    }
+  } catch {
+    // dir not readable
+  }
+}
+
+function extractDescription(content: string): string {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (fmMatch) {
+    const fm = fmMatch[1];
+    const descMatch = fm.match(/^description:\s*>?\s*\n?([\s\S]*?)(?=\n\w|\n---|\n$)/m);
+    if (descMatch) {
+      const raw = descMatch[1].replace(/\n\s*/g, " ").trim();
+      if (raw) return raw.slice(0, 256);
+    }
+    const singleMatch = fm.match(/^description:\s*["']?(.+?)["']?\s*$/m);
+    if (singleMatch) return singleMatch[1].trim().slice(0, 256);
+  }
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("---")) continue;
+    return trimmed.slice(0, 256);
+  }
+  return "Claude Code skill";
+}
 
 // Resolve a slash command name to a Claude Code skill prompt.
 // Search order:


### PR DESCRIPTION
## Summary

- On startup, the Telegram bot scans all available Claude Code skills and registers them via the `setMyCommands` API
- Users see a command menu when typing `/` in Telegram chat, showing all available skills
- Adds `listSkills()` to the existing `src/skills.ts`, reusing the same directory scanning logic

## How it works

1. Daemon starts → Telegram bot calls `listSkills()` to scan all skill directories
2. Skill names are sanitized for Telegram (hyphens → underscores, max 32 chars)
3. Descriptions are extracted from SKILL.md frontmatter
4. Commands are registered via Telegram's `setMyCommands` API
5. User types `/` → sees `/commit`, `/review_pr`, `/simplify`, etc.

## Search locations (same as skill routing from #27)

- Project: `.claude/skills/*/SKILL.md`
- Global: `~/.claude/skills/*/SKILL.md`
- Plugins: `~/.claude/plugins/cache/*/*/*/skills/*/SKILL.md`

## Test plan

- [ ] Start daemon with Telegram configured → commands registered in log
- [ ] Type `/` in Telegram chat → see list of available skills
- [ ] Select a skill from the menu → message sent to Claude and executed
- [ ] No skills installed → only `/start` and `/reset` show up

🤖 Generated with [Claude Code](https://claude.com/claude-code)