### PR TITLE
feat: surface sub-agent lifecycle events in chat

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,7 +1,7 @@
 import { writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { fileURLToPath } from "url";
-import { run, runUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
+import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs } from "../jobs";
@@ -460,6 +460,9 @@ export async function start(args: string[] = []) {
             scheduleHeartbeat();
             updateState();
             console.log(`[${ts()}] Jobs reloaded from Web UI`);
+          },
+          onChat: async (message, onChunk, onUnblock, onAgentEvent) => {
+            await streamUserMessage("chat", message, onChunk, onUnblock, onAgentEvent);
           },
         });
       } catch (err) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -346,6 +346,170 @@ export async function run(name: string, prompt: string): Promise<RunResult> {
   return enqueue(() => execClaude(name, prompt));
 }
 
+export interface AgentStreamEvent {
+  type: "spawn" | "done";
+  id: string;
+  description: string;
+  result?: string;
+}
+
+async function streamClaude(
+  name: string,
+  prompt: string,
+  onChunk: (text: string) => void,
+  onUnblock: () => void,
+  onAgentEvent?: (ev: AgentStreamEvent) => void
+): Promise<void> {
+  await mkdir(LOGS_DIR, { recursive: true });
+
+  const existing = await getSession();
+  const { security, model, api } = getSettings();
+  const securityArgs = buildSecurityArgs(security);
+
+  // stream-json gives us events as they happen — text before tool calls,
+  // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
+  // --verbose is required for stream-json to produce output in -p (print) mode.
+  const args = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+
+  if (existing) args.push("--resume", existing.sessionId);
+
+  const promptContent = await loadPrompts();
+  const appendParts: string[] = ["You are running inside ClaudeClaw."];
+  if (promptContent) appendParts.push(promptContent);
+
+  if (existsSync(PROJECT_CLAUDE_MD)) {
+    try {
+      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+    } catch {}
+  }
+
+  if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
+  if (appendParts.length > 0) {
+    args.push("--append-system-prompt", appendParts.join("\n\n"));
+  }
+
+  const normalizedModel = model.trim().toLowerCase();
+  if (model.trim() && normalizedModel !== "glm") args.push("--model", model.trim());
+
+  const { CLAUDECODE: _, ...cleanEnv } = process.env;
+  const childEnv = buildChildEnv(cleanEnv as Record<string, string>, model, api);
+
+  console.log(`[${new Date().toLocaleTimeString()}] Running: ${name} (stream-json, session: ${existing?.sessionId?.slice(0, 8) ?? "new"})`);
+
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: childEnv,
+  });
+
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let unblocked = false;
+  let textEmitted = false;
+  // Track pending Agent tool calls: tool_use_id → description
+  const pendingAgents = new Map<string, string>();
+
+  const maybeUnblock = () => {
+    if (!unblocked) {
+      unblocked = true;
+      onUnblock();
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+
+    // Parse complete newline-delimited JSON events
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const event = JSON.parse(trimmed) as Record<string, unknown>;
+
+        if (event.type === "system" && (event.subtype === "init" || event.session_id)) {
+          // Capture session ID for new sessions
+          const sid = event.session_id as string | undefined;
+          if (sid && !existing) {
+            await createSession(sid);
+            console.log(`[${new Date().toLocaleTimeString()}] Session created (stream-json): ${sid}`);
+          }
+        } else if (event.type === "assistant") {
+          // Text and tool_use blocks from the assistant
+          type ContentBlock = { type: string; text?: string; id?: string; name?: string; input?: Record<string, unknown> };
+          const msg = event.message as { content?: ContentBlock[] } | undefined;
+          const blocks = msg?.content ?? [];
+          let hasActivity = false;
+          for (const block of blocks) {
+            if (block.type === "text" && block.text) {
+              onChunk(block.text);
+              textEmitted = true;
+              hasActivity = true;
+            }
+            // Detect Agent tool spawns
+            if (block.type === "tool_use" && block.name === "Agent" && block.id && onAgentEvent) {
+              const description = String(block.input?.description ?? block.input?.prompt ?? "Running background task...");
+              pendingAgents.set(block.id, description);
+              onAgentEvent({ type: "spawn", id: block.id, description });
+              hasActivity = true;
+            } else if (block.type === "tool_use") {
+              hasActivity = true;
+            }
+          }
+          if (hasActivity) maybeUnblock();
+        } else if (event.type === "user") {
+          // Tool results come back as user messages — match Agent completions
+          type ToolResultBlock = { type: string; tool_use_id?: string; content?: unknown };
+          const msg = event.message as { content?: ToolResultBlock[] } | undefined;
+          const blocks = msg?.content ?? [];
+          for (const block of blocks) {
+            if (block.type === "tool_result" && block.tool_use_id && pendingAgents.has(block.tool_use_id)) {
+              const description = pendingAgents.get(block.tool_use_id)!;
+              pendingAgents.delete(block.tool_use_id);
+              const result = typeof block.content === "string"
+                ? block.content
+                : JSON.stringify(block.content ?? "");
+              if (onAgentEvent) onAgentEvent({ type: "done", id: block.tool_use_id, description, result });
+            }
+          }
+        } else if (event.type === "tool_use") {
+          // Top-level tool_use event (some stream-json versions) — unblock the UI
+          maybeUnblock();
+        } else if (event.type === "result") {
+          // Final result event — emit text as fallback if no assistant text was seen
+          const resultText = (event as Record<string, unknown>).result as string | undefined;
+          if (resultText && !textEmitted) {
+            onChunk(resultText);
+          }
+          maybeUnblock();
+        }
+      } catch {}
+    }
+  }
+
+  await proc.exited;
+  // Ensure unblock fires even if something unexpected happened
+  maybeUnblock();
+
+  console.log(`[${new Date().toLocaleTimeString()}] Done: ${name}`);
+}
+
+export async function streamUserMessage(
+  name: string,
+  prompt: string,
+  onChunk: (text: string) => void,
+  onUnblock: () => void,
+  onAgentEvent?: (ev: AgentStreamEvent) => void
+): Promise<void> {
+  return enqueue(() => streamClaude(name, prefixUserMessageWithClock(prompt), onChunk, onUnblock, onAgentEvent));
+}
+
 function prefixUserMessageWithClock(prompt: string): string {
   try {
     const settings = getSettings();

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -930,4 +930,264 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
 
     loadSettings();
     refreshState();
-    setInterval(refreshState, 1000);`;
+    setInterval(refreshState, 1000);
+
+    // ── Chat ──
+    const tabDashboardBtn = $("tab-dashboard");
+    const tabChatBtn = $("tab-chat");
+    const dashboardPanel = $("dashboard-panel");
+    const chatPanel = $("chat-panel");
+    const chatMessages = $("chat-messages");
+    const chatForm = $("chat-form");
+    const chatInput = $("chat-input");
+    const chatSend = $("chat-send");
+
+    var CHAT_STORAGE_KEY = "claudeclaw.chat.history";
+    let chatBusy = false;
+    let chatAbortController = null;
+    let chatElapsedTimer = null;
+    let chatStartedAt = 0;
+    let chatHistory = (function() {
+      try {
+        var saved = localStorage.getItem(CHAT_STORAGE_KEY);
+        return saved ? JSON.parse(saved) : [];
+      } catch (_) { return []; }
+    })();
+
+    function setActiveTab(tab) {
+      const allBtns = [tabDashboardBtn, tabChatBtn];
+      const allPanels = [dashboardPanel, chatPanel];
+      allBtns.forEach(b => { if (b) { b.classList.remove("tab-btn-active"); b.setAttribute("aria-selected", "false"); } });
+      allPanels.forEach(p => { if (p) p.hidden = true; });
+
+      if (tab === "dashboard") {
+        tabDashboardBtn && tabDashboardBtn.classList.add("tab-btn-active");
+        tabDashboardBtn && tabDashboardBtn.setAttribute("aria-selected", "true");
+        if (dashboardPanel) dashboardPanel.hidden = false;
+      } else {
+        tabChatBtn && tabChatBtn.classList.add("tab-btn-active");
+        tabChatBtn && tabChatBtn.setAttribute("aria-selected", "true");
+        if (chatPanel) chatPanel.hidden = false;
+        if (chatInput) chatInput.focus();
+      }
+    }
+
+    if (tabDashboardBtn) tabDashboardBtn.addEventListener("click", () => setActiveTab("dashboard"));
+    if (tabChatBtn) tabChatBtn.addEventListener("click", () => setActiveTab("chat"));
+
+    renderChatHistory();
+
+    function saveChatHistory() {
+      try {
+        var toSave = chatHistory.filter(function(m) { return !m.streaming && m.agentStatus !== "running"; });
+        localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(toSave));
+      } catch (_) {}
+    }
+
+    function fmtElapsed(ms) {
+      var s = Math.floor(ms / 1000);
+      if (s < 60) return s + "s";
+      return Math.floor(s / 60) + "m " + (s % 60) + "s";
+    }
+
+    function setChatBusy(busy) {
+      chatBusy = busy;
+      var cancelBtn = $("chat-cancel");
+      if (chatSend) chatSend.disabled = busy;
+      if (cancelBtn) cancelBtn.hidden = !busy;
+      if (busy) {
+        chatStartedAt = Date.now();
+        chatElapsedTimer = setInterval(function() {
+          var el = document.querySelector(".chat-msg-elapsed");
+          if (el) el.textContent = fmtElapsed(Date.now() - chatStartedAt);
+        }, 1000);
+      } else {
+        if (chatElapsedTimer) { clearInterval(chatElapsedTimer); chatElapsedTimer = null; }
+        chatAbortController = null;
+      }
+    }
+
+    function cancelChat() {
+      if (chatAbortController) chatAbortController.abort();
+    }
+
+    function renderChatHistory() {
+      if (!chatMessages) return;
+      if (!chatHistory.length) {
+        chatMessages.innerHTML = '<div class="chat-empty">Send a message to start chatting with the daemon.</div>';
+        return;
+      }
+      var elapsedMs = Date.now() - chatStartedAt;
+      chatMessages.innerHTML = chatHistory.map(function(msg) {
+        if (msg.role === "agent") {
+          var agentCls = "chat-msg chat-msg-agent" + (msg.agentStatus === "running" ? " chat-msg-agent-running" : " chat-msg-agent-done");
+          return (
+            '<div class="' + agentCls + '">' +
+              '<div class="chat-msg-text">' + esc(msg.text || "") + (msg.agentStatus === "running" ? ' <span class="chat-agent-spinner">…</span>' : "") + "</div>" +
+            "</div>"
+          );
+        }
+        var cls = "chat-msg " + (msg.role === "user" ? "chat-msg-user" : "chat-msg-assistant");
+        if (msg.streaming) cls += " chat-msg-streaming";
+        var meta = "";
+        if (msg.streaming && chatBusy) {
+          meta = '<div class="chat-msg-elapsed">' + fmtElapsed(elapsedMs) + "</div>";
+        } else if (msg.background) {
+          meta = '<div class="chat-msg-background">⚙ working in background...</div>';
+        }
+        return (
+          '<div class="' + cls + '">' +
+            '<div class="chat-msg-role">' + (msg.role === "user" ? "You" : "Claude") + "</div>" +
+            '<div class="chat-msg-text">' + (msg.text ? esc(msg.text) : "") + "</div>" +
+            meta +
+          "</div>"
+        );
+      }).join("");
+      chatMessages.scrollTop = chatMessages.scrollHeight;
+    }
+
+    function autoResizeChatInput() {
+      if (!chatInput) return;
+      chatInput.style.height = "auto";
+      chatInput.style.height = Math.min(chatInput.scrollHeight, 160) + "px";
+    }
+
+    async function sendChat() {
+      if (chatBusy || !chatInput) return;
+      var message = (chatInput.value || "").trim();
+      if (!message) return;
+
+      chatInput.value = "";
+      autoResizeChatInput();
+      setChatBusy(true);
+
+      chatHistory.push({ role: "user", text: message });
+      var assistantIdx = chatHistory.length;
+      chatHistory.push({ role: "assistant", text: "", streaming: true });
+      renderChatHistory();
+
+      chatAbortController = new AbortController();
+
+      try {
+        var res = await fetch("/api/chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ message: message }),
+          signal: chatAbortController.signal,
+        });
+
+        if (!res.body) throw new Error("No response body");
+
+        var reader = res.body.getReader();
+        var dec = new TextDecoder();
+        var buf = "";
+
+        while (true) {
+          var read = await reader.read();
+          if (read.done) break;
+          buf += dec.decode(read.value, { stream: true });
+          var lines = buf.split("\n");
+          buf = lines.pop() || "";
+          for (var i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            if (!line.startsWith("data: ")) continue;
+            try {
+              var ev = JSON.parse(line.slice(6));
+              if (ev.type === "chunk") {
+                chatHistory[assistantIdx].text += ev.text;
+                renderChatHistory();
+              } else if (ev.type === "unblock") {
+                // Claude has acknowledged — unblock the input so user can send more messages
+                // while the background task continues running
+                setChatBusy(false);
+                chatHistory[assistantIdx].background = true;
+                renderChatHistory();
+              } else if (ev.type === "agent_spawn") {
+                // A sub-agent was spawned — add an activity bubble
+                chatHistory.push({ role: "agent", agentId: ev.id, text: "🤖 Sub-agent started: " + ev.description, agentStatus: "running" });
+                renderChatHistory();
+              } else if (ev.type === "agent_done") {
+                // Find the matching agent bubble and update it
+                var agentBubble = null;
+                for (var k = chatHistory.length - 1; k >= 0; k--) {
+                  if (chatHistory[k].role === "agent" && chatHistory[k].agentId === ev.id) {
+                    agentBubble = chatHistory[k];
+                    break;
+                  }
+                }
+                if (agentBubble) {
+                  agentBubble.agentStatus = "done";
+                  agentBubble.text = "✅ Sub-agent done: " + ev.description;
+                } else {
+                  chatHistory.push({ role: "agent", agentId: ev.id, text: "✅ Sub-agent done: " + ev.description, agentStatus: "done" });
+                }
+                // Also append result summary to the main assistant bubble if it has text
+                if (ev.result && ev.result.trim()) {
+                  chatHistory.push({ role: "assistant", text: ev.result.trim(), streaming: false, background: false });
+                }
+                renderChatHistory();
+                saveChatHistory();
+              } else if (ev.type === "done") {
+                chatHistory[assistantIdx].streaming = false;
+                chatHistory[assistantIdx].background = false;
+                renderChatHistory();
+                saveChatHistory();
+              } else if (ev.type === "error") {
+                chatHistory[assistantIdx].text = chatHistory[assistantIdx].text
+                  ? chatHistory[assistantIdx].text + "\n\n[Error: " + ev.message + "]"
+                  : "[Error: " + ev.message + "]";
+                chatHistory[assistantIdx].streaming = false;
+                chatHistory[assistantIdx].background = false;
+                renderChatHistory();
+                saveChatHistory();
+              }
+            } catch (_) {}
+          }
+        }
+        chatHistory[assistantIdx].streaming = false;
+        renderChatHistory();
+        saveChatHistory();
+      } catch (err) {
+        var cancelled = err && err.name === "AbortError";
+        chatHistory[assistantIdx].text = cancelled
+          ? (chatHistory[assistantIdx].text || "[Cancelled]")
+          : "[Failed: " + String(err) + "]";
+        chatHistory[assistantIdx].streaming = false;
+        renderChatHistory();
+        saveChatHistory();
+      } finally {
+        setChatBusy(false);
+        if (chatInput) chatInput.focus();
+      }
+    }
+
+    if (chatForm) {
+      chatForm.addEventListener("submit", function(e) {
+        e.preventDefault();
+        sendChat();
+      });
+    }
+
+    if (chatInput) {
+      chatInput.addEventListener("input", autoResizeChatInput);
+      chatInput.addEventListener("keydown", function(e) {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          sendChat();
+        }
+      });
+    }
+
+    var chatCancelBtn = $("chat-cancel");
+    if (chatCancelBtn) {
+      chatCancelBtn.addEventListener("click", cancelChat);
+    }
+
+    // Update elapsed timer in-place every second (no full re-render = no blink).
+    // CSS animations handle "working in background..." and agent spinner indicators.
+    setInterval(function() {
+      if (chatBusy && chatMessages) {
+        var elapsedEl = chatMessages.querySelector(".chat-msg-elapsed");
+        if (elapsedEl) elapsedEl.textContent = fmtElapsed(Date.now() - chatStartedAt);
+      }
+    }, 1000);`;

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -14,6 +14,7 @@ export const pageStyles = String.raw`    :root {
     }
 
     * { box-sizing: border-box; }
+    [hidden] { display: none !important; }
 
     html, body {
       width: 100%;
@@ -1072,6 +1073,270 @@ export const pageStyles = String.raw`    :root {
     .pill.warn .pill-value { color: #ffd298; }
     .pill.bad { border-color: #ff7f7f47; }
     .pill.bad .pill-value { color: #ffacac; }
+
+    .tab-nav {
+      display: flex;
+      gap: 6px;
+      justify-content: center;
+      margin-bottom: 28px;
+      background: #ffffff08;
+      backdrop-filter: blur(8px);
+      border: 1px solid #ffffff14;
+      border-radius: 999px;
+      padding: 4px;
+      width: fit-content;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .tab-btn {
+      height: 32px;
+      padding: 0 18px;
+      border: 1px solid transparent;
+      border-radius: 999px;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 11px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: #a8b8d0;
+      background: transparent;
+      cursor: pointer;
+      transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+    }
+    .tab-btn:hover {
+      color: #d6e6f8;
+      background: #ffffff10;
+    }
+    .tab-btn-active {
+      background: #0e2040cc;
+      border-color: #ffffff22;
+      color: #eef4ff;
+    }
+
+    /* ── Chat panel ── */
+    .chat-panel {
+      display: flex;
+      flex-direction: column;
+      height: calc(100svh - 280px);
+      min-height: 400px;
+      text-align: left;
+      border: 1px solid #ffffff22;
+      border-radius: 16px;
+      background:
+        radial-gradient(120% 100% at 100% 0%, #7dc5ff12, transparent 55%),
+        linear-gradient(180deg, #0e1a2a88 0%, #0a1220a8 100%);
+      backdrop-filter: blur(6px);
+      box-shadow: 0 14px 34px #00000045;
+      overflow: hidden;
+    }
+    .chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 16px;
+      scrollbar-width: thin;
+      scrollbar-color: #7fa6d5 #091222;
+    }
+    .chat-messages::-webkit-scrollbar {
+      width: 6px;
+    }
+    .chat-messages::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    .chat-messages::-webkit-scrollbar-thumb {
+      background: #3a5a80;
+      border-radius: 999px;
+    }
+    .chat-empty {
+      margin: auto;
+      text-align: center;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 12px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: #5a7a9a;
+      padding: 40px 20px;
+    }
+    .chat-msg {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      max-width: 88%;
+      animation: rise 200ms ease-out both;
+    }
+    .chat-msg-user {
+      align-self: flex-end;
+      align-items: flex-end;
+    }
+    .chat-msg-assistant {
+      align-self: flex-start;
+      align-items: flex-start;
+    }
+    .chat-msg-role {
+      font-family: "JetBrains Mono", monospace;
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      opacity: 0.55;
+      padding: 0 4px;
+    }
+    .chat-msg-text {
+      padding: 10px 14px;
+      border-radius: 14px;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 13px;
+      line-height: 1.55;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .chat-msg-user .chat-msg-text {
+      background: linear-gradient(135deg, #1a4a7a, #0f3060);
+      border: 1px solid #2a6aaa44;
+      color: #d8eeff;
+      border-bottom-right-radius: 4px;
+    }
+    .chat-msg-assistant .chat-msg-text {
+      background: #0b1828cc;
+      border: 1px solid #ffffff18;
+      color: #e4eefb;
+      border-bottom-left-radius: 4px;
+    }
+    .chat-msg-streaming .chat-msg-text::after {
+      content: "▋";
+      display: inline-block;
+      color: var(--accent);
+      animation: caret 0.8s step-end infinite;
+      margin-left: 2px;
+    }
+    .chat-input-area {
+      flex-shrink: 0;
+      padding: 10px 12px 12px;
+      border-top: 1px solid #ffffff12;
+      background: #080f1c66;
+    }
+    .chat-form {
+      display: flex;
+      align-items: flex-end;
+      gap: 8px;
+      border: 1px solid #ffffff2e;
+      border-radius: 14px;
+      background: #ffffff09;
+      padding: 8px 8px 8px 12px;
+      transition: border-color 0.18s ease;
+    }
+    .chat-form:focus-within {
+      border-color: #7dc5ff55;
+    }
+    .chat-input {
+      flex: 1;
+      border: 0;
+      background: transparent;
+      color: #eef4ff;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      resize: none;
+      max-height: 160px;
+      overflow-y: auto;
+      padding: 2px 0;
+      scrollbar-width: thin;
+      scrollbar-color: #3a5a80 transparent;
+    }
+    .chat-input::placeholder {
+      color: #4a6a8a;
+    }
+    .chat-input:focus {
+      outline: none;
+    }
+    .chat-send {
+      flex-shrink: 0;
+      width: 34px;
+      height: 34px;
+      border-radius: 999px;
+      border: 1px solid #3cb87980;
+      background: linear-gradient(180deg, #1f6f47d4 0%, #18563ace 100%);
+      color: #c8f8de;
+      font-size: 16px;
+      font-weight: 700;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.16s ease, filter 0.16s ease, opacity 0.16s ease;
+      line-height: 1;
+    }
+    .chat-send:hover {
+      transform: translateY(-1px);
+      filter: brightness(1.1);
+    }
+    .chat-send:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+      transform: none;
+      filter: none;
+    }
+    .chat-cancel {
+      flex-shrink: 0;
+      width: 34px;
+      height: 34px;
+      border-radius: 999px;
+      border: 1px solid #ff7f7f55;
+      background: #34181855;
+      color: #ff9b9b;
+      font-size: 14px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.16s ease, background 0.16s ease;
+    }
+    .chat-cancel:hover {
+      transform: translateY(-1px);
+      background: #4d191970;
+    }
+    .chat-msg-elapsed {
+      font-family: "JetBrains Mono", monospace;
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      color: #5a8aaa;
+      padding: 2px 4px;
+      margin-top: 2px;
+    }
+    .chat-msg-background {
+      font-family: "JetBrains Mono", monospace;
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      color: #7a9aba;
+      padding: 2px 4px;
+      margin-top: 4px;
+      animation: caret 2s step-end infinite;
+    }
+    .chat-msg-agent {
+      align-self: center;
+      max-width: 90%;
+      background: rgba(90, 130, 170, 0.08);
+      border: 1px solid rgba(90, 130, 170, 0.25);
+      border-radius: 8px;
+      padding: 6px 12px;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 11px;
+      color: #7aaac8;
+      letter-spacing: 0.02em;
+    }
+    .chat-msg-agent-running {
+      color: #8ac0e8;
+      border-color: rgba(100, 160, 200, 0.4);
+    }
+    .chat-msg-agent-done {
+      color: #5a9a7a;
+      border-color: rgba(90, 154, 122, 0.35);
+      background: rgba(90, 154, 122, 0.06);
+    }
+    .chat-agent-spinner {
+      opacity: 0.6;
+      animation: caret 1.2s step-end infinite;
+    }
 
     @media (max-width: 640px) {
       .stage {

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -112,6 +112,11 @@ ${pageStyles}
     </article>
   </section>
   <main class="stage">
+    <nav class="tab-nav" role="tablist" aria-label="Main navigation">
+      <button class="tab-btn tab-btn-active" id="tab-dashboard" type="button" role="tab" aria-selected="true" aria-controls="dashboard-panel">Dashboard</button>
+      <button class="tab-btn" id="tab-chat" type="button" role="tab" aria-selected="false" aria-controls="chat-panel">Chat</button>
+    </nav>
+    <div id="dashboard-panel">
     <section class="hero">
       <div class="logo-art" role="img" aria-label="Lobster ASCII art logo">
         <div class="logo-top"><span>🦞</span><span>🦞</span></div>
@@ -178,6 +183,23 @@ ${pageStyles}
         </div>
       </form>
     </section>
+    </div>
+    <div id="chat-panel" class="chat-panel" hidden>
+      <div id="chat-messages" class="chat-messages"></div>
+      <div class="chat-input-area">
+        <form id="chat-form" class="chat-form">
+          <textarea
+            id="chat-input"
+            class="chat-input"
+            placeholder="Message Claude..."
+            rows="1"
+            autocomplete="off"
+          ></textarea>
+          <button id="chat-cancel" class="chat-cancel" type="button" hidden>Cancel</button>
+          <button id="chat-send" class="chat-send" type="submit">Send</button>
+        </form>
+      </div>
+    </div>
   </main>
 
   <div class="dock-shell">

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -10,6 +10,7 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
   const server = Bun.serve({
     hostname: opts.host,
     port: opts.port,
+    idleTimeout: 0,
     fetch: async (req) => {
       const url = new URL(req.url);
 
@@ -146,6 +147,49 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       if (url.pathname === "/api/logs") {
         const tail = clampInt(url.searchParams.get("tail"), 200, 20, 2000);
         return json(await readLogs(tail));
+      }
+
+      if (url.pathname === "/api/chat" && req.method === "POST") {
+        if (!opts.onChat) return json({ ok: false, error: "chat not configured" });
+        try {
+          const body = await req.json();
+          const message = String(body?.message ?? "").trim();
+          if (!message) return json({ ok: false, error: "message required" });
+
+          const encoder = new TextEncoder();
+          const onChat = opts.onChat;
+          const stream = new ReadableStream({
+            async start(controller) {
+              const send = (data: object) => {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+              };
+              try {
+                await onChat(
+                  message,
+                  (chunk) => send({ type: "chunk", text: chunk }),
+                  () => send({ type: "unblock" }),
+                  (ev) => send({ type: ev.type === "spawn" ? "agent_spawn" : "agent_done", id: ev.id, description: ev.description, result: ev.result })
+                );
+                send({ type: "done" });
+              } catch (err) {
+                send({ type: "error", message: String(err) });
+              } finally {
+                controller.close();
+              }
+            },
+          });
+
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              "Connection": "keep-alive",
+              "X-Accel-Buffering": "no",
+            },
+          });
+        } catch (err) {
+          return json({ ok: false, error: String(err) });
+        }
       }
 
       return new Response("Not found", { status: 404 });

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,5 +1,6 @@
 import type { Settings } from "../config";
 import type { Job } from "../jobs";
+export type { AgentStreamEvent } from "../runner";
 
 export interface WebSnapshot {
   pid: number;
@@ -27,4 +28,10 @@ export interface StartWebUiOptions {
     excludeWindows?: Array<{ days?: number[]; start: string; end: string }>;
   }) => void | Promise<void>;
   onJobsChanged?: () => void | Promise<void>;
+  onChat?: (
+    message: string,
+    onChunk: (text: string) => void,
+    onUnblock: () => void,
+    onAgentEvent: (ev: import("../runner").AgentStreamEvent) => void
+  ) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

When Claude uses the `Agent` tool to spawn a sub-agent, the chat UI now shows real-time activity bubbles tracking the spawn and completion of those agents.

**Depends on:** #40 (chat tab)

- **Spawn acknowledgment** — a `🤖 Sub-agent started: [description]` bubble appears immediately when an Agent tool call is detected in the stream, so you know a background task was dispatched
- **Completion result** — when the sub-agent finishes, its result text is posted back to the chat as a new assistant bubble
- Agent activity bubbles are styled distinctly from regular chat messages and are excluded from localStorage persistence while running

## Architecture

The `stream-json` event stream is parsed for two new event types:

- `assistant` events with `content[].type === "tool_use"` and `name === "Agent"` → spawn
- `user` events with `content[].type === "tool_result"` matching a tracked `tool_use_id` → done

These are surfaced as new SSE event types from `/api/chat`:
- `{ type: "agent_spawn", id, description }`
- `{ type: "agent_done", id, description, result }`

A `Map<tool_use_id, description>` tracks pending agents across events in `streamClaude`.

## New types

```typescript
export interface AgentStreamEvent {
  type: "spawn" | "done";
  id: string;
  description: string;
  result?: string;
}
```

## Test plan

- [ ] Ask the daemon to do a research task that spawns a sub-agent
- [ ] Verify a `🤖 Sub-agent started: ...` bubble appears immediately in chat
- [ ] Verify the input unblocks so you can continue chatting while the agent runs
- [ ] Verify `✅ Sub-agent done: ...` bubble appears when complete, followed by the result
- [ ] Reload page — verify running agent bubbles are not persisted to localStorage; completed ones are