### PR TITLE
feat: add /compact, /status, /context slash commands for Telegram and Discord

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,6 +1,9 @@
-import { ensureProjectClaudeMd, run, runUserMessage } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { getSettings, loadSettings } from "../config";
-import { resetSession } from "../sessions";
+import { resetSession, peekSession } from "../sessions";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
@@ -295,6 +298,21 @@ async function registerSlashCommands(token: string): Promise<void> {
       description: "Reset the global session for a fresh start",
       type: 1,
     },
+    {
+      name: "compact",
+      description: "Compact session to reduce context size",
+      type: 1,
+    },
+    {
+      name: "status",
+      description: "Show current session status",
+      type: 1,
+    },
+    {
+      name: "context",
+      description: "Show context window usage",
+      type: 1,
+    },
   ];
 
   await discordApi(
@@ -505,6 +523,99 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
       await respondToInteraction(interaction, {
         content: "Global session reset. Next message starts fresh.",
       });
+      return;
+    }
+
+    if (interaction.data.name === "compact") {
+      await respondToInteraction(interaction, { content: "⏳ Compacting session..." });
+      const result = await compactCurrentSession();
+      await fetch(
+        `${DISCORD_API}/webhooks/${applicationId}/${interaction.token}/messages/@original`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: result.message }),
+        },
+      );
+      return;
+    }
+
+    if (interaction.data.name === "status") {
+      const session = await peekSession();
+      const settings = getSettings();
+      if (!session) {
+        await respondToInteraction(interaction, { content: "📊 No active session." });
+        return;
+      }
+      const lines = [
+        "📊 **Session Status**",
+        `Session: \`${session.sessionId.slice(0, 8)}\``,
+        `Turns: ${(session as any).turnCount ?? 0}`,
+        `Model: ${settings.model || "default"}`,
+        `Security: ${settings.security.level}`,
+        `Created: ${session.createdAt}`,
+        `Last used: ${session.lastUsedAt}`,
+        `Compact warned: ${(session as any).compactWarned ? "yes" : "no"}`,
+      ];
+      await respondToInteraction(interaction, { content: lines.join("\n") });
+      return;
+    }
+
+    if (interaction.data.name === "context") {
+      const session = await peekSession();
+      if (!session) {
+        await respondToInteraction(interaction, { content: "No active session." });
+        return;
+      }
+      const home = homedir();
+      const projectSlug = process.cwd().replace(/\//g, "-");
+      const jsonlPath = `${home}/.claude/projects/${projectSlug}/${session.sessionId}.jsonl`;
+      if (!existsSync(jsonlPath)) {
+        await respondToInteraction(interaction, { content: "Conversation file not found." });
+        return;
+      }
+      try {
+        const raw = await readFile(jsonlPath, "utf8");
+        const fileLines = raw.trim().split("\n");
+        let lastUsage: any = null;
+        let totalOutput = 0;
+        for (const line of fileLines) {
+          try {
+            const obj = JSON.parse(line);
+            if (obj.message?.usage) lastUsage = obj.message.usage;
+            if (obj.message?.usage?.output_tokens) totalOutput += obj.message.usage.output_tokens;
+          } catch {}
+        }
+        if (!lastUsage) {
+          await respondToInteraction(interaction, { content: "No usage data found." });
+          return;
+        }
+        const input = lastUsage.input_tokens ?? 0;
+        const cacheCreation = lastUsage.cache_creation_input_tokens ?? 0;
+        const cacheRead = lastUsage.cache_read_input_tokens ?? 0;
+        const totalContext = input + cacheCreation + cacheRead;
+        const maxContext = 200000;
+        const pct = ((totalContext / maxContext) * 100).toFixed(1);
+        const filled = Math.round((Math.min(totalContext / maxContext, 1)) * 20);
+        const bar = "█".repeat(filled) + "░".repeat(20 - filled);
+        const msg = [
+          `📐 **Context Window**`,
+          `${bar} ${pct}%`,
+          ``,
+          `Total: \`${totalContext.toLocaleString()}\` / \`${maxContext.toLocaleString()}\` tokens`,
+          `├ Input: \`${input.toLocaleString()}\``,
+          `├ Cache creation: \`${cacheCreation.toLocaleString()}\``,
+          `├ Cache read: \`${cacheRead.toLocaleString()}\``,
+          `└ Output (cumulative): \`${totalOutput.toLocaleString()}\``,
+          ``,
+          `Turns: ${(session as any).turnCount ?? 0}`,
+        ];
+        await respondToInteraction(interaction, { content: msg.join("\n") });
+      } catch (err) {
+        await respondToInteraction(interaction, {
+          content: `Failed to read context: ${err instanceof Error ? err.message : err}`,
+        });
+      }
       return;
     }
 

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,6 +1,9 @@
-import { ensureProjectClaudeMd, run, runUserMessage } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { getSettings, loadSettings } from "../config";
-import { resetSession } from "../sessions";
+import { resetSession, peekSession } from "../sessions";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt, listSkills } from "../skills";
 import { mkdir } from "node:fs/promises";
