### PR TITLE
fix: prevent double Telegram polling loop on startup

### DIFF
--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -952,6 +952,7 @@ async function registerBotCommands(token: string): Promise<void> {
 // --- Polling loop ---
 
 let running = true;
+let isPolling = false;
 
 async function poll(): Promise<void> {
   const config = getSettings().telegram;
@@ -1030,12 +1031,15 @@ process.on("SIGINT", () => { running = false; });
 
 /** Start polling in-process (called by start.ts when token is configured) */
 export function startPolling(debug = false): void {
+  if (isPolling) return;
+  isPolling = true;
   telegramDebug = debug;
   (async () => {
     await ensureProjectClaudeMd();
     await poll();
   })().catch((err) => {
     console.error(`[Telegram] Fatal: ${err}`);
+    isPolling = false;
   });
 }
 


### PR DESCRIPTION
## Problem

The Telegram bot daemon opens two concurrent connections to `api.telegram.org` on startup, which causes `getUpdates` to return `409 Conflict` on every poll. Messages still work through retries but the logs are spammed with error messages nonstop.

I had this happening on one of my agents and the logs were full of 409 errors which made it hard to see the real activity.

## Root Cause

`startPolling()` in `src/commands/telegram.ts` has no guard against being called twice. If `initTelegram()` is invoked twice before the first `poll()` enters its `while (running)` loop, two polling loops start concurrently - each opening its own TCP connection to Telegram API.

## Fix

Added an `isPolling` flag that prevents `startPolling()` from running more than once:

```typescript
let isPolling = false;

export function startPolling(debug = false): void {
  if (isPolling) return;  // already running, skip
  isPolling = true;
  // ...
}
```

The flag is also reset to `false` in the catch handler so if the first attempt fails completely, a retry can still work.

This is the exact fix suggested in the issue. Simple, no side effects, covers the race condition.

Closes #47