### PR TITLE
feat: sync daemon session with active Claude Code terminal windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .codemachine
 AGENTS.md
+.worktrees

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,5 +1,6 @@
 import { join } from "path";
-import { unlink, readdir, rename } from "fs/promises";
+import { unlink, readdir, rename, stat } from "fs/promises";
+import { homedir } from "os";
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
@@ -27,14 +28,81 @@ async function saveSession(session: GlobalSession): Promise<void> {
   await Bun.write(SESSION_FILE, JSON.stringify(session, null, 2) + "\n");
 }
 
+/**
+ * Encode a filesystem path to Claude Code's project directory name format.
+ * Claude Code replaces each path separator '/' with '-'.
+ * e.g. /Users/alex/Sites/project → -Users-alex-Sites-project
+ */
+function encodeProjectPath(dir: string): string {
+  return dir.replace(/\//g, "-");
+}
+
+/**
+ * Find the most recently modified Claude Code session for the current project
+ * by scanning ~/.claude/projects/<encoded-path>/ for .jsonl session files.
+ */
+async function findLatestClaudeCodeSession(): Promise<{ sessionId: string; lastModified: Date } | null> {
+  const projectDir = join(homedir(), ".claude", "projects", encodeProjectPath(process.cwd()));
+
+  let files: string[];
+  try {
+    files = await readdir(projectDir);
+  } catch {
+    return null;
+  }
+
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+  let latest: { sessionId: string; lastModified: Date } | null = null;
+
+  for (const file of files) {
+    if (!file.endsWith(".jsonl")) continue;
+    const sessionId = file.slice(0, -6); // strip ".jsonl"
+    if (!UUID_RE.test(sessionId)) continue;
+
+    try {
+      const { mtime } = await stat(join(projectDir, file));
+      if (!latest || mtime > latest.lastModified) {
+        latest = { sessionId, lastModified: mtime };
+      }
+    } catch {
+      // ignore unreadable files
+    }
+  }
+
+  return latest;
+}
+
 /** Returns the existing session or null. Never creates one. */
 export async function getSession(): Promise<{ sessionId: string } | null> {
   const existing = await loadSession();
+  const terminal = await findLatestClaudeCodeSession();
+
+  if (terminal) {
+    const existingTime = existing ? new Date(existing.lastUsedAt).getTime() : 0;
+
+    if (terminal.lastModified.getTime() > existingTime) {
+      // A more recent terminal session exists — sync to it so all chat windows
+      // share the same Claude Code conversation context (issue #39).
+      if (!existing || existing.sessionId !== terminal.sessionId) {
+        console.log(
+          `[${new Date().toLocaleTimeString()}] Session sync: adopting terminal session ${terminal.sessionId.slice(0, 8)}...`
+        );
+      }
+      await saveSession({
+        sessionId: terminal.sessionId,
+        createdAt: existing?.createdAt ?? terminal.lastModified.toISOString(),
+        lastUsedAt: new Date().toISOString(),
+      });
+      return { sessionId: terminal.sessionId };
+    }
+  }
+
   if (existing) {
     existing.lastUsedAt = new Date().toISOString();
     await saveSession(existing);
     return { sessionId: existing.sessionId };
   }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary

Fixes #39

When a user is actively chatting in a Claude Code terminal session while the daemon is also serving Telegram or Discord, the two windows are disconnected — each has its own conversation context and neither knows what the other is doing.

This PR adds automatic terminal session detection:

- Before each execution, claudeclaw scans `~/.claude/projects/<project>/` for `.jsonl` session files (Claude Code's native session storage)
- If the most recently modified session file is newer than claudeclaw's own `lastUsedAt` timestamp, claudeclaw adopts that session ID
- All subsequent Telegram/Discord messages then `--resume` the same thread the user was just in from their terminal, and vice versa
- On daemon startup, if a terminal session already exists, bootstrap skips creating a new session and joins the active one instead

The sync is transparent — a log line is printed when a session switch occurs, and no configuration is needed.

## Test plan

- [ ] Start a Claude Code terminal session in a project (`claude` or `claude --resume`)
- [ ] Start claudeclaw daemon in the same project directory
- [ ] Send a Telegram/Discord message — confirm the daemon continues the terminal conversation context
- [ ] Do work in the terminal after the daemon runs — confirm the next Telegram message picks it back up
- [ ] Verify daemon log shows `Session sync: adopting terminal session <id>...` when a switch occurs
- [ ] Verify no change in behaviour when no terminal session exists (fresh project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)