### PR TITLE
feat: add policy engine with deterministic rule evaluation

### DIFF
--- a/src/__tests__/policy/approval-queue.test.ts
+++ b/src/__tests__/policy/approval-queue.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for policy/approval-queue.ts
+ * 
+ * Run with: bun test src/__tests__/policy/approval-queue.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  enqueue,
+  approve,
+  deny,
+  listPending,
+  loadState,
+  findByEventId,
+  findById,
+  isPending,
+  getLoadedAt,
+} from "../../policy/approval-queue";
+import { loadRules, type ToolRequestContext, type PolicyDecision } from "../../policy/engine";
+
+const APPROVAL_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const APPROVAL_QUEUE_FILE = join(APPROVAL_DIR, "approval-queue.jsonl");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-" + Math.random().toString(36).slice(2),
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+// Helper to create a test decision
+const createDecision = (overrides: Partial<PolicyDecision> = {}): PolicyDecision => ({
+  requestId: "req-" + Math.random().toString(36).slice(2),
+  action: "require_approval",
+  reason: "Test approval required",
+  evaluatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("Approval Queue - Enqueue", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should enqueue a request for approval", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(entry).toBeDefined();
+    expect(entry.id).toBeDefined();
+    expect(entry.eventId).toBe(request.eventId);
+    expect(entry.status).toBe("pending");
+    expect(entry.request).toEqual(request);
+    expect(entry.decision).toEqual(decision);
+    expect(entry.requestedAt).toBeDefined();
+  });
+
+  it("should persist entry to queue file", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(existsSync(APPROVAL_QUEUE_FILE)).toBe(true);
+    
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    const found = lines.some(line => {
+      const parsed = JSON.parse(line);
+      return parsed.id === entry.id;
+    });
+    expect(found).toBe(true);
+  });
+
+  it("should generate unique IDs for each entry", async () => {
+    const request1 = createRequest();
+    const request2 = createRequest();
+    const decision = createDecision();
+    
+    const entry1 = await enqueue(request1, decision);
+    const entry2 = await enqueue(request2, decision);
+    
+    expect(entry1.id).not.toBe(entry2.id);
+  });
+
+  it("should set default expiry time", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(entry.expiresAt).toBeDefined();
+    
+    const expiryDate = new Date(entry.expiresAt!);
+    const now = new Date();
+    const diffHours = (expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60);
+    
+    expect(diffHours).toBeGreaterThan(23);
+    expect(diffHours).toBeLessThan(25);
+  });
+});
+
+describe("Approval Queue - Approve", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should approve a pending request", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    const result = await approve(request.eventId, "operator-1", "Looks good");
+    
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("approved");
+    expect(result?.approvedBy).toBe("operator-1");
+    expect(result?.approvedAt).toBeDefined();
+    expect(result?.resolutionReason).toBe("Looks good");
+  });
+
+  it("should persist approval to queue file", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    await approve(request.eventId, "operator-1");
+    
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Find the approval entry
+    const approvalLine = lines.find(line => {
+      const parsed = JSON.parse(line);
+      return parsed.eventId === request.eventId && parsed.status === "approved";
+    });
+    
+    expect(approvalLine).toBeDefined();
+  });
+
+  it("should be idempotent for already approved requests", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    const first = await approve(request.eventId, "operator-1", "First approval");
+    const second = await approve(request.eventId, "operator-2", "Second approval");
+    
+    expect(first?.approvedBy).toBe("operator-1");
+    expect(second?.approvedBy).toBe("operator-1"); // Should remain first approver
+    expect(second?.resolutionReason).toBe("First approval");
+  });
+
+  it("should return null for non-existent event", async () => {
+    const result = await approve("non-existent-event", "operator-1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("Approval Queue - Deny", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should deny a pending request", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    const result = await deny(request.eventId, "operator-1", "Not allowed");
+    
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("denied");
+    expect(result?.deniedBy).toBe("operator-1");
+    expect(result?.deniedAt).toBeDefined();
+    expect(result?.resolutionReason).toBe("Not allowed");
+  });
+
+  it("should be idempotent for already denied requests", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    const first = await deny(request.eventId, "operator-1", "First denial");
+    const second = await deny(request.eventId, "operator-2", "Second denial");
+    
+    expect(first?.deniedBy).toBe("operator-1");
+    expect(second?.deniedBy).toBe("operator-1"); // Should remain first denier
+  });
+});
+
+describe("Approval Queue - List Pending", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should list only pending requests", async () => {
+    const request1 = createRequest();
+    const request2 = createRequest();
+    const request3 = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request1, decision);
+    await enqueue(request2, decision);
+    await enqueue(request3, decision);
+    
+    await approve(request1.eventId, "operator-1");
+    
+    const pending = listPending();
+    
+    expect(pending).toHaveLength(2);
+    expect(pending.every(e => e.status === "pending")).toBe(true);
+  });
+
+  it("should sort pending by oldest first", async () => {
+    const decision = createDecision();
+    
+    const entry1 = await enqueue(createRequest({ eventId: "event-1" }), decision);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const entry2 = await enqueue(createRequest({ eventId: "event-2" }), decision);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const entry3 = await enqueue(createRequest({ eventId: "event-3" }), decision);
+    
+    const pending = listPending();
+    
+    expect(pending[0].eventId).toBe("event-1");
+    expect(pending[1].eventId).toBe("event-2");
+    expect(pending[2].eventId).toBe("event-3");
+  });
+});
+
+describe("Approval Queue - Persistence", () => {
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should recover state after restart", async () => {
+    const decision = createDecision();
+    
+    // Create some entries
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+    
+    const entry1 = await enqueue(createRequest({ eventId: "restart-event-1" }), decision);
+    const entry2 = await enqueue(createRequest({ eventId: "restart-event-2" }), decision);
+    
+    await approve(entry1.eventId, "operator-1");
+    
+    // Simulate restart - reload state from disk
+    await loadState();
+    
+    // Should recover state
+    const pending = listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].eventId).toBe("restart-event-2");
+    
+    const recoveredEntry2 = await findById(entry2.id);
+    expect(recoveredEntry2).toBeDefined();
+    expect(recoveredEntry2?.status).toBe("pending");
+  });
+
+  it("should find entry by eventId", async () => {
+    const decision = createDecision();
+    
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+    
+    const entry = await enqueue(createRequest({ eventId: "find-me-event" }), decision);
+    
+    const found = await findByEventId("find-me-event");
+    expect(found).toBeDefined();
+    expect(found?.id).toBe(entry.id);
+  });
+});

--- a/src/__tests__/policy/audit-log.test.ts
+++ b/src/__tests__/policy/audit-log.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for policy/audit-log.ts
+ * 
+ * Run with: bun test src/__tests__/policy/audit-log.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  log,
+  logPolicyDecision,
+  logApproval,
+  logDenial,
+  query,
+  exportEntries,
+  getStats,
+  cleanupRetention,
+  getRetentionPolicy,
+  type AuditEntry,
+  type AuditAction,
+} from "../../policy/audit-log";
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
+
+describe("Audit Log - Basic Operations", () => {
+  beforeEach(async () => {
+    // Clean audit log before test to ensure isolation
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should log an audit entry", async () => {
+    const entry: AuditEntry = {
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      channelId: "telegram:123",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Tool denied by policy",
+      matchedRuleId: "global-deny-bash",
+    };
+    
+    await log(entry);
+    
+    expect(existsSync(AUDIT_LOG_FILE)).toBe(true);
+    
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    expect(lines).toHaveLength(1);
+    
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.eventId).toBe("event-1");
+    expect(parsed.action).toBe("deny");
+  });
+
+  it("should append multiple entries", async () => {
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Denied",
+    });
+    
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-2",
+      requestId: "req-2",
+      source: "discord",
+      toolName: "View",
+      action: "allow",
+      reason: "Allowed",
+    });
+    
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe("Audit Log - Policy Decision Logging", () => {
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should log a policy decision", async () => {
+    await logPolicyDecision(
+      "event-1",
+      "req-1",
+      "telegram",
+      "Bash",
+      "deny",
+      "Global policy denies Bash",
+      { matchedRuleId: "global-deny-bash" }
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("deny");
+    expect(entries[0].matchedRuleId).toBe("global-deny-bash");
+  });
+
+  it("should log an approval action", async () => {
+    await logApproval(
+      "event-1",
+      "req-1",
+      "telegram",
+      "Edit",
+      "operator-1",
+      "Looks good"
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("approved");
+    expect(entries[0].operatorId).toBe("operator-1");
+    expect(entries[0].reason).toBe("Looks good");
+  });
+
+  it("should log a denial action", async () => {
+    await logDenial(
+      "event-1",
+      "req-1",
+      "discord",
+      "Bash",
+      "operator-2",
+      "Not allowed"
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("denied");
+    expect(entries[0].operatorId).toBe("operator-2");
+  });
+});
+
+describe("Audit Log - Querying", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    
+    // Create some test entries
+    await logPolicyDecision("event-1", "req-1", "telegram", "Bash", "deny", "Denied");
+    await logPolicyDecision("event-2", "req-2", "telegram", "View", "allow", "Allowed");
+    await logPolicyDecision("event-3", "req-3", "discord", "Edit", "require_approval", "Needs approval");
+    await logApproval("event-4", "req-4", "telegram", "Edit", "operator-1", "Approved");
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return all entries with no filters", async () => {
+    const entries = await query({});
+    expect(entries).toHaveLength(4);
+  });
+
+  it("should filter by source", async () => {
+    const entries = await query({ source: "telegram" });
+    expect(entries).toHaveLength(3);
+    expect(entries.every(e => e.source === "telegram")).toBe(true);
+  });
+
+  it("should filter by action", async () => {
+    const entries = await query({ action: "deny" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("deny");
+  });
+
+  it("should filter by toolName", async () => {
+    const entries = await query({ toolName: "Edit" });
+    expect(entries).toHaveLength(2); // require_approval and approved
+  });
+
+  it("should filter by operatorId", async () => {
+    const entries = await query({ operatorId: "operator-1" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].operatorId).toBe("operator-1");
+  });
+
+  it("should filter by eventId", async () => {
+    const entries = await query({ eventId: "event-2" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].eventId).toBe("event-2");
+  });
+
+  it("should sort by timestamp descending (newest first)", async () => {
+    // Add another entry with a newer timestamp
+    await log({
+      timestamp: new Date(Date.now() + 10000).toISOString(), // 10 seconds in future
+      eventId: "event-5",
+      requestId: "req-5",
+      source: "slack",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Latest",
+    });
+    
+    const entries = await query({});
+    expect(entries[0].eventId).toBe("event-5");
+  });
+});
+
+describe("Audit Log - Export", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should export entries within date range", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Test",
+    });
+    
+    const entries = await exportEntries(yesterday, tomorrow);
+    expect(entries).toHaveLength(1);
+  });
+});
+
+describe("Audit Log - Statistics", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return correct statistics", async () => {
+    await logPolicyDecision("event-1", "req-1", "telegram", "Bash", "deny", "Deny");
+    await logPolicyDecision("event-2", "req-2", "telegram", "View", "allow", "Allow");
+    await logPolicyDecision("event-3", "req-3", "discord", "Edit", "require_approval", "Approve");
+    
+    const stats = await getStats();
+    
+    expect(stats.totalEntries).toBe(3);
+    expect(stats.byAction.deny).toBe(1);
+    expect(stats.byAction.allow).toBe(1);
+    expect(stats.byAction.require_approval).toBe(1);
+    expect(stats.bySource.telegram).toBe(2);
+    expect(stats.bySource.discord).toBe(1);
+  });
+
+  it("should return empty stats for no entries", async () => {
+    const stats = await getStats();
+    
+    expect(stats.totalEntries).toBe(0);
+    expect(stats.oldestTimestamp).toBeNull();
+    expect(stats.newestTimestamp).toBeNull();
+  });
+});
+
+describe("Audit Log - Retention", () => {
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should report retention policy", () => {
+    const policy = getRetentionPolicy();
+    
+    expect(policy.defaultRetentionDays).toBe(30);
+    expect(policy.defaultMaxFileSizeBytes).toBe(10 * 1024 * 1024);
+    expect(policy.recommendation).toContain("30 days");
+  });
+
+  it("should identify entries older than retention period", async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    
+    // Create an old entry
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 60); // 60 days ago
+    await log({
+      timestamp: oldDate.toISOString(),
+      eventId: "old-event",
+      requestId: "old-req",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Old entry",
+    });
+    
+    // Create a recent entry
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "new-event",
+      requestId: "new-req",
+      source: "telegram",
+      toolName: "View",
+      action: "allow",
+      reason: "New entry",
+    });
+    
+    const result = await cleanupRetention({ maxAgeDays: 30 });
+    
+    expect(result.deleted).toBe(1);
+    expect(result.remaining).toBe(1);
+  });
+});

