### PR TITLE
fix: show stdout in error message when stderr is empty

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -435,7 +435,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -601,7 +601,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const result = await runUserMessage("telegram", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`, threadId);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {


### PR DESCRIPTION
## Problem

When Claude Code hits rate limits, the error message (e.g. `You've hit your limit · resets 1am`) is output to **stdout**, not stderr. The error handler only checked `result.stderr`, so users saw `Unknown error` instead of the actual message.

## Fix

Fall back to `result.stdout` before showing `Unknown error` in both Telegram and Discord handlers.

```
result.stderr || result.stdout || "Unknown error"
```