### PR TITLE
feat: add shared messaging utils and surface real Claude CLI errors

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,5 +1,6 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { getSettings, loadSettings } from "../config";
+import { extractErrorDetail } from "../messaging";
 import { resetSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -479,7 +480,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,6 +2,7 @@ import { writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { run, runUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
+import { extractErrorDetail } from "../messaging";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs } from "../jobs";
@@ -499,7 +500,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -511,7 +512,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,5 +1,6 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { getSettings, loadSettings } from "../config";
+import { extractErrorDetail } from "../messaging";
 import { resetSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -715,7 +716,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const result = await runUserMessage("telegram", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`, threadId);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,102 @@
+// Shared messaging utilities used by telegram.ts, discord.ts, and start.ts
+
+/**
+ * Describe the current provider/model in a human-readable string.
+ */
+export function describeProvider(result: { providerLabel: string; modelLabel: string; usedFallback: boolean }): string {
+  if (!result.usedFallback) return `Primary Claude active (${result.modelLabel}).`;
+
+  if (result.providerLabel === "fallback:openrouter") {
+    return `Fallback active: OpenRouter (${result.modelLabel}).`;
+  }
+  if (result.providerLabel === "fallback:gemini") {
+    return `Fallback active: Gemini (${result.modelLabel}).`;
+  }
+  if (result.providerLabel === "fallback:ollama") {
+    return `Fallback active: Ollama (${result.modelLabel}).`;
+  }
+  return `Fallback active: ${result.providerLabel} (${result.modelLabel}).`;
+}
+
+/**
+ * Extract an error detail string from a run result, preferring stderr,
+ * then trying to parse JSON stdout for error fields emitted by Claude CLI.
+ *
+ * Claude CLI exits non-zero on auth and quota failures, but the human-readable
+ * message ("Not logged in · Please run /login") lives in the JSON stdout
+ * `result` field, not stderr. This function extracts it so chat bridges show
+ * the real error instead of "Unknown error".
+ */
+export function extractErrorDetail(result: { stdout: string; stderr: string }): string {
+  const stderr = result.stderr?.trim() || "";
+  if (stderr) return stderr;
+
+  const stdout = result.stdout?.trim() || "";
+  if (!stdout) return "";
+
+  try {
+    const parsed = JSON.parse(stdout);
+    if (parsed?.is_error && parsed?.result) return String(parsed.result).trim();
+    if (parsed?.error?.message) return String(parsed.error.message).trim();
+    if (typeof parsed?.error === "string") return parsed.error.trim();
+  } catch {}
+
+  return stdout;
+}
+
+/**
+ * Check if user text is asking about which model/provider is active.
+ */
+export function isProviderStatusQuery(text: string): boolean {
+  return /(what model|which model|what provider|which provider|running on|active model|active provider|are you on|using openrouter|using ollama|using gemini|using opus|change\s+(?:to|model)|switch\s+(?:to|model)|use\s+(?:opus|sonnet|haiku|gemini|ollama|claude))/i.test(text);
+}
+
+/**
+ * Check if user text is requesting a model change (not just asking about it).
+ */
+export function isModelChangeRequest(text: string): boolean {
+  return /\b(change\s+(?:to|model)|switch\s+(?:to|model)|use\s+(?:opus|sonnet|haiku|gemini|ollama|claude)|(?:opus|sonnet|haiku)\s+(?:mode|model|please))\b/i.test(text);
+}
+
+/**
+ * Build an authoritative reply about the current provider status.
+ */
+export function authoritativeProviderReply(text: string, result: { providerLabel: string; modelLabel: string; usedFallback: boolean }): string {
+  const isChangeReq = isModelChangeRequest(text);
+  const suffix = isChangeReq
+    ? " To change models, edit settings.json or use /config in Dispatch."
+    : "";
+
+  if (!result.usedFallback) {
+    return `Primary Claude is active right now (${result.modelLabel}).${suffix}`;
+  }
+
+  if (result.providerLabel === "fallback:openrouter") {
+    return `Claude is not active right now. Current provider is OpenRouter (${result.modelLabel}).${suffix}`;
+  }
+  if (result.providerLabel === "fallback:gemini") {
+    return `Claude is not active right now. Current provider is Gemini (${result.modelLabel}).${suffix}`;
+  }
+  if (result.providerLabel === "fallback:ollama") {
+    return `Claude is not active right now. Current provider is Ollama (${result.modelLabel}).${suffix}`;
+  }
+  return `Current provider is ${result.providerLabel} (${result.modelLabel}).${suffix}`;
+}
+
+/**
+ * Extract a [react:emoji] directive from response text, returning
+ * the cleaned text and the first reaction emoji found (if any).
+ */
+export function extractReactionDirective(text: string): { cleanedText: string; reactionEmoji: string | null } {
+  let reactionEmoji: string | null = null;
+  const cleanedText = text
+    .replace(/\[react:([^\]\r\n]+)\]/gi, (_match, raw) => {
+      const candidate = String(raw).trim();
+      if (!reactionEmoji && candidate) reactionEmoji = candidate;
+      return "";
+    })
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { cleanedText, reactionEmoji };
+}


### PR DESCRIPTION
## Problem

Claude CLI exits non-zero on auth and quota failures, but the human-readable error message (e.g. `Not logged in · Please run /login`) lives in the JSON stdout `result` field — **not** in stderr. All three chat bridges were showing `Unknown error` instead of the actual failure reason.

**Before:**
```
Error (exit 1): Unknown error
```
**After:**
```
Error (exit 1): Not logged in · Please run /login
```

## Solution

Introduces `src/messaging.ts` — a shared utilities module used by `start.ts`, `telegram.ts`, and `discord.ts`.

### Key function: `extractErrorDetail(result)`

```typescript
export function extractErrorDetail(result: { stdout: string; stderr: string }): string {
  const stderr = result.stderr?.trim() || "";
  if (stderr) return stderr;

  // Claude CLI emits human-readable errors in JSON stdout when stderr is empty
  try {
    const parsed = JSON.parse(stdout);
    if (parsed?.is_error && parsed?.result) return String(parsed.result).trim();
    if (parsed?.error?.message) return String(parsed.error.message).trim();
    if (typeof parsed?.error === "string") return parsed.error.trim();
  } catch {}

  return stdout;
}
```

### Additional utilities (no behaviour change, available for future use)

- `describeProvider()` — human-readable provider/model label
- `isProviderStatusQuery()` / `isModelChangeRequest()` — intent detection for model-switch queries
- `authoritativeProviderReply()` — canonical provider status response
- `extractReactionDirective()` — strips `[react:emoji]` directives from response text

### Files changed

| File | Change |
|------|--------|
| `src/messaging.ts` | New shared utilities module |
| `src/commands/start.ts` | Use `extractErrorDetail` in `forwardToTelegram` and `forwardToDiscord` |
| `src/commands/telegram.ts` | Use `extractErrorDetail` in the main message handler error path |
| `src/commands/discord.ts` | Use `extractErrorDetail` in the main message handler error path |

## Testing

Auth failures now surface the real Claude CLI message across all three chat interfaces. The fix handles:
- `stderr` present → returns stderr (existing behaviour, unchanged)
- `stderr` empty, JSON stdout with `is_error: true` → returns `result` field  
- `stderr` empty, JSON stdout with `error.message` → returns `error.message`
- Fallback to raw stdout if JSON parse fails