### PR TITLE
Adds more flexibility for heartbeats to place HEARTBEAT_OK

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -564,7 +564,7 @@ export async function start(args: string[] = []) {
         })
         .then((r) => {
           if (!r) return;
-          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.trim().startsWith("HEARTBEAT_OK");
+          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.includes("HEARTBEAT_OK");
           if (shouldForward) {
             forwardToTelegram("", r);
             forwardToDiscord("", r);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -564,7 +564,9 @@ export async function start(args: string[] = []) {
         })
         .then((r) => {
           if (!r) return;
-          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.includes("HEARTBEAT_OK");
+          const normalized = r.stdout.trim();
+          const shouldSuppress = normalized.startsWith("HEARTBEAT_OK") || normalized.endsWith("HEARTBEAT_OK");
+          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !shouldSuppress;
           if (shouldForward) {
             forwardToTelegram("", r);
             forwardToDiscord("", r);


### PR DESCRIPTION
Heartbeat messages are only suppressed in the current master when the agent starts its response with HEARTBEAT_OK, potentially followed with other text (e.g., justifications or internal thoughts).

Quite often, my agent tends to **end** heartbeats with HEARTBEAT_OK rather than starting them. Hence, the heartbeat message is forwarded to me rather than suppressed (albeit the agent intended to suppress).

This PR generalizes the current handling to suppress any heartbeat message that contains the string HEARTBEAT_OK.