--- a/src/__tests__/policy/channel-policies.test.ts
+++ b/src/__tests__/policy/channel-policies.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for policy/channel-policies.ts
+ * 
+ * Run with: bun test src/__tests__/policy/channel-policies.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { writeFile, rm, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  getScopedRules,
+  mergeScopedPolicies,
+  validateScopedPolicyConfig,
+  createDefaultScopedPolicyConfig,
+  getExampleScopedPolicyConfig,
+  reloadScopedPolicy,
+  type ScopedPolicyConfig,
+} from "../../policy/channel-policies";
+import { loadRules, type ToolRequestContext, type PolicyRule } from "../../policy/engine";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SCOPED_POLICY_FILE = join(POLICY_DIR, "scoped-policies.json");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-1",
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+describe("Channel Policies - Scoped Rules", () => {
+  beforeEach(async () => {
+    // Clear any cached config
+    reloadScopedPolicy();
+    
+    // Ensure directory exists
+    await mkdir(POLICY_DIR, { recursive: true });
+    
+    // Clean up
+    try {
+      await rm(SCOPED_POLICY_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+    
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(SCOPED_POLICY_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return empty array when no scoped policy file exists", () => {
+    const request = createRequest();
+    const rules = getScopedRules(request);
+    expect(Array.isArray(rules)).toBe(true);
+  });
+
+  it("should resolve channel-specific deny rules", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "telegram:123": {
+              channelId: "telegram:123",
+              denyRules: [
+                {
+                  id: "channel-deny-bash",
+                  priority: 200,
+                  tool: "Bash",
+                  action: "deny",
+                  reason: "Bash denied in this channel",
+                },
+              ],
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const request = createRequest({ toolName: "Bash" });
+    const rules = getScopedRules(request);
+    
+    // Should have the channel deny rule
+    const denyRule = rules.find(r => r.id === "channel-deny-bash");
+    expect(denyRule).toBeDefined();
+    expect(denyRule?.action).toBe("deny");
+  });
+
+  it("should resolve user-specific overrides", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "telegram:123": {
+              channelId: "telegram:123",
+              userOverrides: {
+                "admin-user": {
+                  userId: "admin-user",
+                  allowRules: [
+                    {
+                      id: "admin-allow-all",
+                      priority: 200,
+                      tool: "*",
+                      action: "allow",
+                      reason: "Admin has full access",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const request = createRequest({ userId: "admin-user", toolName: "Bash" });
+    const rules = getScopedRules(request);
+    
+    const adminRule = rules.find(r => r.id === "admin-allow-all");
+    expect(adminRule).toBeDefined();
+    expect(adminRule?.action).toBe("allow");
+  });
+
+  it("should handle discord and telegram as different contexts", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          defaultRules: [
+            {
+              id: "telegram-deny-bash",
+              priority: 100,
+              tool: "Bash",
+              action: "deny",
+            },
+          ],
+        },
+        discord: {
+          source: "discord",
+          defaultRules: [
+            {
+              id: "discord-allow-bash",
+              priority: 100,
+              tool: "Bash",
+              action: "allow",
+            },
+          ],
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const telegramRequest = createRequest({ source: "telegram", toolName: "Bash" });
+    const telegramRules = getScopedRules(telegramRequest);
+    const telegramDeny = telegramRules.find(r => r.id === "telegram-deny-bash");
+    expect(telegramDeny?.action).toBe("deny");
+    
+    const discordRequest = createRequest({ source: "discord", toolName: "Bash" });
+    const discordRules = getScopedRules(discordRequest);
+    const discordAllow = discordRules.find(r => r.id === "discord-allow-bash");
+    expect(discordAllow?.action).toBe("allow");
+  });
+});
+
+describe("Channel Policies - Merge Scoped Policies", () => {
+  it("should merge global and scoped rules without duplicates", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "global-allow", tool: "View", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "scoped-deny", tool: "Edit", action: "deny" },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged).toHaveLength(2);
+    expect(merged.find(r => r.id === "global-allow")).toBeDefined();
+    expect(merged.find(r => r.id === "scoped-deny")).toBeDefined();
+  });
+
+  it("should prefer scoped rules over global rules with same ID", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "same-id", tool: "View", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "same-id", tool: "View", action: "deny" },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged).toHaveLength(1);
+    expect(merged[0].action).toBe("deny");
+  });
+
+  it("should filter out disabled rules", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "disabled-global", tool: "View", action: "allow", enabled: false },
+      { id: "enabled-global", tool: "Edit", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "disabled-scoped", tool: "Bash", action: "deny", enabled: false },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged.find(r => r.id === "disabled-global")).toBeUndefined();
+    expect(merged.find(r => r.id === "enabled-global")).toBeDefined();
+    expect(merged.find(r => r.id === "disabled-scoped")).toBeUndefined();
+  });
+});
+
+describe("Channel Policies - Validation", () => {
+  it("should validate a correct scoped policy config", () => {
+    const config = getExampleScopedPolicyConfig();
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should detect missing version", () => {
+    const config = {
+      sources: {},
+      globalRules: [],
+    } as any;
+    
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes("version"))).toBe(true);
+  });
+
+  it("should detect mismatched channel IDs", () => {
+    const config: ScopedPolicyConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "channel-1": {
+              channelId: "different-id", // Mismatch!
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes("mismatch"))).toBe(true);
+  });
+});
+
+describe("Channel Policies - Default Config", () => {
+  it("should create a valid default config", () => {
+    const config = createDefaultScopedPolicyConfig();
+    expect(config.version).toBe(1);
+    expect(config.sources).toEqual({});
+    expect(config.globalRules).toEqual([]);
+  });
+
+  it("should have proper structure in example config", () => {
+    const config = getExampleScopedPolicyConfig();
+    
+    // Should have telegram and discord sources
+    expect(config.sources["telegram"]).toBeDefined();
+    expect(config.sources["discord"]).toBeDefined();
+    
+    // Telegram should have channel config
+    expect(config.sources["telegram"].channels?.["telegram:123"]).toBeDefined();
+    
+    // Should have global deny rule
+    const globalDeny = config.globalRules.find(r => r.id === "global-deny-dangerous");
+    expect(globalDeny).toBeDefined();
+    expect(globalDeny?.action).toBe("deny");
+  });
+});