@@ -250,6 +253,12 @@ function extensionFromAudioMimeType(mimeType?: string): string {
     default:
       return "";
   }
+}
+
+function buildProgressBar(current: number, max: number, width: number = 20): string {
+  const ratio = Math.min(current / max, 1);
+  const filled = Math.round(ratio * width);
+  return "█".repeat(filled) + "░".repeat(width - filled);
 }
 
 function extractTelegramCommand(text: string): string | null {
@@ -517,6 +526,89 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     return;
   }
 
+  if (command === "/compact") {
+    await sendMessage(config.token, chatId, "⏳ Compacting session...", threadId);
+    const result = await compactCurrentSession();
+    await sendMessage(config.token, chatId, result.message, threadId);
+    return;
+  }
+
+  if (command === "/status") {
+    const session = await peekSession();
+    const settings = getSettings();
+    if (!session) {
+      await sendMessage(config.token, chatId, "📊 No active session.", threadId);
+      return;
+    }
+    const lines = [
+      "📊 **Session Status**",
+      `Session: \`${session.sessionId.slice(0, 8)}\``,
+      `Turns: ${session.turnCount ?? 0}`,
+      `Model: ${settings.model || "default"}`,
+      `Security: ${settings.security.level}`,
+      `Created: ${session.createdAt}`,
+      `Last used: ${session.lastUsedAt}`,
+      `Compact warned: ${(session as any).compactWarned ? "yes" : "no"}`,
+    ];
+    await sendMessage(config.token, chatId, lines.join("\n"), threadId);
+    return;
+  }
+
+  if (command === "/context") {
+    const session = await peekSession();
+    if (!session) {
+      await sendMessage(config.token, chatId, "No active session.", threadId);
+      return;
+    }
+    const home = homedir();
+    const projectSlug = process.cwd().replace(/\//g, "-");
+    const jsonlPath = `${home}/.claude/projects/${projectSlug}/${session.sessionId}.jsonl`;
+    if (!existsSync(jsonlPath)) {
+      await sendMessage(config.token, chatId, "Conversation file not found.", threadId);
+      return;
+    }
+    try {
+      const raw = await readFile(jsonlPath, "utf8");
+      const fileLines = raw.trim().split("\n");
+      let lastUsage: any = null;
+      let totalOutput = 0;
+      for (const line of fileLines) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.message?.usage) lastUsage = obj.message.usage;
+          if (obj.message?.usage?.output_tokens) totalOutput += obj.message.usage.output_tokens;
+        } catch {}
+      }
+      if (!lastUsage) {
+        await sendMessage(config.token, chatId, "No usage data found.", threadId);
+        return;
+      }
+      const input = lastUsage.input_tokens ?? 0;
+      const cacheCreation = lastUsage.cache_creation_input_tokens ?? 0;
+      const cacheRead = lastUsage.cache_read_input_tokens ?? 0;
+      const totalContext = input + cacheCreation + cacheRead;
+      const maxContext = 200000;
+      const pct = ((totalContext / maxContext) * 100).toFixed(1);
+      const bar = buildProgressBar(totalContext, maxContext);
+      const msg = [
+        `📐 **Context Window**`,
+        `${bar} ${pct}%`,
+        ``,
+        `Total: \`${totalContext.toLocaleString()}\` / \`${maxContext.toLocaleString()}\` tokens`,
+        `├ Input: \`${input.toLocaleString()}\``,
+        `├ Cache creation: \`${cacheCreation.toLocaleString()}\``,
+        `├ Cache read: \`${cacheRead.toLocaleString()}\``,
+        `└ Output (cumulative): \`${totalOutput.toLocaleString()}\``,
+        ``,
+        `Turns: ${session.turnCount ?? 0}`,
+      ];
+      await sendMessage(config.token, chatId, msg.join("\n"), threadId);
+    } catch (err) {
+      await sendMessage(config.token, chatId, `Failed to read context: ${err instanceof Error ? err.message : err}`, threadId);
+    }
+    return;
+  }
+
   // Secretary: detect reply to a bot alert message → treat as custom reply
   const replyToMsgId = message.reply_to_message?.message_id;
   if (replyToMsgId && text && botId && message.reply_to_message?.from?.id === botId) {
@@ -583,7 +675,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
     // Skill routing: resolve slash commands to SKILL.md prompts
     let skillContext: string | null = null;
-    if (command && command !== "/start" && command !== "/reset") {
+    if (command && command !== "/start" && command !== "/reset" && command !== "/compact" && command !== "/status" && command !== "/context") {
       try {
         skillContext = await resolveSkillPrompt(command);
         if (skillContext) {
@@ -689,6 +781,9 @@ async function registerBotCommands(token: string): Promise<void> {
     const commands = [
       { command: "start", description: "Show welcome message" },
       { command: "reset", description: "Reset session and start fresh" },
+      { command: "compact", description: "Compact session to reduce context size" },
+      { command: "status", description: "Show current session status" },
+      { command: "context", description: "Show context window usage" },
     ];
     for (const skill of skills) {
       // Telegram commands: 1-32 chars, lowercase a-z, 0-9, underscores only
@@ -705,8 +800,16 @@ async function registerBotCommands(token: string): Promise<void> {
       commands.push({ command: cmd, description: desc });
     }
     if (commands.length > 100) commands.length = 100;
-    await callApi(token, "setMyCommands", { commands });
-    console.log(`  Commands registered: ${commands.length} (${commands.map((c) => "/" + c.command).join(", ")})`);
+    try {
+      await callApi(token, "setMyCommands", { commands });
+      console.log(`  Commands registered: ${commands.length} (${commands.map((c) => "/" + c.command).join(", ")})`);
+    } catch (regErr) {
+      // Skill-generated commands may violate Telegram constraints; retry with built-in commands only
+      console.warn(`[Telegram] Full command registration failed, retrying with built-in commands only: ${regErr instanceof Error ? regErr.message : regErr}`);
+      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context"].includes(c.command));
+      await callApi(token, "setMyCommands", { commands: builtinOnly });
+      console.log(`  Commands registered (built-in only): ${builtinOnly.length}`);
+    }
   } catch (err) {
     console.error(`[Telegram] Failed to register commands: ${err instanceof Error ? err.message : err}`);
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession } from "./sessions";
+import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
 import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 
@@ -15,6 +15,34 @@ const PROJECT_CLAUDE_MD = join(process.cwd(), "CLAUDE.md");
 const LEGACY_PROJECT_CLAUDE_MD = join(process.cwd(), ".claude", "CLAUDE.md");
 const CLAUDECLAW_BLOCK_START = "<!-- claudeclaw:managed:start -->";
 const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
+
+/**
+ * Compact configuration.
+ * COMPACT_WARN_THRESHOLD: notify user that context is getting large.
+ * COMPACT_TIMEOUT_ENABLED: whether to auto-compact on timeout (exit 124).
+ */
+const COMPACT_WARN_THRESHOLD = 25;
+const COMPACT_TIMEOUT_ENABLED = true;
+
+export type CompactEvent =
+  | { type: "warn"; turnCount: number }
+  | { type: "auto-compact-start" }
+  | { type: "auto-compact-done"; success: boolean }
+  | { type: "auto-compact-retry"; success: boolean; stdout: string; stderr: string; exitCode: number };
+
+type CompactEventListener = (event: CompactEvent) => void;
+const compactListeners: CompactEventListener[] = [];
+
+/** Register a listener for compact-related events (warnings, auto-compact notifications). */
+export function onCompactEvent(listener: CompactEventListener): void {
+  compactListeners.push(listener);
+}
+
+function emitCompactEvent(event: CompactEvent): void {
+  for (const listener of compactListeners) {
+    try { listener(event); } catch {}
+  }
+}
 
 export interface RunResult {
   stdout: string;
@@ -72,11 +100,15 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
   return childEnv;
 }
 
+/** Default timeout for a single Claude Code invocation (5 minutes). */
+const CLAUDE_TIMEOUT_MS = 5 * 60 * 1000;
+
 async function runClaudeOnce(
   baseArgs: string[],
   model: string,
   api: string,
-  baseEnv: Record<string, string>
+  baseEnv: Record<string, string>,
+  timeoutMs: number = CLAUDE_TIMEOUT_MS
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();
@@ -88,17 +120,39 @@ async function runClaudeOnce(
     env: buildChildEnv(baseEnv, model, api),
   });
 
-  const [rawStdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  await proc.exited;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+  });
 
-  return {
-    rawStdout,
-    stderr,
-    exitCode: proc.exitCode ?? 1,
-  };
+  try {
+    const [rawStdout, stderr] = await Promise.race([
+      Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]),
+      timeoutPromise,
+    ]) as [string, string];
+    await proc.exited;
+
+    return {
+      rawStdout,
+      stderr,
+      exitCode: proc.exitCode ?? 1,
+    };
+  } catch (err) {
+    // Kill the hung process
+    try { proc.kill("SIGTERM"); } catch {}
+    setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
+
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[${new Date().toLocaleTimeString()}] ${message}`);
+
+    return {
+      rawStdout: "",
+      stderr: message,
+      exitCode: 124,
+    };
+  }
 }
 
 const PROJECT_DIR = process.cwd();
@@ -223,6 +277,56 @@ export async function loadHeartbeatPromptTemplate(): Promise<string> {
   return "";
 }
 
+/** Run /compact on the current session to reduce context size. */
+export async function runCompact(
+  sessionId: string,
+  model: string,
+  api: string,
+  baseEnv: Record<string, string>,
+  securityArgs: string[],
+  timeoutMs: number
+): Promise<boolean> {
+  const compactArgs = [
+    "claude", "-p", "/compact",
+    "--output-format", "text",
+    "--resume", sessionId,
+    ...securityArgs,
+  ];
+  console.log(`[${new Date().toLocaleTimeString()}] Running /compact on session ${sessionId.slice(0, 8)}...`);
+  const result = await runClaudeOnce(compactArgs, model, api, baseEnv, timeoutMs);
+  const success = result.exitCode === 0;
+  console.log(`[${new Date().toLocaleTimeString()}] Compact ${success ? "succeeded" : `failed (exit ${result.exitCode})`}`);
+  return success;
+}
+
+/**
+ * High-level compact: resolves session + settings internally.
+ * Returns { success, message }.
+ */
+export async function compactCurrentSession(): Promise<{ success: boolean; message: string }> {
+  const existing = await getSession();
+  if (!existing) return { success: false, message: "No active session to compact." };
+
+  const settings = getSettings();
+  const securityArgs = buildSecurityArgs(settings.security);
+  const { CLAUDECODE: _, ...cleanEnv } = process.env;
+  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+
+  const ok = await runCompact(
+    existing.sessionId,
+    settings.model,
+    settings.api,
+    baseEnv,
+    securityArgs,
+    timeoutMs
+  );
+
+  return ok
+    ? { success: true, message: `✅ Session compact complete (${existing.sessionId.slice(0, 8)})` }
+    : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
+}
+
 async function execClaude(name: string, prompt: string): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
@@ -238,6 +342,7 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
+  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
@@ -280,7 +385,7 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
 
-  let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv);
+  let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
   let usedFallback = false;
 
@@ -288,7 +393,7 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
     console.warn(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv);
+    exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs);
     usedFallback = true;
   }
 
@@ -338,6 +443,54 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
 
   await Bun.write(logFile, output);
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
+
+  // --- Auto-compact on timeout (exit 124) ---
+  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {
+    emitCompactEvent({ type: "auto-compact-start" });
+    const compactOk = await runCompact(
+      existing.sessionId,
+      primaryConfig.model,
+      primaryConfig.api,
+      baseEnv,
+      securityArgs,
+      timeoutMs
+    );
+    emitCompactEvent({ type: "auto-compact-done", success: compactOk });
+
+    if (compactOk) {
+      console.log(`[${new Date().toLocaleTimeString()}] Retrying ${name} after compact...`);
+      const retryExec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+      const retryResult: RunResult = {
+        stdout: retryExec.rawStdout,
+        stderr: retryExec.stderr,
+        exitCode: retryExec.exitCode,
+      };
+      emitCompactEvent({
+        type: "auto-compact-retry",
+        success: retryExec.exitCode === 0,
+        stdout: retryResult.stdout,
+        stderr: retryResult.stderr,
+        exitCode: retryResult.exitCode,
+      });
+
+      if (retryExec.exitCode === 0) {
+        const count = await incrementTurn();
+        console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${count} (after compact + retry)`);
+      }
+      return retryResult;
+    }
+  }
+
+  // --- Turn tracking & compact warning ---
+  if (exitCode === 0 && !isNew) {
+    const turnCount = await incrementTurn();
+    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}`);
+
+    if (turnCount >= COMPACT_WARN_THRESHOLD && existing && !existing.compactWarned) {
+      await markCompactWarned();
+      emitCompactEvent({ type: "warn", turnCount });
+    }
+  }
 
   return result;
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -8,6 +8,8 @@ export interface GlobalSession {
   sessionId: string;
   createdAt: string;
   lastUsedAt: string;
+  turnCount: number;
+  compactWarned: boolean;
 }
 
 let current: GlobalSession | null = null;
@@ -28,12 +30,15 @@ async function saveSession(session: GlobalSession): Promise<void> {
 }
 
 /** Returns the existing session or null. Never creates one. */
-export async function getSession(): Promise<{ sessionId: string } | null> {
+export async function getSession(): Promise<{ sessionId: string; turnCount: number; compactWarned: boolean } | null> {
   const existing = await loadSession();
   if (existing) {
+    // Backfill missing fields from older session.json files
+    if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+    if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
     existing.lastUsedAt = new Date().toISOString();
     await saveSession(existing);
-    return { sessionId: existing.sessionId };
+    return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
   }
   return null;
 }
@@ -44,12 +49,32 @@ export async function createSession(sessionId: string): Promise<void> {
     sessionId,
     createdAt: new Date().toISOString(),
     lastUsedAt: new Date().toISOString(),
+    turnCount: 0,
+    compactWarned: false,
   });
 }
 
 /** Returns session metadata without mutating lastUsedAt. */
 export async function peekSession(): Promise<GlobalSession | null> {
   return await loadSession();
+}
+
+/** Increment the turn counter after a successful Claude invocation. */
+export async function incrementTurn(): Promise<number> {
+  const existing = await loadSession();
+  if (!existing) return 0;
+  if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+  existing.turnCount += 1;
+  await saveSession(existing);
+  return existing.turnCount;
+}
+
+/** Mark that the compact warning has been sent for the current session. */
+export async function markCompactWarned(): Promise<void> {
+  const existing = await loadSession();
+  if (!existing) return;
+  existing.compactWarned = true;
+  await saveSession(existing);
 }
 
 export async function resetSession(): Promise<void> {


### PR DESCRIPTION
Adds three new slash commands for both Telegram and Discord:

- `/compact` — Triggers context compaction on the current Claude Code session
- `/status` — Shows session ID, turn count, model, security level, timestamps
- `/context` — Shows context window usage with progress bar and token breakdown

Also includes: turn tracking, session timeout with auto-compact, and compact event system.