### PR TITLE
fix(config): add missing discordUserIds param to parseSettings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "keywords": ["cron", "heartbeat", "scheduler", "daemon"],
       "category": "productivity"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -217,7 +217,7 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -336,7 +336,8 @@ async function execClaude(name: string, prompt: string): Promise<RunResult> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const logFile = join(LOGS_DIR, `${name}-${timestamp}.log`);
 
-  const { security, model, api, fallback, agentic } = getSettings();
+  const settings = getSettings();
+  const { security, model, api, fallback, agentic } = settings;
 
   // Determine which model to use based on agentic routing
   let primaryConfig: ModelConfig;


### PR DESCRIPTION
## Summary
- Restores the `discordUserIds?: string[]` parameter to `parseSettings()` in `src/config.ts` (accidentally removed in `58f6c4f`), fixing `ReferenceError: discordUserIds is not defined` from `loadSettings`/`reloadSettings`.
- Declares `const settings = getSettings()` in `execClaude` (`src/runner.ts`) so the existing `(settings as any).sessionTimeoutMs` reference resolves. Previously `execClaude` only destructured `getSettings()`, leaving `settings` undefined and causing a `ReferenceError` on every Discord message / heartbeat / job run (and a `tsc --noEmit` failure).

Both bugs are crash-on-execute caused by incomplete refactors that left dangling references; both fixes are minimal and mirror patterns already used elsewhere in the file (`compactCurrentSession` declares `settings` the same way).

## Context
- Discord snowflake IDs exceed `Number.MAX_SAFE_INTEGER`. `extractDiscordUserIds()` extracts them as raw strings before `JSON.parse` loses precision — restoring the `discordUserIds` parameter keeps that pipeline working.
- `compactCurrentSession` already does `const settings = getSettings(); … settings.sessionTimeoutMs …`. We use the same pattern in `execClaude`.
- The broader `sessionTimeoutMs`-through-`parseSettings` cleanup (removing the `as any` cast) is intentionally **not** done here — that's the scope of #101.

Closes #63

## Test plan
- [x] `bunx tsc --noEmit` is no longer blocked on `settings is not defined` in `src/runner.ts` (two remaining errors are pre-existing in `src/ui/server.ts` and `src/whisper.ts`, unrelated to this PR).
- [x] `bun run src/index.ts start --web` starts without ReferenceError.
- [ ] Configure Discord with snowflake user IDs and verify they are parsed correctly as strings.
- [ ] Send a Discord message / trigger a heartbeat to exercise `execClaude` and confirm no `ReferenceError: settings is not defined`.