--- a/src/__tests__/policy/engine.test.ts
+++ b/src/__tests__/policy/engine.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Tests for policy/engine.ts
+ * 
+ * Run with: bun test src/__tests__/policy/engine.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  evaluate,
+  loadRules,
+  validateRules,
+  getRules,
+  clearCache,
+  isCacheEnabled,
+  type ToolRequestContext,
+  type PolicyRule,
+} from "../../policy/engine";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const POLICY_FILE = join(POLICY_DIR, "policies.json");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-1",
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+// Helper to write a policy file
+async function writePolicyFile(rules: PolicyRule[], cache?: { enabled: boolean; maxEntries: number; ttlMs: number }): Promise<void> {
+  const policy = {
+    version: 1,
+    rules,
+    cache: cache || { enabled: false, maxEntries: 1000, ttlMs: 60000 },
+    updatedAt: new Date().toISOString(),
+  };
+  await mkdir(POLICY_DIR, { recursive: true });
+  await writeFile(POLICY_FILE, JSON.stringify(policy, null, 2), "utf8");
+}
+
+describe("Policy Engine - Core Evaluation", () => {
+  beforeEach(async () => {
+    clearCache();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    clearCache();
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should deny request when no rules match", async () => {
+    await writePolicyFile([]);
+    
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBeUndefined();
+    expect(decision.reason).toContain("No matching policy rule");
+  });
+
+  it("should allow request when explicit allow rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-telegram",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "*",
+        action: "allow",
+        reason: "Allow all tools on telegram",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("allow");
+    expect(decision.matchedRuleId).toBe("allow-telegram");
+  });
+
+  it("should deny request when explicit deny rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-telegram",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "*",
+        action: "allow",
+      },
+      {
+        id: "deny-bash",
+        priority: 200,
+        tool: "Bash",
+        action: "deny",
+        reason: "Deny bash tool",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("deny-bash");
+  });
+
+  it("should require_approval when require_approval rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "approval-edit",
+        priority: 100,
+        tool: "Edit",
+        action: "require_approval",
+        reason: "Edit requires approval",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Edit" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("require_approval");
+    expect(decision.matchedRuleId).toBe("approval-edit");
+  });
+
+  it("should evaluate rules by highest priority first", async () => {
+    await writePolicyFile([
+      {
+        id: "low-priority-allow",
+        priority: 50,
+        tool: "Bash",
+        action: "allow",
+      },
+      {
+        id: "high-priority-deny",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("high-priority-deny");
+  });
+
+  it("should use specificity as tiebreaker when priorities equal", async () => {
+    await writePolicyFile([
+      {
+        id: "global-allow",
+        priority: 100,
+        tool: "Bash",
+        action: "allow",
+        reason: "Global allow",
+      },
+      {
+        id: "telegram-deny",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "Bash",
+        action: "deny",
+        reason: "Telegram specific deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    // More specific rule (telegram-deny) should win
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("telegram-deny");
+  });
+
+  it("should deny when no allow rule matches but deny rule exists", async () => {
+    await writePolicyFile([
+      {
+        id: "deny-bash",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Bash" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+
+  it("should match wildcard tool", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "AnyTool" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("allow");
+  });
+
+  it("should match tool array", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-view-edit",
+        priority: 100,
+        tool: ["View", "Edit", "GrepTool"],
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const viewRequest = createRequest({ toolName: "View" });
+    expect(evaluate(viewRequest).action).toBe("allow");
+    
+    const editRequest = createRequest({ toolName: "Edit" });
+    expect(evaluate(editRequest).action).toBe("allow");
+    
+    const bashRequest = createRequest({ toolName: "Bash" });
+    expect(evaluate(bashRequest).action).toBe("deny");
+  });
+
+  it("should match source array", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-multiple-sources",
+        priority: 100,
+        scope: { source: ["telegram", "discord"] },
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const telegramRequest = createRequest({ source: "telegram" });
+    expect(evaluate(telegramRequest).action).toBe("allow");
+    
+    const discordRequest = createRequest({ source: "discord" });
+    expect(evaluate(discordRequest).action).toBe("allow");
+    
+    const slackRequest = createRequest({ source: "slack" });
+    expect(evaluate(slackRequest).action).toBe("deny");
+  });
+
+  it("should skip disabled rules", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-disabled",
+        priority: 100,
+        enabled: false,
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+
+  it("should handle userId scope correctly", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-admin",
+        priority: 100,
+        scope: { userId: "admin-user" },
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const adminRequest = createRequest({ userId: "admin-user" });
+    expect(evaluate(adminRequest).action).toBe("allow");
+    
+    const regularRequest = createRequest({ userId: "regular-user" });
+    expect(evaluate(regularRequest).action).toBe("deny");
+  });
+
+  it("should handle skillName scope correctly", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-code-review",
+        priority: 100,
+        scope: { skillName: "code-review" },
+        tool: ["View", "GlobTool", "GrepTool"],
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const codeReviewRequest = createRequest({ 
+      skillName: "code-review",
+      toolName: "View",
+    });
+    expect(evaluate(codeReviewRequest).action).toBe("allow");
+    
+    const otherSkillRequest = createRequest({ 
+      skillName: "other-skill",
+      toolName: "View",
+    });
+    expect(evaluate(otherSkillRequest).action).toBe("deny");
+  });
+});
+
+describe("Policy Engine - Time Window Conditions", () => {
+  afterEach(async () => {
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should deny request outside time window", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    const lastWeek = new Date(Date.now() - 7 * 86400000).toISOString();
+    const nextWeek = new Date(Date.now() + 7 * 86400000).toISOString();
+    
+    await writePolicyFile([
+      {
+        id: "allow-business-hours",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+        conditions: {
+          timeWindow: { start: lastWeek, end: yesterday }, // Past window
+        },
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+});
+
+describe("Policy Engine - Validation", () => {
+  it("should return valid for correct rules", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "valid-rule",
+        tool: "Bash",
+        action: "allow",
+        reason: "Valid rule",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should reject rule without id", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "",
+        tool: "Bash",
+        action: "allow",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "id")).toBe(true);
+  });
+
+  it("should reject rule without tool", () => {
+    // Cast to PolicyRule[] to test validation catches missing tool
+    const rules = [
+      {
+        id: "no-tool",
+        action: "allow",
+      },
+    ] as unknown as PolicyRule[];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "tool")).toBe(true);
+  });
+
+  it("should reject rule with invalid action", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "invalid-action",
+        tool: "Bash",
+        action: "invalid" as any,
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "action")).toBe(true);
+  });
+
+  it("should warn about unscoped allow rules", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "unscoped-allow",
+        tool: "*",
+        action: "allow",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.warnings.some(w => w.field === "scope")).toBe(true);
+  });
+
+  it("should detect duplicate rule IDs", () => {
+    const rules: PolicyRule[] = [
+      { id: "duplicate", tool: "Bash", action: "allow" },
+      { id: "duplicate", tool: "Edit", action: "deny" },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes("Duplicate"))).toBe(true);
+  });
+
+  it("should warn on invalid time window dates", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "bad-timewindow",
+        tool: "Bash",
+        action: "allow",
+        conditions: {
+          timeWindow: { start: "not-a-date", end: "also-not-a-date" },
+        },
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Policy Engine - Cache", () => {
+  afterEach(async () => {
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should cache decisions when cache enabled", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    expect(isCacheEnabled()).toBe(true);
+    
+    const request = createRequest();
+    const decision1 = evaluate(request);
+    expect(decision1.action).toBe("allow");
+    
+    // Second evaluation should use cache
+    const decision2 = evaluate(request);
+    expect(decision2.action).toBe("allow");
+  });
+
+  it("should clear cache on reload", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const request = createRequest();
+    evaluate(request);
+    
+    // Change policy
+    await writePolicyFile([
+      {
+        id: "deny-all",
+        priority: 100,
+        tool: "*",
+        action: "deny",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const decision = evaluate(request);
+    
+    // Should reflect new policy, not cached
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("deny-all");
+  });
+
+  it("should not cache require_approval decisions", async () => {
+    await writePolicyFile([
+      {
+        id: "approval-edit",
+        priority: 100,
+        tool: "Edit",
+        action: "require_approval",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Edit" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("require_approval");
+    expect(decision.cacheable).toBe(false);
+  });
+});

--- a/src/__tests__/policy/skill-overlays.test.ts
+++ b/src/__tests__/policy/skill-overlays.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for policy/skill-overlays.ts
+ * 
+ * Run with: bun test src/__tests__/policy/skill-overlays.test.ts
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  parseSkillMetadata,
+  getSkillOverlayFromContent,
+  overlayToRules,
+  evaluateSkillPolicy,
+  validateRequiredTools,
+  getExampleSkillOverlays,
+  type SkillOverlay,
+} from "../../policy/skill-overlays";
+
+describe("Skill Overlays - Metadata Parsing", () => {
+  it("should parse requiredTools from SKILL.md frontmatter", () => {
+    const content = `---
+requiredTools:
+  - View
+  - GlobTool
+  - GrepTool
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.requiredTools).toEqual(["View", "GlobTool", "GrepTool"]);
+  });
+
+  it("should parse preferredTools from SKILL.md frontmatter", () => {
+    const content = `---
+preferredTools:
+  - View
+  - Bash
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.preferredTools).toEqual(["View", "Bash"]);
+  });
+
+  it("should parse deniedTools from SKILL.md frontmatter", () => {
+    const content = `---
+deniedTools:
+  - Bash
+  - Edit
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.deniedTools).toEqual(["Bash", "Edit"]);
+  });
+
+  it("should parse all policy fields together", () => {
+    const content = `---
+requiredTools:
+  - View
+preferredTools:
+  - View
+  - GrepTool
+deniedTools:
+  - Bash
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "code-review");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.skillName).toBe("code-review");
+    expect(overlay?.requiredTools).toEqual(["View"]);
+    expect(overlay?.preferredTools).toEqual(["View", "GrepTool"]);
+    expect(overlay?.deniedTools).toEqual(["Bash"]);
+  });
+
+  it("should return null when no policy fields present", () => {
+    const content = `---
+description: A test skill
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).toBeNull();
+  });
+
+  it("should return null for content without frontmatter", () => {
+    const content = `# Skill Content
+This is just regular markdown content.
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).toBeNull();
+  });
+
+  it("should handle empty tool lists", () => {
+    const content = `---
+requiredTools: []
+preferredTools: []
+deniedTools: []
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.requiredTools).toEqual([]);
+    expect(overlay?.preferredTools).toEqual([]);
+    expect(overlay?.deniedTools).toEqual([]);
+  });
+});
+
+describe("Skill Overlays - Overlay to Rules Conversion", () => {
+  it("should convert denied tools to deny rules", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const rules = overlayToRules(overlay);
+    
+    expect(rules).toHaveLength(2);
+    
+    const bashRule = rules.find(r => r.tool === "Bash");
+    expect(bashRule).toBeDefined();
+    expect(bashRule?.action).toBe("deny");
+    expect(bashRule?.scope?.skillName).toBe("code-review");
+    expect(bashRule?.id).toContain("code-review");
+    
+    const editRule = rules.find(r => r.tool === "Edit");
+    expect(editRule).toBeDefined();
+    expect(editRule?.action).toBe("deny");
+  });
+
+  it("should not create rules for empty deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "read-only",
+      deniedTools: [],
+    };
+    
+    const rules = overlayToRules(overlay);
+    expect(rules).toHaveLength(0);
+  });
+
+  it("should use custom base priority when provided", () => {
+    const overlay: SkillOverlay = {
+      skillName: "test",
+      deniedTools: ["Bash"],
+    };
+    
+    const rules = overlayToRules(overlay, 200);
+    expect(rules[0].priority).toBe(250); // base + 50
+  });
+
+  it("should not create rules for preferredTools or requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "test",
+      requiredTools: ["View"],
+      preferredTools: ["View", "GrepTool"],
+    };
+    
+    const rules = overlayToRules(overlay);
+    expect(rules).toHaveLength(0);
+  });
+});
+
+describe("Skill Overlays - Policy Evaluation", () => {
+  it("should deny when tool is in deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "Bash");
+    
+    expect(result.allowed).toBe(false);
+    expect(result.deniedTools).toContain("Bash");
+    expect(result.skillOverlay).toBe(overlay);
+  });
+
+  it("should allow when tool is not in deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "View");
+    
+    expect(result.allowed).toBe(true);
+    expect(result.deniedTools).toBeUndefined();
+  });
+
+  it("should handle empty deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "open-skill",
+      deniedTools: [],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "Bash");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("should handle overlay with no deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "View");
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("Skill Overlays - Required Tools Validation", () => {
+  it("should validate all required tools are available", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+    };
+    
+    const availableTools = ["View", "GlobTool", "GrepTool", "Bash"];
+    const result = validateRequiredTools(overlay, availableTools);
+    
+    expect(result.valid).toBe(true);
+    expect(result.missingTools).toHaveLength(0);
+  });
+
+  it("should detect missing required tools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+    };
+    
+    const availableTools = ["View", "Bash"];
+    const result = validateRequiredTools(overlay, availableTools);
+    
+    expect(result.valid).toBe(false);
+    expect(result.missingTools).toContain("GlobTool");
+    expect(result.missingTools).toContain("GrepTool");
+  });
+
+  it("should handle empty requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+      requiredTools: [],
+    };
+    
+    const result = validateRequiredTools(overlay, []);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should handle undefined requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+    };
+    
+    const result = validateRequiredTools(overlay, []);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("Skill Overlays - Example Configurations", () => {
+  it("should provide valid example overlays", () => {
+    const examples = getExampleSkillOverlays();
+    
+    // Code review should be read-only
+    const codeReview = examples["code-review"];
+    expect(codeReview.deniedTools).toContain("Bash");
+    expect(codeReview.deniedTools).toContain("Edit");
+    expect(codeReview.deniedTools).toContain("Write");
+    expect(codeReview.requiredTools).toContain("View");
+    
+    // Admin should have full access
+    const admin = examples["admin"];
+    expect(admin.deniedTools).toHaveLength(0);
+    expect(admin.requiredTools).toContain("Bash");
+    
+    // Web scrape needs network
+    const webScrape = examples["web-scrape"];
+    expect(webScrape.requiredTools).toContain("WebFetch");
+    expect(webScrape.requiredTools).toContain("Bash");
+  });
+});

--- a/src/policy/approval-queue.ts
+++ b/src/policy/approval-queue.ts
@@ -1,0 +1,338 @@
+/**
+ * Approval Workflow
+ * 
+ * Durable approval workflow for requests that require operator authorization.
+ * 
+ * DESIGN:
+ * - Approval requests are durably stored in append-friendly format
+ * - Storage path: .claude/claudeclaw/approval-queue.jsonl
+ * - Queue state must not live only in memory
+ * - Approval resolution is restart-safe
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All queue operations use atomic file operations
+ * - State is loaded from disk on init and kept in sync
+ * - Approval must result in controlled continuation path
+ */
+
+import { appendFile, readFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { type ToolRequestContext, type PolicyDecision } from "./engine";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ApprovalStatus = "pending" | "approved" | "denied" | "expired";
+
+export interface ApprovalRequest {
+  eventId: string;
+  request: ToolRequestContext;
+  decision: PolicyDecision;
+  requestedAt: string;
+  status: ApprovalStatus;
+  approvedBy?: string;
+  approvedAt?: string;
+  deniedBy?: string;
+  deniedAt?: string;
+  resolutionReason?: string;
+  expiresAt?: string;
+}
+
+export interface ApprovalEntry extends ApprovalRequest {
+  id: string;
+  createdAt: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const APPROVAL_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const APPROVAL_QUEUE_FILE = join(APPROVAL_DIR, "approval-queue.jsonl");
+const DEFAULT_EXPIRY_HOURS = 24;
+
+// ============================================================================
+// State
+// ============================================================================
+
+let approvalIndex: Map<string, ApprovalEntry> = new Map();
+let indexLoadedAt: string = "";
+let loadError: Error | null = null;
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Enqueue a request that requires approval.
+ * Returns the approval entry with generated ID.
+ */
+export async function enqueue(
+  request: ToolRequestContext,
+  decision: PolicyDecision
+): Promise<ApprovalEntry> {
+  const now = new Date();
+  const expiryDate = new Date(now.getTime() + DEFAULT_EXPIRY_HOURS * 60 * 60 * 1000);
+  
+  const entry: ApprovalEntry = {
+    id: randomUUID(),
+    eventId: request.eventId,
+    request,
+    decision,
+    requestedAt: now.toISOString(),
+    status: "pending",
+    createdAt: now.toISOString(),
+    expiresAt: expiryDate.toISOString(),
+  };
+  
+  // Ensure directory exists
+  await mkdir(APPROVAL_DIR, { recursive: true });
+  
+  // Append to queue file (atomic append)
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(APPROVAL_QUEUE_FILE, line, "utf8");
+  
+  // Update in-memory index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * Approve a pending approval request.
+ */
+export async function approve(
+  eventId: string,
+  actor: string,
+  reason?: string
+): Promise<ApprovalEntry | null> {
+  const entry = await findByEventId(eventId);
+  if (!entry) {
+    return null;
+  }
+  
+  if (entry.status !== "pending") {
+    // Already resolved - idempotent operation
+    return entry;
+  }
+  
+  const now = new Date().toISOString();
+
+  // Create new object instead of mutating the shared in-memory entry
+  const updated: ApprovalEntry = {
+    ...entry,
+    status: "approved",
+    approvedBy: actor,
+    approvedAt: now,
+    resolutionReason: reason,
+  };
+
+  // Persist to disk first, then update in-memory index
+  await appendResolution(updated);
+  approvalIndex.set(updated.id, updated);
+
+  return updated;
+}
+
+/**
+ * Deny a pending approval request.
+ */
+export async function deny(
+  eventId: string,
+  actor: string,
+  reason?: string
+): Promise<ApprovalEntry | null> {
+  const entry = await findByEventId(eventId);
+  if (!entry) {
+    return null;
+  }
+  
+  if (entry.status !== "pending") {
+    // Already resolved - idempotent operation
+    return entry;
+  }
+  
+  const now = new Date().toISOString();
+
+  // Create new object instead of mutating the shared in-memory entry
+  const updated: ApprovalEntry = {
+    ...entry,
+    status: "denied",
+    deniedBy: actor,
+    deniedAt: now,
+    resolutionReason: reason,
+  };
+
+  // Persist to disk first, then update in-memory index
+  await appendResolution(updated);
+  approvalIndex.set(updated.id, updated);
+
+  return updated;
+}
+
+/**
+ * List all pending approval requests.
+ */
+export function listPending(): ApprovalEntry[] {
+  const pending: ApprovalEntry[] = [];
+  
+  for (const entry of approvalIndex.values()) {
+    if (entry.status === "pending") {
+      // Check if expired
+      if (entry.expiresAt) {
+        const expiryDate = new Date(entry.expiresAt);
+        if (expiryDate < new Date()) {
+          continue; // Skip expired
+        }
+      }
+      pending.push(entry);
+    }
+  }
+  
+  // Sort by requestedAt (oldest first)
+  pending.sort((a, b) => 
+    new Date(a.requestedAt).getTime() - new Date(b.requestedAt).getTime()
+  );
+  
+  return pending;
+}
+
+/**
+ * Load state from disk.
+ * Rebuilds in-memory index from queue file.
+ * Since we always append to the file, the last occurrence of each ID is the latest state.
+ */
+export async function loadState(): Promise<void> {
+  approvalIndex.clear();
+  
+  // Ensure directory exists
+  if (!existsSync(APPROVAL_DIR)) {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    indexLoadedAt = new Date().toISOString();
+    return;
+  }
+  
+  // Check if queue file exists
+  if (!existsSync(APPROVAL_QUEUE_FILE)) {
+    indexLoadedAt = new Date().toISOString();
+    return;
+  }
+  
+  try {
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Since we always append and never modify existing lines,
+    // the LAST occurrence of each ID in the file is the most recent state.
+    // So we iterate in order and just overwrite with the latest.
+    for (const line of lines) {
+      try {
+        const entry: ApprovalEntry = JSON.parse(line);
+        approvalIndex.set(entry.id, entry);
+      } catch {
+        // Skip malformed lines
+        continue;
+      }
+    }
+  } catch {
+    // File doesn't exist or can't be read - start fresh
+  }
+  
+  indexLoadedAt = new Date().toISOString();
+}
+
+/**
+ * Get the last time state was loaded.
+ */
+export function getLoadedAt(): string {
+  return indexLoadedAt;
+}
+
+/**
+ * Get entry by event ID.
+ */
+export async function findByEventId(eventId: string): Promise<ApprovalEntry | null> {
+  // Search in memory first
+  for (const entry of approvalIndex.values()) {
+    if (entry.eventId === eventId) {
+      return entry;
+    }
+  }
+  
+  // Fallback: search in file
+  if (!existsSync(APPROVAL_QUEUE_FILE)) {
+    return null;
+  }
+  
+  try {
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Find most recent entry for this eventId
+    let latest: ApprovalEntry | null = null;
+    
+    for (const line of lines) {
+      try {
+        const entry: ApprovalEntry = JSON.parse(line);
+        if (entry.eventId === eventId) {
+          if (!latest || new Date(entry.createdAt) > new Date(latest.createdAt)) {
+            latest = entry;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+    
+    return latest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get entry by approval ID.
+ */
+export function findById(id: string): ApprovalEntry | null {
+  return approvalIndex.get(id) || null;
+}
+
+/**
+ * Check if an event is pending approval.
+ */
+export function isPending(eventId: string): boolean {
+  const entry = approvalIndex.get(idFromEventId(eventId));
+  return entry?.status === "pending";
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function idFromEventId(eventId: string): string | undefined {
+  for (const [id, entry] of approvalIndex.entries()) {
+    if (entry.eventId === eventId) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+async function appendResolution(entry: ApprovalEntry): Promise<void> {
+  // Append updated entry as new line
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(APPROVAL_QUEUE_FILE, line, "utf8");
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+// Auto-load state on module import
+loadState().catch(err => {
+  loadError = err instanceof Error ? err : new Error(String(err));
+  console.error("Failed to load approval queue state:", err);
+});

--- a/src/policy/audit-log.ts
+++ b/src/policy/audit-log.ts
@@ -1,0 +1,407 @@
+/**
+ * Audit Log
+ * 
+ * Durable audit trail capturing all policy-relevant decisions and operator actions.
+ * 
+ * DESIGN:
+ * - Every policy decision is logged
+ * - Every approval/denial action is logged
+ * - File stored at .claude/claudeclaw/audit-log.jsonl
+ * - Log entries are queryable and exportable
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All log entries are append-only
+ * - Entries include rule provenance and operator attribution
+ */
+
+import { appendFile, readFile, mkdir, writeFile, rename } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type AuditAction = "allow" | "deny" | "require_approval" | "approved" | "denied" | "expired";
+
+export interface AuditEntry {
+  timestamp: string;
+  eventId: string;
+  requestId: string;
+  source: string;
+  channelId?: string;
+  threadId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName: string;
+  action: AuditAction;
+  reason: string;
+  matchedRuleId?: string;
+  operatorId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Filters
+// ============================================================================
+
+export interface AuditLogFilters {
+  startDate?: string;
+  endDate?: string;
+  source?: string;
+  channelId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName?: string;
+  action?: AuditAction;
+  eventId?: string;
+  operatorId?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
+const DEFAULT_RETENTION_DAYS = 30;
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Log a policy decision or operator action.
+ */
+export async function log(entry: AuditEntry): Promise<void> {
+  // Ensure directory exists
+  if (!existsSync(AUDIT_DIR)) {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  }
+  
+  // Create a new object with timestamp if not provided (never mutate the input)
+  const finalEntry = entry.timestamp ? entry : { ...entry, timestamp: new Date().toISOString() };
+
+  // Append to log file
+  const line = JSON.stringify(finalEntry) + "\n";
+  await appendFile(AUDIT_LOG_FILE, line, "utf8");
+}
+
+/**
+ * Log a policy decision.
+ */
+export async function logPolicyDecision(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  action: AuditAction,
+  reason: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    matchedRuleId?: string;
+    operatorId?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  const entry: AuditEntry = {
+    timestamp: new Date().toISOString(),
+    eventId,
+    requestId,
+    source,
+    toolName,
+    action,
+    reason,
+    ...options,
+  };
+  
+  await log(entry);
+}
+
+/**
+ * Log an approval action.
+ */
+export async function logApproval(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  operatorId: string,
+  reason?: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logPolicyDecision(
+    eventId,
+    requestId,
+    source,
+    toolName,
+    "approved",
+    reason || "Approved by operator",
+    {
+      ...options,
+      operatorId,
+    }
+  );
+}
+
+/**
+ * Log a denial action.
+ */
+export async function logDenial(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  operatorId: string,
+  reason?: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logPolicyDecision(
+    eventId,
+    requestId,
+    source,
+    toolName,
+    "denied",
+    reason || "Denied by operator",
+    {
+      ...options,
+      operatorId,
+    }
+  );
+}
+
+/**
+ * Query audit log entries with filters.
+ */
+export async function query(filters: AuditLogFilters = {}): Promise<AuditEntry[]> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return [];
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const results: AuditEntry[] = [];
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      // Apply filters
+      if (filters.startDate && entry.timestamp < filters.startDate) {
+        continue;
+      }
+      
+      if (filters.endDate && entry.timestamp > filters.endDate) {
+        continue;
+      }
+      
+      if (filters.source && entry.source !== filters.source) {
+        continue;
+      }
+      
+      if (filters.channelId && entry.channelId !== filters.channelId) {
+        continue;
+      }
+      
+      if (filters.userId && entry.userId !== filters.userId) {
+        continue;
+      }
+      
+      if (filters.skillName && entry.skillName !== filters.skillName) {
+        continue;
+      }
+      
+      if (filters.toolName && entry.toolName !== filters.toolName) {
+        continue;
+      }
+      
+      if (filters.action && entry.action !== filters.action) {
+        continue;
+      }
+      
+      if (filters.eventId && entry.eventId !== filters.eventId) {
+        continue;
+      }
+      
+      if (filters.operatorId && entry.operatorId !== filters.operatorId) {
+        continue;
+      }
+      
+      results.push(entry);
+    } catch {
+      // Skip malformed entries
+      continue;
+    }
+  }
+  
+  // Sort by timestamp descending (newest first)
+  results.sort((a, b) => 
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+  
+  return results;
+}
+
+/**
+ * Export audit log entries within a date range.
+ */
+export async function exportEntries(
+  startDate: string,
+  endDate: string
+): Promise<AuditEntry[]> {
+  return query({ startDate, endDate });
+}
+
+/**
+ * Get audit log statistics.
+ */
+export async function getStats(): Promise<{
+  totalEntries: number;
+  byAction: Record<AuditAction, number>;
+  bySource: Record<string, number>;
+  oldestTimestamp: string | null;
+  newestTimestamp: string | null;
+}> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return {
+      totalEntries: 0,
+      byAction: { allow: 0, deny: 0, require_approval: 0, approved: 0, denied: 0, expired: 0 },
+      bySource: {},
+      oldestTimestamp: null,
+      newestTimestamp: null,
+    };
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const byAction: Record<AuditAction, number> = {
+    allow: 0,
+    deny: 0,
+    require_approval: 0,
+    approved: 0,
+    denied: 0,
+    expired: 0,
+  };
+  const bySource: Record<string, number> = {};
+  let oldestTimestamp: string | null = null;
+  let newestTimestamp: string | null = null;
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      byAction[entry.action] = (byAction[entry.action] || 0) + 1;
+      bySource[entry.source] = (bySource[entry.source] || 0) + 1;
+      
+      if (!oldestTimestamp || entry.timestamp < oldestTimestamp) {
+        oldestTimestamp = entry.timestamp;
+      }
+      if (!newestTimestamp || entry.timestamp > newestTimestamp) {
+        newestTimestamp = entry.timestamp;
+      }
+    } catch {
+      continue;
+    }
+  }
+  
+  return {
+    totalEntries: lines.length,
+    byAction,
+    bySource,
+    oldestTimestamp,
+    newestTimestamp,
+  };
+}
+
+// ============================================================================
+// Retention Management
+// ============================================================================
+
+export interface RetentionConfig {
+  maxAgeDays?: number;
+  maxFileSizeBytes?: number;
+}
+
+/**
+ * Clean up old audit log entries based on retention policy.
+ */
+export async function cleanupRetention(
+  config: RetentionConfig = {}
+): Promise<{ deleted: number; remaining: number }> {
+  const maxAgeDays = config.maxAgeDays ?? DEFAULT_RETENTION_DAYS;
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays);
+  const cutoffTimestamp = cutoffDate.toISOString();
+  
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return { deleted: 0, remaining: 0 };
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const keptLines: string[] = [];
+  let deleted = 0;
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      if (entry.timestamp < cutoffTimestamp) {
+        deleted++;
+        continue;
+      }
+      
+      keptLines.push(line);
+    } catch {
+      // Skip malformed entries - count as deleted
+      deleted++;
+      continue;
+    }
+  }
+  
+  // Write kept lines back atomically (temp file + rename)
+  if (deleted > 0) {
+    const tmpPath = AUDIT_LOG_FILE + ".tmp";
+    await writeFile(tmpPath, keptLines.map(l => l + "\n").join(""), "utf8");
+    await rename(tmpPath, AUDIT_LOG_FILE);
+  }
+
+  return {
+    deleted,
+    remaining: keptLines.length,
+  };
+}
+
+/**
+ * Get retention configuration documentation.
+ */
+export function getRetentionPolicy(): {
+  defaultRetentionDays: number;
+  defaultMaxFileSizeBytes: number;
+  recommendation: string;
+} {
+  return {
+    defaultRetentionDays: DEFAULT_RETENTION_DAYS,
+    defaultMaxFileSizeBytes: MAX_FILE_SIZE_BYTES,
+    recommendation: `Default retention is ${DEFAULT_RETENTION_DAYS} days. Rotate log file monthly and archive entries older than retention period. Monitor file size and rotate when approaching ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB.`,
+  };
+}

--- a/src/policy/channel-policies.ts
+++ b/src/policy/channel-policies.ts
@@ -1,0 +1,345 @@
+/**
+ * Scoped Channel and User Policies
+ * 
+ * Helper layer that resolves channel/user scoped policy rules into
+ * normalized engine rules without hard-coding channel-specific logic.
+ * 
+ * This module produces normalized rules - not a parallel evaluator.
+ */
+
+import {
+  type PolicyRule,
+  type ToolRequestContext,
+  getRules,
+} from "./engine";
+
+import { readFileSync, existsSync } from "fs";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SourceConfig {
+  source: string;
+  channels?: Record<string, ChannelConfig>;
+  defaultRules?: PolicyRule[];
+}
+
+export interface ChannelConfig {
+  channelId: string;
+  denyRules?: PolicyRule[];
+  allowRules?: PolicyRule[];
+  userOverrides?: Record<string, UserOverride>;
+}
+
+export interface UserOverride {
+  userId: string;
+  denyRules?: PolicyRule[];
+  allowRules?: PolicyRule[];
+}
+
+export interface ScopedPolicyConfig {
+  version: number;
+  sources: Record<string, SourceConfig>;
+  globalRules: PolicyRule[];
+  updatedAt: string;
+}
+
+const POLICY_DIR = ".claude/claudeclaw";
+const SCOPED_POLICY_FILE = `${POLICY_DIR}/scoped-policies.json`;
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Get all scoped rules applicable to a request context.
+ * Returns rules from global, source, channel, and user levels.
+ */
+export function getScopedRules(context: ToolRequestContext): PolicyRule[] {
+  const allRules: PolicyRule[] = [];
+  
+  // Get global rules (these are already loaded in engine)
+  const globalRules = getRules();
+  allRules.push(...globalRules);
+  
+  // Try to load and merge scoped policies (use cache first)
+  try {
+    const scopedConfig = cachedConfig ?? loadScopedPolicyConfig();
+    if (scopedConfig) {
+      const sourceConfig = scopedConfig.sources[context.source];
+      if (sourceConfig) {
+        // Add source-level default rules
+        if (sourceConfig.defaultRules) {
+          allRules.push(...sourceConfig.defaultRules);
+        }
+        
+        // Find channel-specific rules
+        if (context.channelId && sourceConfig.channels) {
+          const channelConfig = sourceConfig.channels[context.channelId];
+          if (channelConfig) {
+            // Add channel deny rules (high priority)
+            if (channelConfig.denyRules) {
+              allRules.push(...channelConfig.denyRules.map(rule => ({
+                ...rule,
+                priority: rule.priority ?? 150, // Higher than typical
+              })));
+            }
+            
+            // Add channel allow rules
+            if (channelConfig.allowRules) {
+              allRules.push(...channelConfig.allowRules.map(rule => ({
+                ...rule,
+                priority: rule.priority ?? 100,
+              })));
+            }
+            
+            // Find user-specific overrides
+            if (context.userId && channelConfig.userOverrides) {
+              const userOverride = channelConfig.userOverrides[context.userId];
+              if (userOverride) {
+                // User deny rules override channel allows
+                if (userOverride.denyRules) {
+                  allRules.push(...userOverride.denyRules.map(rule => ({
+                    ...rule,
+                    priority: rule.priority ?? 200, // Even higher priority
+                  })));
+                }
+                
+                // User allow rules
+                if (userOverride.allowRules) {
+                  allRules.push(...userOverride.allowRules.map(rule => ({
+                    ...rule,
+                    priority: rule.priority ?? 100,
+                  })));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // Scoped policy config not found or invalid - proceed with global rules only
+  }
+  
+  return allRules;
+}
+
+/**
+ * Merge scoped policies with global rules to produce effective rule set.
+ * This is the main entry point for the channel policy system.
+ */
+export function mergeScopedPolicies(
+  globalRules: PolicyRule[],
+  scopedRules: PolicyRule[]
+): PolicyRule[] {
+  // Scoped rules are already enriched with priorities in getScopedRules
+  // Here we just combine them with global rules
+  
+  // Filter out any disabled rules
+  const enabledGlobal = globalRules.filter(r => r.enabled !== false);
+  const enabledScoped = scopedRules.filter(r => r.enabled !== false);
+  
+  // Return combined and deduplicated rules
+  const ruleMap = new Map<string, PolicyRule>();
+  
+  // Add global rules first (lower base priority)
+  for (const rule of enabledGlobal) {
+    ruleMap.set(rule.id, rule);
+  }
+  
+  // Add scoped rules (may override global rules with same ID)
+  for (const rule of enabledScoped) {
+    ruleMap.set(rule.id, rule);
+  }
+  
+  return Array.from(ruleMap.values());
+}
+
+// ============================================================================
+// Configuration Loading
+// ============================================================================
+
+let cachedConfig: ScopedPolicyConfig | null = null;
+let configLoadedAt: string = "";
+
+function loadScopedPolicyConfig(): ScopedPolicyConfig | null {
+  if (cachedConfig) return cachedConfig;
+  try {
+    if (!existsSync(SCOPED_POLICY_FILE)) {
+      return null;
+    }
+
+    const content = readFileSync(SCOPED_POLICY_FILE, "utf8");
+    const config = JSON.parse(content) as ScopedPolicyConfig;
+
+    cachedConfig = config;
+    configLoadedAt = new Date().toISOString();
+
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the scoped policy configuration.
+ */
+export function getScopedPolicyConfig(): ScopedPolicyConfig | null {
+  if (!cachedConfig) {
+    return loadScopedPolicyConfig();
+  }
+  return cachedConfig;
+}
+
+/**
+ * Reload the scoped policy configuration from disk.
+ */
+export function reloadScopedPolicy(): ScopedPolicyConfig | null {
+  cachedConfig = null;
+  return loadScopedPolicyConfig();
+}
+
+/**
+ * Validate a scoped policy configuration.
+ */
+export function validateScopedPolicyConfig(
+  config: ScopedPolicyConfig
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  
+  if (!config.version) {
+    errors.push("Missing version field");
+  }
+  
+  if (!config.sources || typeof config.sources !== "object") {
+    errors.push("Missing or invalid sources object");
+  } else {
+    for (const [source, sourceConfig] of Object.entries(config.sources)) {
+      if (!sourceConfig.source) {
+        errors.push(`Source "${source}" missing source field`);
+      }
+      
+      if (sourceConfig.channels) {
+        for (const [channelId, channelConfig] of Object.entries(sourceConfig.channels)) {
+          if (channelConfig.channelId !== channelId) {
+            errors.push(`Channel ${channelId} has mismatched channelId`);
+          }
+          
+          // Validate nested rules
+          if (channelConfig.denyRules) {
+            for (const rule of channelConfig.denyRules) {
+              if (!rule.id || !rule.tool || !rule.action) {
+                errors.push(`Channel ${channelId} has invalid deny rule`);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+// ============================================================================
+// Default Configuration Factory
+// ============================================================================
+
+/**
+ * Create a default scoped policy configuration.
+ */
+export function createDefaultScopedPolicyConfig(): ScopedPolicyConfig {
+  return {
+    version: 1,
+    sources: {},
+    globalRules: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Get example configuration structure.
+ */
+export function getExampleScopedPolicyConfig(): ScopedPolicyConfig {
+  return {
+    version: 1,
+    sources: {
+      telegram: {
+        source: "telegram",
+        channels: {
+          "telegram:123": {
+            channelId: "telegram:123",
+            denyRules: [
+              {
+                id: "telegram-123-deny-bash",
+                priority: 200,
+                tool: "Bash",
+                action: "deny",
+                reason: "Bash disabled in this channel",
+              },
+            ],
+            allowRules: [
+              {
+                id: "telegram-123-allow-view",
+                priority: 100,
+                tool: ["View", "GlobTool", "GrepTool"],
+                action: "allow",
+                reason: "Read-only tools allowed",
+              },
+            ],
+            userOverrides: {
+              "admin-user": {
+                userId: "admin-user",
+                allowRules: [
+                  {
+                    id: "telegram-123-admin-allow-all",
+                    priority: 200,
+                    tool: "*",
+                    action: "allow",
+                    reason: "Admin has full access in this channel",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        defaultRules: [
+          {
+            id: "telegram-default-deny-edit",
+            priority: 50,
+            tool: "Edit",
+            action: "require_approval",
+            reason: "Edit requires approval on telegram by default",
+          },
+        ],
+      },
+      discord: {
+        source: "discord",
+        defaultRules: [
+          {
+            id: "discord-default-allow-view",
+            priority: 50,
+            tool: ["View", "GlobTool"],
+            action: "allow",
+            reason: "View tools allowed on discord",
+          },
+        ],
+      },
+    },
+    globalRules: [
+      {
+        id: "global-deny-dangerous",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+        reason: "Bash disabled globally unless explicitly allowed",
+      },
+    ],
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,0 +1,545 @@
+/**
+ * Policy Engine Core
+ * 
+ * Deterministic rule evaluation over normalized tool-use requests.
+ * 
+ * DESIGN:
+ * - Policy file stored at .claude/claudeclaw/policies.json
+ * - Default decision is DENY unless explicitly allowed
+ * - Evaluation order: highest priority first, then specificity, then explicit deny > allow > require_approval
+ * - Cache is configurable and bounded, invalidated on policy reload
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All policy state is loaded from disk on init
+ * - Invalid rules fail closed and are surfaced clearly
+ * - Cache must not become source of truth
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "crypto";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const POLICY_FILE = join(POLICY_DIR, "policies.json");
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ToolRequestContext {
+  eventId: string;
+  source: string;               // telegram, discord, slack, web, etc.
+  channelId?: string;
+  threadId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName: string;
+  toolArgs?: Record<string, unknown>;
+  sessionId?: string;           // local session mapping ID
+  claudeSessionId?: string | null;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type PolicyAction = "allow" | "deny" | "require_approval";
+
+export interface PolicyDecision {
+  requestId: string;
+  action: PolicyAction;
+  matchedRuleId?: string;
+  reason: string;
+  evaluatedAt: string;
+  cacheable?: boolean;
+}
+
+export interface PolicyScope {
+  source?: string | string[]; // "telegram", ["telegram","discord"], "*"
+  channelId?: string | string[];
+  userId?: string | string[];
+  skillName?: string | string[];
+}
+
+export interface PolicyConditions {
+  timeWindow?: { start: string; end: string };
+  argConstraints?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyRule {
+  id: string;
+  enabled?: boolean;
+  priority?: number;            // higher priority evaluated first
+  scope?: PolicyScope;
+  tool: string | string[];      // specific tool(s) or "*"
+  action: PolicyAction;
+  conditions?: PolicyConditions;
+  reason?: string;
+}
+
+export interface PolicyFile {
+  version: number;
+  rules: PolicyRule[];
+  cache?: {
+    enabled: boolean;
+    maxEntries: number;
+    ttlMs: number;
+  };
+  updatedAt: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+export interface ValidationError {
+  ruleId: string;
+  field: string;
+  message: string;
+}
+
+export interface ValidationWarning {
+  ruleId: string;
+  field: string;
+  message: string;
+}
+
+// ============================================================================
+// Cache
+// ============================================================================
+
+interface CacheEntry {
+  requestKey: string;
+  decision: PolicyDecision;
+  expiresAt: number;
+}
+
+let policyCache: Map<string, CacheEntry> = new Map();
+let cacheConfig = { enabled: false, maxEntries: 1000, ttlMs: 60000 };
+
+// ============================================================================
+// State
+// ============================================================================
+
+let loadedRules: PolicyRule[] = [];
+let loadedAt: string = "";
+let loadError: Error | null = null;
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Evaluate a tool-use request against loaded policy rules.
+ * Returns a deterministic PolicyDecision.
+ */
+export function evaluate(request: ToolRequestContext): PolicyDecision {
+  const requestId = randomUUID();
+  const evaluatedAt = new Date().toISOString();
+
+  // Fail closed if policy engine failed to initialize
+  if (loadError) {
+    return {
+      requestId,
+      action: "deny",
+      reason: `Policy engine failed to initialize: ${loadError.message}`,
+      evaluatedAt,
+      cacheable: false,
+    };
+  }
+
+  // Check cache first if enabled
+  if (cacheConfig.enabled) {
+    const cached = getCachedDecision(request);
+    if (cached) {
+      return {
+        ...cached,
+        requestId, // Fresh request ID even for cached decisions
+        evaluatedAt, // Fresh evaluation timestamp
+      };
+    }
+  }
+  
+  // Get all applicable rules sorted by priority
+  const applicableRules = getApplicableRules(request);
+  
+  if (applicableRules.length === 0) {
+    // No matching rules - default deny
+    const decision: PolicyDecision = {
+      requestId,
+      action: "deny",
+      reason: "No matching policy rule - default deny",
+      evaluatedAt,
+      cacheable: true,
+    };
+    
+    if (cacheConfig.enabled) {
+      cacheDecision(request, decision);
+    }
+    
+    return decision;
+  }
+  
+  // Sort by priority (highest first), then by specificity
+  const sortedRules = sortRules(applicableRules);
+  
+  // Find the best matching rule
+  const matchedRule = sortedRules[0];
+  
+  const decision: PolicyDecision = {
+    requestId,
+    action: matchedRule.action,
+    matchedRuleId: matchedRule.id,
+    reason: matchedRule.reason || `Matched rule: ${matchedRule.id}`,
+    evaluatedAt,
+    cacheable: matchedRule.action === "allow" && !matchedRule.conditions?.timeWindow,
+  };
+  
+  if (cacheConfig.enabled && decision.cacheable) {
+    cacheDecision(request, decision);
+  }
+  
+  return decision;
+}
+
+/**
+ * Load and validate rules from the policy file.
+ * Creates default policy file if none exists.
+ */
+export async function loadRules(): Promise<PolicyRule[]> {
+  // Ensure directory exists
+  if (!existsSync(POLICY_DIR)) {
+    await mkdir(POLICY_DIR, { recursive: true });
+  }
+  
+  // Create default policy file if none exists
+  if (!existsSync(POLICY_FILE)) {
+    const defaultPolicy: PolicyFile = {
+      version: 1,
+      rules: [],
+      cache: { enabled: false, maxEntries: 1000, ttlMs: 60000 },
+      updatedAt: new Date().toISOString(),
+    };
+    await writeFile(POLICY_FILE, JSON.stringify(defaultPolicy, null, 2), "utf8");
+  }
+  
+  // Read and parse policy file
+  const content = await readFile(POLICY_FILE, "utf8");
+  const policyFile: PolicyFile = JSON.parse(content);
+  
+  // Validate rules
+  const validation = validateRules(policyFile.rules);
+  if (!validation.valid) {
+    // Fail closed - don't load invalid rules
+    const errorMsg = validation.errors.map(e => `${e.ruleId}: ${e.message}`).join("; ");
+    throw new Error(`Policy file contains invalid rules: ${errorMsg}`);
+  }
+  
+  // Update cache config
+  if (policyFile.cache) {
+    cacheConfig = { ...cacheConfig, ...policyFile.cache };
+  }
+  
+  // Clear cache on reload
+  policyCache.clear();
+  
+  loadedRules = policyFile.rules;
+  loadedAt = new Date().toISOString();
+  
+  return loadedRules;
+}
+
+/**
+ * Validate a set of policy rules.
+ * Returns validation result with errors and warnings.
+ */
+export function validateRules(rules: PolicyRule[]): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  
+  for (const rule of rules) {
+    // Validate rule ID
+    if (!rule.id || typeof rule.id !== "string") {
+      errors.push({ ruleId: rule.id || "unknown", field: "id", message: "Rule must have a valid id string" });
+    }
+    
+    // Validate action
+    if (!rule.action || !["allow", "deny", "require_approval"].includes(rule.action)) {
+      errors.push({ ruleId: rule.id, field: "action", message: "Rule must have action: allow | deny | require_approval" });
+    }
+    
+    // Validate tool
+    if (!rule.tool) {
+      errors.push({ ruleId: rule.id, field: "tool", message: "Rule must specify tool(s)" });
+    } else if (Array.isArray(rule.tool) && rule.tool.length === 0) {
+      errors.push({ ruleId: rule.id, field: "tool", message: "Tool array cannot be empty" });
+    }
+    
+    // Validate scope values
+    if (rule.scope) {
+      if (rule.scope.source === "") {
+        errors.push({ ruleId: rule.id, field: "scope.source", message: "Scope source cannot be empty string" });
+      }
+    }
+    
+    // Validate conditions
+    if (rule.conditions) {
+      if (rule.conditions.timeWindow) {
+        const tw = rule.conditions.timeWindow;
+        if (!tw.start || !tw.end) {
+          errors.push({ ruleId: rule.id, field: "conditions.timeWindow", message: "timeWindow requires start and end" });
+        } else {
+          const startDate = new Date(tw.start);
+          const endDate = new Date(tw.end);
+          if (isNaN(startDate.getTime())) {
+            errors.push({ ruleId: rule.id, field: "conditions.timeWindow.start", message: "Invalid start date format" });
+          }
+          if (isNaN(endDate.getTime())) {
+            errors.push({ ruleId: rule.id, field: "conditions.timeWindow.end", message: "Invalid end date format" });
+          }
+          if (!isNaN(startDate.getTime()) && !isNaN(endDate.getTime()) && startDate >= endDate) {
+            warnings.push({ ruleId: rule.id, field: "conditions.timeWindow", message: "timeWindow end is not after start - rule will never match" });
+          }
+        }
+      }
+    }
+    
+    // Warnings for potentially problematic patterns
+    if (rule.action === "allow" && !rule.scope) {
+      warnings.push({ ruleId: rule.id, field: "scope", message: "Unscoped allow rule - will apply to all requests" });
+    }
+    
+    if (rule.tool === "*" && !rule.scope) {
+      warnings.push({ ruleId: rule.id, field: "tool/scope", message: "Globally allow all tools - may be overly permissive" });
+    }
+  }
+  
+  // Check for duplicate rule IDs
+  const ids = rules.map(r => r.id);
+  const duplicates = ids.filter((id, idx) => ids.indexOf(id) !== idx);
+  if (duplicates.length > 0) {
+    errors.push({ ruleId: "global", field: "rules", message: `Duplicate rule IDs: ${[...new Set(duplicates)].join(", ")}` });
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Get the currently loaded rules.
+ */
+export function getRules(): PolicyRule[] {
+  return [...loadedRules];
+}
+
+/**
+ * Get the last time rules were loaded.
+ */
+export function getLoadedAt(): string {
+  return loadedAt;
+}
+
+/**
+ * Check if cache is enabled.
+ */
+export function isCacheEnabled(): boolean {
+  return cacheConfig.enabled;
+}
+
+/**
+ * Clear the decision cache.
+ */
+export function clearCache(): void {
+  policyCache.clear();
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function getApplicableRules(request: ToolRequestContext): PolicyRule[] {
+  return loadedRules.filter(rule => {
+    // Skip disabled rules
+    if (rule.enabled === false) return false;
+    
+    // Check tool match
+    if (!matchesTool(rule.tool, request.toolName)) return false;
+    
+    // Check scope match
+    if (!matchesScope(rule.scope, request)) return false;
+    
+    // Check conditions
+    if (!matchesConditions(rule.conditions, request)) return false;
+    
+    return true;
+  });
+}
+
+function matchesTool(ruleTool: string | string[], requestTool: string): boolean {
+  if (ruleTool === "*") return true;
+  if (Array.isArray(ruleTool)) return ruleTool.includes(requestTool);
+  return ruleTool === requestTool;
+}
+
+function matchesScope(scope: PolicyScope | undefined, request: ToolRequestContext): boolean {
+  if (!scope) return true; // No scope = match all
+  
+  // Check source
+  if (scope.source) {
+    if (Array.isArray(scope.source)) {
+      if (!scope.source.includes(request.source)) return false;
+    } else if (scope.source !== "*") {
+      if (scope.source !== request.source) return false;
+    }
+  }
+  
+  // Check channelId
+  if (scope.channelId) {
+    if (!request.channelId) return false;
+    if (Array.isArray(scope.channelId)) {
+      if (!scope.channelId.includes(request.channelId)) return false;
+    } else if (scope.channelId !== "*") {
+      if (scope.channelId !== request.channelId) return false;
+    }
+  }
+
+  // Check userId
+  if (scope.userId) {
+    if (!request.userId) return false;
+    if (Array.isArray(scope.userId)) {
+      if (!scope.userId.includes(request.userId)) return false;
+    } else if (scope.userId !== "*") {
+      if (scope.userId !== request.userId) return false;
+    }
+  }
+
+  // Check skillName
+  if (scope.skillName) {
+    if (!request.skillName) return false;
+    if (Array.isArray(scope.skillName)) {
+      if (!scope.skillName.includes(request.skillName)) return false;
+    } else if (scope.skillName !== "*") {
+      if (scope.skillName !== request.skillName) return false;
+    }
+  }
+  
+  return true;
+}
+
+function matchesConditions(conditions: PolicyConditions | undefined, request: ToolRequestContext): boolean {
+  if (!conditions) return true;
+  
+  // Check time window
+  if (conditions.timeWindow) {
+    const now = new Date(request.timestamp);
+    const start = new Date(conditions.timeWindow.start);
+    const end = new Date(conditions.timeWindow.end);
+    
+    if (now < start || now > end) return false;
+  }
+  
+  // Check arg constraints
+  if (conditions.argConstraints && request.toolArgs) {
+    for (const [key, expectedValue] of Object.entries(conditions.argConstraints)) {
+      const actualValue = request.toolArgs[key];
+      if (actualValue !== expectedValue) return false;
+    }
+  }
+  
+  // Check metadata constraints
+  if (conditions.metadata && request.metadata) {
+    for (const [key, expectedValue] of Object.entries(conditions.metadata)) {
+      const actualValue = request.metadata[key];
+      if (actualValue !== expectedValue) return false;
+    }
+  }
+  
+  return true;
+}
+
+function sortRules(rules: PolicyRule[]): PolicyRule[] {
+  return [...rules].sort((a, b) => {
+    // Highest priority first
+    const priorityA = a.priority ?? 0;
+    const priorityB = b.priority ?? 0;
+    if (priorityB !== priorityA) return priorityB - priorityA;
+    
+    // More specific scope first (more scope fields set = more specific)
+    const specificityA = countScopeFields(a.scope);
+    const specificityB = countScopeFields(b.scope);
+    if (specificityB !== specificityA) return specificityB - specificityA;
+    
+    // Explicit deny beats require_approval beats allow
+    const actionOrder: Record<PolicyAction, number> = { deny: 0, require_approval: 1, allow: 2 };
+    return actionOrder[a.action] - actionOrder[b.action];
+  });
+}
+
+function countScopeFields(scope: PolicyScope | undefined): number {
+  if (!scope) return 0;
+  let count = 0;
+  if (scope.source) count++;
+  if (scope.channelId) count++;
+  if (scope.userId) count++;
+  if (scope.skillName) count++;
+  return count;
+}
+
+function getRequestKey(request: ToolRequestContext): string {
+  const parts = [
+    request.source,
+    request.channelId || "",
+    request.userId || "",
+    request.skillName || "",
+    request.toolName,
+    request.toolArgs ? JSON.stringify(request.toolArgs) : "",
+  ];
+  return parts.join("|");
+}
+
+function getCachedDecision(request: ToolRequestContext): PolicyDecision | null {
+  const key = getRequestKey(request);
+  const entry = policyCache.get(key);
+  
+  if (!entry) return null;
+  
+  if (Date.now() > entry.expiresAt) {
+    policyCache.delete(key);
+    return null;
+  }
+  
+  return entry.decision;
+}
+
+function cacheDecision(request: ToolRequestContext, decision: PolicyDecision): void {
+  if (!decision.cacheable) return;
+  
+  const key = getRequestKey(request);
+  
+  // Evict oldest if at capacity
+  if (policyCache.size >= cacheConfig.maxEntries) {
+    const oldestKey = policyCache.keys().next().value;
+    if (oldestKey) policyCache.delete(oldestKey);
+  }
+  
+  policyCache.set(key, {
+    requestKey: key,
+    decision,
+    expiresAt: Date.now() + cacheConfig.ttlMs,
+  });
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+// Auto-load rules on module import
+loadRules().catch(err => {
+  loadError = err instanceof Error ? err : new Error(String(err));
+  console.error("Failed to load policy rules:", err);
+});

--- a/src/policy/skill-overlays.ts
+++ b/src/policy/skill-overlays.ts
@@ -1,0 +1,275 @@
+/**
+ * Skill Policy Overlays
+ * 
+ * Allow skills to declare tool constraints that integrate with the policy engine.
+ * Skill overlays are translated into policy-relevant constraints.
+ * 
+ * IMPORTANT: Skill overlays must not become a privilege-escalation path.
+ * - "preferredTools" influences recommendation, not security overrides
+ * - "requiredTools" surfaces actionable policy errors when unavailable
+ * - "deniedTools" are enforced as restrictions even when globally allowed
+ */
+
+import {
+  type PolicyRule,
+  type ToolRequestContext,
+} from "./engine";
+import { resolveSkillPrompt } from "../skills";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SkillOverlay {
+  skillName: string;
+  requiredTools?: string[];
+  preferredTools?: string[];
+  deniedTools?: string[];
+  reason?: string;
+}
+
+export interface SkillPolicyResult {
+  allowed: boolean;
+  reason: string;
+  skillOverlay?: SkillOverlay;
+  missingTools?: string[];
+  deniedTools?: string[];
+}
+
+// ============================================================================
+// Skill Metadata Parsing
+// ============================================================================
+
+/**
+ * Parse skill metadata from SKILL.md content.
+ * Looks for policy-related frontmatter fields.
+ */
+export function parseSkillMetadata(skillContent: string, skillName: string): SkillOverlay | null {
+  // Parse YAML frontmatter
+  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    return null;
+  }
+  
+  const fm = fmMatch[1];
+  
+  // Look for policy-related fields
+  let requiredTools: string[] | undefined;
+  let preferredTools: string[] | undefined;
+  let deniedTools: string[] | undefined;
+  
+  // Helper to parse array fields (handles both multiline and inline formats)
+  function parseArrayField(fieldName: string): string[] | undefined {
+    // Match multiline format:
+    // requiredTools:
+    //   - item1
+    //   - item2
+    const multilineMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\n((?:\\s*-\\s*.+\\n?)+)`, 'm'));
+    if (multilineMatch) {
+      return multilineMatch[1]
+        .split("\n")
+        .map(line => line.replace(/^\s*-\s*/, "").trim())
+        .filter(Boolean);
+    }
+    
+    // Match inline empty array: requiredTools: []
+    const emptyMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\[\\s*\\]`, 'm'));
+    if (emptyMatch) {
+      return [];
+    }
+    
+    // Match inline array: requiredTools: [item1, item2]
+    const inlineMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\[([^\\]]+)\\]`, 'm'));
+    if (inlineMatch) {
+      return inlineMatch[1]
+        .split(",")
+        .map(item => item.trim())
+        .filter(Boolean);
+    }
+    
+    return undefined;
+  }
+  
+  // Parse requiredTools
+  const parsedRequired = parseArrayField("requiredTools");
+  if (parsedRequired !== undefined) {
+    requiredTools = parsedRequired;
+  }
+  
+  // Parse preferredTools
+  const parsedPreferred = parseArrayField("preferredTools");
+  if (parsedPreferred !== undefined) {
+    preferredTools = parsedPreferred;
+  }
+  
+  // Parse deniedTools
+  const parsedDenied = parseArrayField("deniedTools");
+  if (parsedDenied !== undefined) {
+    deniedTools = parsedDenied;
+  }
+  
+  // If no policy fields found, return null
+  if (!requiredTools && !preferredTools && !deniedTools) {
+    return null;
+  }
+  
+  return {
+    skillName,
+    requiredTools,
+    preferredTools,
+    deniedTools,
+  };
+}
+
+// ============================================================================
+// Skill Overlay Resolution
+// ============================================================================
+
+/**
+ * Get the skill overlay for a given skill name.
+ * Loads and parses the skill's SKILL.md to extract policy metadata.
+ */
+export async function getSkillOverlay(skillName: string): Promise<SkillOverlay | null> {
+  // Resolve skill prompt (reads SKILL.md)
+  const content = await resolveSkillPrompt(skillName);
+  if (!content) {
+    return null;
+  }
+  
+  return parseSkillMetadata(content, skillName);
+}
+
+/**
+ * Get skill overlay synchronously from cached content.
+ */
+export function getSkillOverlayFromContent(content: string, skillName: string): SkillOverlay | null {
+  return parseSkillMetadata(content, skillName);
+}
+
+// ============================================================================
+// Overlay to Rules Conversion
+// ============================================================================
+
+/**
+ * Convert a skill overlay into policy rules.
+ * 
+ * Rules generated:
+ * - deniedTools → high-priority deny rules (restrictive)
+ * - requiredTools → no direct rules, tracked for validation
+ * - preferredTools → informational only (not security-critical)
+ */
+export function overlayToRules(overlay: SkillOverlay, basePriority: number = 100): PolicyRule[] {
+  const rules: PolicyRule[] = [];
+  
+  // Denied tools become deny rules (high priority)
+  if (overlay.deniedTools && overlay.deniedTools.length > 0) {
+    for (const tool of overlay.deniedTools) {
+      rules.push({
+        id: `skill-${overlay.skillName}-deny-${tool}`,
+        priority: basePriority + 50, // Higher than typical rules
+        scope: {
+          skillName: overlay.skillName,
+        },
+        tool,
+        action: "deny",
+        reason: overlay.reason || `Tool ${tool} denied by skill ${overlay.skillName} policy`,
+      });
+    }
+  }
+  
+  return rules;
+}
+
+// ============================================================================
+// Skill Policy Evaluation
+// ============================================================================
+
+/**
+ * Evaluate a tool request in the context of skill policy.
+ * Checks if the requested tool is allowed given the skill's policy overlay.
+ */
+export function evaluateSkillPolicy(
+  overlay: SkillOverlay,
+  toolName: string
+): SkillPolicyResult {
+  // Check if tool is explicitly denied
+  if (overlay.deniedTools && overlay.deniedTools.includes(toolName)) {
+    return {
+      allowed: false,
+      reason: `Tool ${toolName} is explicitly denied by skill ${overlay.skillName}`,
+      skillOverlay: overlay,
+      deniedTools: [toolName],
+    };
+  }
+  
+  // Check if required tools are missing (but not for the requested tool)
+  if (overlay.requiredTools) {
+    const missingTools = overlay.requiredTools.filter(t => t !== toolName);
+    if (missingTools.length > 0) {
+      // Tool requested is not missing, but some required tools might be
+      // This is informational - not a blocking error
+    }
+  }
+  
+  // If we get here, the tool is allowed by the skill overlay
+  return {
+    allowed: true,
+    reason: `Tool ${toolName} is allowed by skill ${overlay.skillName} policy`,
+    skillOverlay: overlay,
+  };
+}
+
+/**
+ * Validate that all required tools for a skill are available.
+ * Returns information about missing required tools.
+ */
+export function validateRequiredTools(
+  overlay: SkillOverlay,
+  availableTools: string[]
+): { valid: boolean; missingTools: string[] } {
+  if (!overlay.requiredTools || overlay.requiredTools.length === 0) {
+    return { valid: true, missingTools: [] };
+  }
+  
+  const missingTools = overlay.requiredTools.filter(
+    required => !availableTools.includes(required)
+  );
+  
+  return {
+    valid: missingTools.length === 0,
+    missingTools,
+  };
+}
+
+// ============================================================================
+// Example Skill Overlays
+// ============================================================================
+
+/**
+ * Get example skill overlay configurations for documentation.
+ */
+export function getExampleSkillOverlays(): Record<string, SkillOverlay> {
+  return {
+    "code-review": {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+      preferredTools: ["View", "GlobTool", "GrepTool"],
+      deniedTools: ["Bash", "Edit", "Write"],
+      reason: "Code review skill is read-only by default",
+    },
+    "web-scrape": {
+      skillName: "web-scrape",
+      requiredTools: ["WebFetch", "Bash"],
+      preferredTools: ["WebFetch"],
+      deniedTools: [],
+      reason: "Web scraping requires network access and shell",
+    },
+    "admin": {
+      skillName: "admin",
+      requiredTools: ["Bash", "Write", "Edit", "View"],
+      preferredTools: ["Bash", "Write", "Edit", "View"],
+      deniedTools: [],
+      reason: "Admin skill has full tool access",
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Introduces a policy engine for tool-use governance. Foundation for the governance and gateway PRs.

- **Deterministic rule evaluation** — priority first, then specificity, then deny > require_approval > allow
- **Default-deny** — no matching rule = denied
- **Scoped policies** — rules target specific sources, channels, users, skills
- **Audit logging** — append-only JSONL with atomic retention cleanup
- **Approval queue** — durable queue for require_approval actions
- **Channel/skill overlays** — per-source, per-channel, per-user overrides
- **Bounded cache** — LRU with TTL, time-window rules excluded
- **Fail-closed init** — failed loading denies all requests with clear error

### Security hardening

| Issue | Fix |
|-------|-----|
| Scope matching bypass (privilege escalation) | Requests missing scoped fields correctly fail to match |
| Audit log mutating caller objects | New objects via spread |
| Approval queue mutating before persist | Persist-first, then update memory |
| Stale cached time-window decisions | Time-window rules never cached |
| Silent init failure | loadError state checked on every evaluation |
| Unbounded audit log growth | Atomic cleanup via temp file + rename |

### Files

- `src/policy/engine.ts` — Core evaluation, validation, caching
- `src/policy/audit-log.ts` — Append-only logging with retention
- `src/policy/approval-queue.ts` — Durable approval workflow
- `src/policy/channel-policies.ts` — Scoped policy overlays
- `src/policy/skill-overlays.ts` — Skill-based rules
- `src/__tests__/policy/` — 5 test files

## Test plan

- [ ] bun test src/__tests__/policy/ — all policy tests pass
- [ ] Verify default-deny with empty rules
- [ ] Verify scoped rules don't match when request fields missing