### PR TITLE
Surface real runtime errors instead of "Unknown error"

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -3,6 +3,7 @@ import { getSettings, loadSettings } from "../config";
 import { resetSession } from "../sessions";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
+import { extractRuntimeErrorDetail } from "../runtime-error";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
 
@@ -461,7 +462,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractRuntimeErrorDetail(result)}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -9,6 +9,7 @@ import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
 import { getDayAndMinuteAtOffset } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
+import { extractRuntimeErrorDetail } from "../runtime-error";
 import type { Job } from "../jobs";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
@@ -499,7 +500,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractRuntimeErrorDetail(result)}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -511,7 +512,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractRuntimeErrorDetail(result)}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -3,6 +3,7 @@ import { getSettings, loadSettings } from "../config";
 import { resetSession } from "../sessions";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt, listSkills } from "../skills";
+import { extractRuntimeErrorDetail } from "../runtime-error";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
 
@@ -623,7 +624,12 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const result = await runUserMessage("telegram", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      await sendMessage(
+        config.token,
+        chatId,
+        `Error (exit ${result.exitCode}): ${extractRuntimeErrorDetail(result)}`,
+        threadId,
+      );
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/runtime-error.ts
+++ b/src/runtime-error.ts
@@ -1,0 +1,41 @@
+interface ResultEnvelope {
+  is_error?: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+function extractJsonErrorDetail(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed) as ResultEnvelope;
+
+    if (parsed.is_error === true && typeof parsed.result === "string" && parsed.result.trim()) {
+      return parsed.result.trim();
+    }
+
+    if (typeof parsed.error === "string" && parsed.error.trim()) {
+      return parsed.error.trim();
+    }
+
+    if (
+      parsed.error &&
+      typeof parsed.error === "object" &&
+      typeof (parsed.error as { message?: unknown }).message === "string" &&
+      (parsed.error as { message: string }).message.trim()
+    ) {
+      return (parsed.error as { message: string }).message.trim();
+    }
+  } catch {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
+export function extractRuntimeErrorDetail(result: { stdout: string; stderr: string }): string {
+  const stderr = result.stderr.trim();
+  if (stderr) return stderr;
+  return extractJsonErrorDetail(result.stdout) ?? "Unknown error";
+}


### PR DESCRIPTION
## Summary
When Claude returns useful error text on stdout, the current forwarding paths can drop it and show `Unknown error` instead.

This change improves error extraction for daemon forwarding, Telegram, and Discord by:
- preferring stderr when present
- extracting structured JSON error messages when stdout is a Claude error envelope
- falling back to plain-text stdout when that contains the real message

## Why
This preserves actionable runtime failures like `Prompt is too long` and auth errors, instead of collapsing them into a generic placeholder.

## Validation
- bun x tsc --noEmit