### PR TITLE
feat: add governance layer with model routing, budget control, and watchdog

### DIFF
--- a/src/__tests__/governance/budget-engine.test.ts
+++ b/src/__tests__/governance/budget-engine.test.ts
@@ -1,0 +1,326 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  initBudgetEngine,
+  evaluateBudget,
+  getBudgetState,
+  upsertBudgetPolicy,
+  deleteBudgetPolicy,
+  loadPricingConfig,
+  loadPolicies,
+  calculateEstimatedCost,
+  createDefaultPoliciesForChannel,
+  resetBudgetEngine,
+  type BudgetPolicy,
+} from "../../governance/budget-engine";
+import { join } from "path";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+
+const BUDGET_POLICIES_FILE = join(process.cwd(), ".claude", "claudeclaw", "budget-policies.json");
+const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
+
+describe("BudgetEngine", () => {
+  beforeEach(async () => {
+    const { rm, readdir } = await import("fs/promises");
+    
+    // Clean budget policies file for test isolation
+    try {
+      await rm(BUDGET_POLICIES_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    
+    // Clean usage directory for test isolation
+    try {
+      const files = await readdir(USAGE_DIR);
+      await Promise.all(
+        files
+          .filter(f => f !== ".gitkeep")
+          .map(f => rm(join(USAGE_DIR, f), { force: true }))
+      );
+    } catch {
+      // Directory might not exist
+    }
+    
+    resetBudgetEngine();
+    resetUsageTracker();
+    await initUsageTracker();
+    await initBudgetEngine();
+  });
+
+  afterEach(async () => {
+    resetBudgetEngine();
+    resetUsageTracker();
+  });
+
+  test("should initialize with default pricing", async () => {
+    const pricing = await loadPricingConfig();
+    expect(pricing.version).toBe("1.0.0");
+    expect(pricing.tiers.length).toBeGreaterThan(0);
+    expect(pricing.tiers[0].provider).toBe("anthropic");
+  });
+
+  test("should create budget policy", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Test Policy",
+      scope: { channelId: "test-channel" },
+      thresholds: {
+        warnAt: 10,
+        degradeAt: 20,
+        blockAt: 50,
+      },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    expect(policy.id).toBeDefined();
+    expect(policy.name).toBe("Test Policy");
+    expect(policy.thresholds.warnAt).toBe(10);
+    expect(policy.thresholds.degradeAt).toBe(20);
+    expect(policy.thresholds.blockAt).toBe(50);
+  });
+
+  test("should update existing policy", async () => {
+    const created = await upsertBudgetPolicy({
+      name: "Original Name",
+      scope: {},
+      thresholds: {},
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const updated = await upsertBudgetPolicy({
+      id: created.id,
+      name: "Updated Name",
+      scope: {},
+      thresholds: { warnAt: 5 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.name).toBe("Updated Name");
+    expect(updated.thresholds.warnAt).toBe(5);
+  });
+
+  test("should delete budget policy", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "To Delete",
+      scope: {},
+      thresholds: {},
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const deleted = await deleteBudgetPolicy(policy.id);
+    expect(deleted).toBe(true);
+
+    const policies = await loadPolicies();
+    expect(policies.find((p) => p.id === policy.id)).toBeUndefined();
+  });
+
+  test("should evaluate healthy budget when under threshold", async () => {
+    await upsertBudgetPolicy({
+      name: "Low Limit Policy",
+      scope: { channelId: "test-chan" },
+      thresholds: { warnAt: 100, degradeAt: 200, blockAt: 500 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Create a small invocation
+    const start = await recordInvocationStart({
+      channelId: "test-chan",
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 100, outputTokens: 100 },
+      { currency: "USD", totalCost: 0.001 }
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "test-chan" });
+    expect(evaluation.length).toBeGreaterThan(0);
+    expect(evaluation[0].state).toBe("healthy");
+  });
+
+  test("should evaluate warn state at threshold", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Warn Test",
+      scope: { channelId: "warn-chan" },
+      thresholds: { warnAt: 0.05, degradeAt: 0.10 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "warn-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 10000, outputTokens: 5000 },
+      { currency: "USD", totalCost: 0.06 } // Above warnAt
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "warn-chan" });
+    expect(evaluation[0].state).toBe("warn");
+    expect(evaluation[0].actions.shouldWarn).toBe(true);
+  });
+
+  test("should return degrade state when threshold exceeded", async () => {
+    await upsertBudgetPolicy({
+      name: "Degrade Test",
+      scope: { channelId: "degrade-chan" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.05, blockAt: 0.10 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "degrade-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 20000, outputTokens: 10000 },
+      { currency: "USD", totalCost: 0.08 } // Above degradeAt
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "degrade-chan" });
+    expect(["degrade", "reroute", "block"]).toContain(evaluation[0].state);
+  });
+
+  test("should return block state at block threshold", async () => {
+    await upsertBudgetPolicy({
+      name: "Block Test",
+      scope: { channelId: "block-chan" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.05, blockAt: 0.10 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "block-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 40000, outputTokens: 20000 },
+      { currency: "USD", totalCost: 0.15 } // Above blockAt
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "block-chan" });
+    expect(evaluation[0].state).toBe("block");
+    expect(evaluation[0].actions.shouldBlock).toBe(true);
+  });
+
+  test("should calculate estimated cost correctly", async () => {
+    const cost = calculateEstimatedCost(
+      {
+        inputTokens: 1000000, // 1M input
+        outputTokens: 500000, // 500K output
+        cacheCreationInputTokens: 100000,
+        cacheReadInputTokens: 200000,
+      },
+      "anthropic",
+      "claude-3-5-sonnet"
+    );
+
+    expect(cost).not.toBeNull();
+    // 1M * $3 + 500K * $15 + 100K * $3.75 + 200K * $0.30 / 1M
+    // = $3 + $7.5 + $0.375 + $0.06 = $10.935
+    expect(cost!.totalCost).toBeCloseTo(10.935, 2);
+  });
+
+  test("should create default policies for channel", async () => {
+    const policies = await createDefaultPoliciesForChannel("new-channel", {
+      dailyLimit: 10,
+      monthlyLimit: 100,
+    });
+
+    expect(policies.length).toBe(2);
+    expect(policies.find((p) => p.period === "daily")).toBeDefined();
+    expect(policies.find((p) => p.period === "monthly")).toBeDefined();
+  });
+
+  test("should scope policies correctly", async () => {
+    // Policy for specific channel
+    await upsertBudgetPolicy({
+      name: "Channel Specific",
+      scope: { channelId: "specific-chan" },
+      thresholds: { blockAt: 1 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Policy for all channels
+    await upsertBudgetPolicy({
+      name: "Global",
+      scope: {},
+      thresholds: { blockAt: 1000 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const evalForSpecific = await evaluateBudget({ channelId: "specific-chan" });
+    const evalForOther = await evaluateBudget({ channelId: "other-chan" });
+
+    // Should have both policies for specific channel
+    expect(evalForSpecific.length).toBe(2);
+
+    // Should only have global policy for other channel
+    expect(evalForOther.length).toBe(1);
+    expect(evalForOther[0].policyName).toBe("Global");
+  });
+
+  test("should respect period boundaries", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Session Policy",
+      scope: {},
+      thresholds: { warnAt: 0.001 },
+      period: "session",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Session-scoped policy should evaluate based on session usage
+    const start = await recordInvocationStart({
+      sessionId: "test-session",
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.005 }
+    );
+
+    const eval_ = await evaluateBudget({ sessionId: "test-session" });
+    // Should evaluate session policy
+    expect(eval_.some((e) => e.policyId === policy.id)).toBe(true);
+  });
+});

--- a/src/__tests__/governance/model-router.test.ts
+++ b/src/__tests__/governance/model-router.test.ts
@@ -1,0 +1,237 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  selectModel,
+  getFallbackChain,
+  isModelAllowed,
+  configureRouter,
+  getRouterConfig,
+} from "../../governance/model-router";
+import {
+  initBudgetEngine,
+  upsertBudgetPolicy,
+  resetBudgetEngine,
+} from "../../governance/budget-engine";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+import { join } from "path";
+
+const BUDGET_POLICIES_FILE = join(process.cwd(), ".claude", "claudeclaw", "budget-policies.json");
+
+describe("ModelRouter", () => {
+  beforeEach(async () => {
+    resetUsageTracker();
+    resetBudgetEngine();
+    
+    // Clear budget policies file for test isolation
+    try {
+      const { rm } = await import("fs/promises");
+      await rm(BUDGET_POLICIES_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    
+    await initUsageTracker();
+    await initBudgetEngine();
+    
+    // Reset router config
+    configureRouter({
+      defaultProvider: "anthropic",
+      defaultModel: "claude-3-5-sonnet",
+      fallbackChain: [
+        { provider: "anthropic", model: "claude-3-5-sonnet" },
+        { provider: "anthropic", model: "claude-3-haiku" },
+        { provider: "openai", model: "gpt-4o-mini" },
+      ],
+    });
+  });
+
+  test("should select default model with healthy budget", async () => {
+    const decision = await selectModel({});
+
+    expect(decision.selectedProvider).toBe("anthropic");
+    expect(decision.selectedModel).toBe("claude-3-5-sonnet");
+    expect(decision.budgetState).toBe("healthy");
+    expect(decision.reason).toContain("Default model selection");
+  });
+
+  test("should respect preferred provider/model", async () => {
+    const decision = await selectModel({
+      preferredProvider: "openai",
+      preferredModel: "gpt-4o",
+    });
+
+    expect(decision.selectedProvider).toBe("openai");
+    expect(decision.selectedModel).toBe("gpt-4o");
+  });
+
+  test("should return auditable decision", async () => {
+    const decision = await selectModel({});
+
+    expect(decision.requestId).toBeDefined();
+    expect(decision.decidedAt).toBeDefined();
+    expect(decision.reason).toBeDefined();
+    expect(decision.fallbackChain).toBeDefined();
+    expect(Array.isArray(decision.fallbackChain)).toBe(true);
+  });
+
+  test("should block execution when budget exceeded", async () => {
+    // Create a policy that will be exceeded
+    await upsertBudgetPolicy({
+      name: "Very Low Limit",
+      scope: { channelId: "low-limit-chan" },
+      thresholds: { blockAt: 0.001 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Add usage that exceeds the limit
+    const start = await recordInvocationStart({
+      channelId: "low-limit-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 100000, outputTokens: 50000 },
+      { currency: "USD", totalCost: 0.50 }
+    );
+
+    const decision = await selectModel({ channelId: "low-limit-chan" });
+
+    expect(decision.selectedModel).toBe("");
+    expect(decision.budgetState).toBe("block");
+    expect(decision.reason).toContain("blocked");
+  });
+
+  test("should allow explicit override when permitted", async () => {
+    const decision = await selectModel({
+      explicitOverride: {
+        provider: "openai",
+        model: "gpt-4o",
+        allowed: true,
+      },
+    });
+
+    expect(decision.selectedProvider).toBe("openai");
+    expect(decision.selectedModel).toBe("gpt-4o");
+    expect(decision.reason).toContain("override");
+  });
+
+  test("should use capability mapping", async () => {
+    const decision = await selectModel({
+      capability: "coding",
+    });
+
+    expect(decision.selectedProvider).toBe("anthropic");
+    expect(decision.selectedModel).toBe("claude-3-5-sonnet");
+  });
+
+  test("should use fast capability for quick tasks", async () => {
+    const decision = await selectModel({
+      capability: "fast",
+    });
+
+    expect(decision.selectedProvider).toBe("anthropic");
+    expect(decision.selectedModel).toBe("claude-3-haiku");
+  });
+
+  test("should provide fallback chain", async () => {
+    const chain = await getFallbackChain({});
+
+    expect(chain.length).toBeGreaterThan(0);
+    expect(chain[0]).toHaveProperty("provider");
+    expect(chain[0]).toHaveProperty("model");
+  });
+
+  test("should check model allowed status", async () => {
+    const result = await isModelAllowed("anthropic", "claude-3-5-sonnet", {});
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBeDefined();
+  });
+
+  test("should deny model when budget exceeded", async () => {
+    // Create a policy that will be exceeded
+    await upsertBudgetPolicy({
+      name: "Deny Test",
+      scope: { channelId: "deny-chan" },
+      thresholds: { blockAt: 0.001 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Add usage
+    const start = await recordInvocationStart({
+      channelId: "deny-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 100000, outputTokens: 50000 },
+      { currency: "USD", totalCost: 0.50 }
+    );
+
+    const result = await isModelAllowed(
+      "anthropic",
+      "claude-3-5-sonnet",
+      { channelId: "deny-chan" }
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("blocked");
+  });
+
+  test("should configure router", () => {
+    configureRouter({
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o",
+      degradeToModel: "claude-3-haiku",
+      rerouteToProvider: "google",
+    });
+
+    const config = getRouterConfig();
+    expect(config.defaultProvider).toBe("openai");
+    expect(config.defaultModel).toBe("gpt-4o");
+    expect(config.degradeToModel).toBe("claude-3-haiku");
+    expect(config.rerouteToProvider).toBe("google");
+  });
+
+  test("should include budget state in decision", async () => {
+    // Create usage that will trigger warn state
+    await upsertBudgetPolicy({
+      name: "Warn Test",
+      scope: { channelId: "warn-chan" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.05 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "warn-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 5000, outputTokens: 2500 },
+      { currency: "USD", totalCost: 0.02 } // Above warnAt
+    );
+
+    const decision = await selectModel({ channelId: "warn-chan" });
+
+    expect(decision.budgetState).toBeDefined();
+    expect(["warn", "degrade", "block"]).toContain(decision.budgetState);
+    expect(decision.matchedPolicyId).toBeDefined();
+  });
+});

--- a/src/__tests__/governance/telemetry.test.ts
+++ b/src/__tests__/governance/telemetry.test.ts
@@ -1,0 +1,247 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  getTelemetry,
+  getTelemetrySummary,
+  getProviderBreakdown,
+  getModelBreakdown,
+  getChannelBreakdown,
+  getBudgetHealth,
+} from "../../governance/telemetry";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+import {
+  initBudgetEngine,
+  upsertBudgetPolicy,
+  resetBudgetEngine,
+} from "../../governance/budget-engine";
+
+describe("Telemetry", () => {
+  beforeEach(async () => {
+    resetUsageTracker();
+    resetBudgetEngine();
+    await initUsageTracker();
+    await initBudgetEngine();
+  });
+
+  test("should return telemetry summary", async () => {
+    const summary = await getTelemetrySummary();
+
+    expect(summary).toHaveProperty("totalInvocations");
+    expect(summary).toHaveProperty("estimatedTotalCost");
+    expect(summary).toHaveProperty("activeBudgets");
+    expect(summary).toHaveProperty("blockedBudgets");
+    expect(typeof summary.totalInvocations).toBe("number");
+    expect(typeof summary.estimatedTotalCost).toBe("number");
+  });
+
+  test("should return comprehensive telemetry", async () => {
+    // Create some usage data
+    const context = {
+      sessionId: "telemetry-session",
+      channelId: "telegram:telemetry",
+      source: "telegram",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const start = await recordInvocationStart(context);
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      {
+        inputTokens: 5000,
+        outputTokens: 10000,
+      },
+      {
+        currency: "USD",
+        totalCost: 0.165,
+      }
+    );
+
+    const telemetry = await getTelemetry({});
+
+    expect(telemetry.estimatedTotalCost).toBeGreaterThan(0);
+    expect(telemetry.invocationStats.total).toBeGreaterThan(0);
+    expect(telemetry.invocationStats.completed).toBeGreaterThan(0);
+    expect(telemetry.providerStats["anthropic"]).toBeDefined();
+    expect(telemetry.modelStats["claude-3-5-sonnet"]).toBeDefined();
+  });
+
+  test("should filter telemetry by date range", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.02 }
+    );
+
+    // Future date should return empty
+    const futureFilter = await getTelemetry({
+      startDate: "2099-01-01T00:00:00Z",
+    });
+    expect(futureFilter.invocationStats.total).toBe(0);
+
+    // Past date should include data
+    const pastFilter = await getTelemetry({
+      startDate: "1970-01-01T00:00:00Z",
+    });
+    expect(pastFilter.invocationStats.total).toBeGreaterThan(0);
+  });
+
+  test("should filter telemetry by provider", async () => {
+    // Anthropic invocation
+    const anthropicStart = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+    await recordInvocationCompletion(
+      anthropicStart.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.02 }
+    );
+
+    // OpenAI invocation
+    const openaiStart = await recordInvocationStart({
+      provider: "openai",
+      model: "gpt-4o",
+    });
+    await recordInvocationCompletion(
+      openaiStart.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.03 }
+    );
+
+    const anthropicTelemetry = await getTelemetry({ provider: "anthropic" });
+    expect(anthropicTelemetry.providerStats["anthropic"]).toBeDefined();
+    expect(anthropicTelemetry.providerStats["openai"]).toBeUndefined();
+  });
+
+  test("should return provider breakdown", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 10000, outputTokens: 5000 },
+      { currency: "USD", totalCost: 0.105 }
+    );
+
+    const breakdown = await getProviderBreakdown();
+
+    expect(Array.isArray(breakdown)).toBe(true);
+    const anthropic = breakdown.find((p) => p.provider === "anthropic");
+    expect(anthropic).toBeDefined();
+    expect(anthropic!.calls).toBeGreaterThan(0);
+    expect(anthropic!.tokens).toBeGreaterThan(0);
+  });
+
+  test("should return model breakdown", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 500, outputTokens: 250 },
+      { currency: "USD", totalCost: 0.005 }
+    );
+
+    const breakdown = await getModelBreakdown();
+
+    expect(Array.isArray(breakdown)).toBe(true);
+    const haiku = breakdown.find((m) => m.model === "claude-3-haiku");
+    expect(haiku).toBeDefined();
+    expect(haiku!.calls).toBeGreaterThan(0);
+  });
+
+  test("should return channel breakdown", async () => {
+    const start = await recordInvocationStart({
+      channelId: "discord:12345",
+      source: "discord",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 2000, outputTokens: 1000 },
+      { currency: "USD", totalCost: 0.045 }
+    );
+
+    const breakdown = await getChannelBreakdown();
+
+    expect(Array.isArray(breakdown)).toBe(true);
+    const discord = breakdown.find((c) => c.channelId === "discord:12345");
+    expect(discord).toBeDefined();
+    expect(discord!.invocations).toBeGreaterThan(0);
+  });
+
+  test("should return budget health", async () => {
+    // Create a policy
+    await upsertBudgetPolicy({
+      name: "Health Test Policy",
+      scope: { channelId: "health-chan" },
+      thresholds: { warnAt: 10, degradeAt: 20, blockAt: 50 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const health = await getBudgetHealth();
+
+    expect(Array.isArray(health)).toBe(true);
+    const policy = health.find((h) => h.policyName === "Health Test Policy");
+    expect(policy).toBeDefined();
+    expect(policy!.state).toBeDefined();
+  });
+
+  test("should handle empty telemetry gracefully", async () => {
+    const telemetry = await getTelemetry({
+      startDate: "2099-01-01T00:00:00Z",
+    });
+
+    expect(telemetry.totalSessions).toBe(0);
+    expect(telemetry.invocationStats.total).toBe(0);
+    expect(telemetry.estimatedTotalCost).toBe(0);
+  });
+
+  test("should include cost breakdown in aggregates", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      {
+        inputTokens: 1000000, // 1M
+        outputTokens: 500000, // 500K
+      },
+      {
+        currency: "USD",
+        inputCost: 3.0,
+        outputCost: 7.5,
+        cacheCost: 0.5,
+        totalCost: 11.0,
+      }
+    );
+
+    const telemetry = await getTelemetry({});
+
+    expect(telemetry.estimatedTotalCost).toBeGreaterThan(0);
+    const anthropicStats = telemetry.providerStats["anthropic"];
+    expect(anthropicStats).toBeDefined();
+    expect(anthropicStats!.estimatedCost).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/governance/usage-tracker.test.ts
+++ b/src/__tests__/governance/usage-tracker.test.ts
@@ -1,0 +1,276 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  recordInvocationFailure,
+  recordInvocationKilled,
+  getInvocation,
+  getSessionUsage,
+  getChannelUsage,
+  getAggregates,
+  getUsageStats,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+import { join } from "path";
+
+// The usage tracker uses .claude/claudeclaw/usage/ - clean this for test isolation
+const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
+
+describe("UsageTracker", () => {
+  beforeEach(async () => {
+    resetUsageTracker();
+    // Clear usage data directory for test isolation
+    try {
+      const { rm, readdir } = await import("fs/promises");
+      const files = await readdir(USAGE_DIR);
+      for (const file of files) {
+        if (file !== ".gitkeep") {
+          await rm(join(USAGE_DIR, file), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // Directory might not exist yet
+    }
+  });
+
+  afterEach(async () => {
+    resetUsageTracker();
+  });
+
+  test("should initialize without error", async () => {
+    await initUsageTracker();
+    const stats = await getUsageStats();
+    expect(stats.totalRecords).toBe(0);
+  });
+
+  test("should record invocation start", async () => {
+    await initUsageTracker();
+
+    const context = {
+      sessionId: "session-123",
+      channelId: "telegram:12345",
+      source: "telegram",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const record = await recordInvocationStart(context);
+
+    expect(record.invocationId).toBeDefined();
+    expect(record.sessionId).toBe("session-123");
+    expect(record.channelId).toBe("telegram:12345");
+    expect(record.provider).toBe("anthropic");
+    expect(record.model).toBe("claude-3-5-sonnet");
+    expect(record.status).toBe("started");
+    expect(record.startedAt).toBeDefined();
+  });
+
+  test("should record invocation completion with usage", async () => {
+    await initUsageTracker();
+
+    const context = {
+      sessionId: "session-123",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+
+    const usage = {
+      inputTokens: 1000,
+      outputTokens: 2000,
+      cacheCreationInputTokens: 500,
+      cacheReadInputTokens: 300,
+    };
+
+    const estimatedCost = {
+      currency: "USD",
+      inputCost: 0.003,
+      outputCost: 0.03,
+      cacheCost: 0.002,
+      totalCost: 0.035,
+      pricingVersion: "1.0.0",
+    };
+
+    const completed = await recordInvocationCompletion(
+      startRecord.invocationId,
+      usage,
+      estimatedCost
+    );
+
+    expect(completed).not.toBeNull();
+    expect(completed!.status).toBe("completed");
+    expect(completed!.completedAt).toBeDefined();
+    expect(completed!.usage).toEqual(usage);
+    expect(completed!.estimatedCost).toEqual(estimatedCost);
+  });
+
+  test("should record invocation failure", async () => {
+    await initUsageTracker();
+
+    const context = {
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+
+    const error = { type: "rate_limit", message: "Rate limit exceeded" };
+
+    const failed = await recordInvocationFailure(startRecord.invocationId, error);
+
+    expect(failed).not.toBeNull();
+    expect(failed!.status).toBe("failed");
+    expect(failed!.error).toEqual(error);
+  });
+
+  test("should record invocation killed by watchdog", async () => {
+    await initUsageTracker();
+
+    const context = {
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+
+    const killed = await recordInvocationKilled(
+      startRecord.invocationId,
+      "maxToolCalls exceeded"
+    );
+
+    expect(killed).not.toBeNull();
+    expect(killed!.status).toBe("killed");
+    expect(killed!.error?.type).toBe("watchdog");
+    expect(killed!.error?.message).toBe("maxToolCalls exceeded");
+  });
+
+  test("should get invocation by id", async () => {
+    await initUsageTracker();
+
+    const context = {
+      provider: "openai",
+      model: "gpt-4o",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+    const retrieved = await getInvocation(startRecord.invocationId);
+
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.invocationId).toBe(startRecord.invocationId);
+  });
+
+  test("should get session usage", async () => {
+    await initUsageTracker();
+
+    const sessionId = "session-session-test";
+
+    // Create multiple invocations for the same session
+    for (let i = 0; i < 3; i++) {
+      await recordInvocationStart({
+        sessionId,
+        provider: "anthropic",
+        model: "claude-3-5-sonnet",
+      });
+    }
+
+    const usage = await getSessionUsage(sessionId);
+    expect(usage.length).toBe(3);
+  });
+
+  test("should get channel usage", async () => {
+    await initUsageTracker();
+
+    const channelId = "telegram:channel-test";
+
+    // Create invocations for the same channel
+    for (let i = 0; i < 2; i++) {
+      await recordInvocationStart({
+        channelId,
+        provider: "anthropic",
+        model: "claude-3-haiku",
+      });
+    }
+
+    const usage = await getChannelUsage(channelId);
+    expect(usage.length).toBe(2);
+  });
+
+  test("should compute aggregates correctly", async () => {
+    await initUsageTracker();
+
+    // Create invocations with usage
+    for (let i = 0; i < 3; i++) {
+      const start = await recordInvocationStart({
+        sessionId: "agg-session",
+        channelId: "telegram:agg",
+        source: "telegram",
+        provider: "anthropic",
+        model: "claude-3-5-sonnet",
+      });
+
+      await recordInvocationCompletion(
+        start.invocationId,
+        {
+          inputTokens: 1000,
+          outputTokens: 2000,
+        },
+        {
+          currency: "USD",
+          totalCost: 0.035,
+        }
+      );
+    }
+
+    const aggregates = await getAggregates({});
+
+    expect(aggregates.totalInvocations).toBe(3);
+    expect(aggregates.completedInvocations).toBe(3);
+    expect(aggregates.totalInputTokens).toBe(3000);
+    expect(aggregates.totalOutputTokens).toBe(6000);
+    expect(aggregates.totalEstimatedCost).toBeCloseTo(0.105);
+    expect(aggregates.byProvider["anthropic"]).toBeDefined();
+    expect(aggregates.byProvider["anthropic"].count).toBe(3);
+  });
+
+  test("should handle missing invocation gracefully", async () => {
+    await initUsageTracker();
+
+    const result = await getInvocation("non-existent-id");
+    expect(result).toBeNull();
+  });
+
+  test("should track failed and killed invocations separately", async () => {
+    await initUsageTracker();
+
+    // Create one of each status
+    const started = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(started.invocationId);
+
+    const failedStart = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+    await recordInvocationFailure(failedStart.invocationId, {
+      type: "error",
+      message: "Test error",
+    });
+
+    const killedStart = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+    await recordInvocationKilled(killedStart.invocationId, "Watchdog triggered");
+
+    const aggregates = await getAggregates({});
+
+    expect(aggregates.completedInvocations).toBe(1);
+    expect(aggregates.failedInvocations).toBe(1);
+    expect(aggregates.killedInvocations).toBe(1);
+  });
+});

--- a/src/__tests__/governance/watchdog.test.ts
+++ b/src/__tests__/governance/watchdog.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  initWatchdog,
+  recordExecutionMetric,
+  incrementToolCall,
+  incrementTurnCount,
+  checkLimits,
+  handleTrigger,
+  getActiveInvocation,
+  getSessionActiveInvocations,
+  clearInvocation,
+  getWatchdogStats,
+  configureWatchdog,
+  getWatchdogConfig,
+  resetWatchdog,
+} from "../../governance/watchdog";
+import { join } from "path";
+
+const WATCHDOG_DIR = join(process.cwd(), ".claude", "claudeclaw", "watchdog");
+
+describe("Watchdog", () => {
+  beforeEach(async () => {
+    resetWatchdog();
+    
+    // Clear watchdog directory for test isolation
+    try {
+      const { rm, readdir } = await import("fs/promises");
+      const files = await readdir(WATCHDOG_DIR);
+      for (const file of files) {
+        if (file !== ".gitkeep") {
+          await rm(join(WATCHDOG_DIR, file), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // Directory might not exist yet
+    }
+    
+    await initWatchdog();
+    
+    // Configure with relaxed limits for testing
+    configureWatchdog({
+      limits: {
+        maxToolCalls: 10,
+        maxTurns: 5,
+        maxRuntimeSeconds: 60,
+        maxRepeatedTools: 3,
+        repeatedToolThreshold: 2,
+      },
+      enabled: true,
+    });
+  });
+
+  test("should initialize with config", async () => {
+    const config = getWatchdogConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.limits.maxToolCalls).toBe(10);
+  });
+
+  test("should configure watchdog limits", () => {
+    configureWatchdog({
+      limits: {
+        maxToolCalls: 50,
+        maxTurns: 20,
+      },
+    });
+
+    const config = getWatchdogConfig();
+    expect(config.limits.maxToolCalls).toBe(50);
+    expect(config.limits.maxTurns).toBe(20);
+  });
+
+  test("should record execution metrics", async () => {
+    const invocationId = "test-invocation-1";
+
+    await recordExecutionMetric({
+      invocationId,
+      sessionId: "test-session",
+    }, {
+      toolCallCount: 5,
+      turnCount: 2,
+    });
+
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics).not.toBeNull();
+    expect(metrics!.toolCallCount).toBe(5);
+    expect(metrics!.turnCount).toBe(2);
+    expect(metrics!.invocationId).toBe(invocationId);
+  });
+
+  test("should increment tool call count", async () => {
+    const invocationId = "test-invocation-2";
+
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/test.txt" });
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/test.txt" });
+    await incrementToolCall(invocationId, "write_file", { path: "/tmp/output.txt" });
+
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics!.toolCallCount).toBe(3);
+    expect(metrics!.toolCalls.length).toBe(3);
+  });
+
+  test("should increment turn count", async () => {
+    const invocationId = "test-invocation-3";
+
+    await incrementTurnCount(invocationId);
+    await incrementTurnCount(invocationId);
+
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics!.turnCount).toBe(2);
+  });
+
+  test("should return healthy when under limits", async () => {
+    const invocationId = "test-invocation-healthy";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 3,
+      turnCount: 2,
+    });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("healthy");
+    expect(decision.triggeredLimits.length).toBe(0);
+  });
+
+  test("should warn at 80% of tool call limit", async () => {
+    const invocationId = "test-invocation-warn";
+
+    // 8 out of 10 = 80%
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 8,
+      turnCount: 1,
+    });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("warn");
+    expect(decision.triggeredLimits.length).toBeGreaterThan(0);
+  });
+
+  test("should trigger suspend at tool call limit", async () => {
+    const invocationId = "test-invocation-suspend";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 10, // At limit
+      turnCount: 1,
+    });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("suspend");
+    expect(decision.triggeredLimits.some(l => l.includes("maxToolCalls"))).toBe(true);
+  });
+
+  test("should detect repeated tool patterns", async () => {
+    const invocationId = "test-invocation-repeat";
+
+    // Make same tool call 3 times with same input
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/same.txt" });
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/same.txt" });
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/same.txt" });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("suspend");
+    expect(decision.triggeredLimits.some(l => l.includes("Repeated"))).toBe(true);
+  });
+
+  test("should handle trigger for warn state", async () => {
+    const invocationId = "test-invocation-warn-handle";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 8, // Warning level
+    });
+
+    const decision = await checkLimits({ invocationId });
+    const result = await handleTrigger({ invocationId }, decision);
+
+    expect(result.success).toBe(true);
+    expect(["warning_logged", "no_action"]).toContain(result.action);
+  });
+
+  test("should handle trigger for suspend state", async () => {
+    const invocationId = "test-invocation-suspend-handle";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 10, // At limit
+    });
+
+    const decision = await checkLimits({ invocationId });
+    const result = await handleTrigger({ invocationId }, decision);
+
+    expect(result.success).toBe(true);
+    expect(["suspended", "paused"]).toContain(result.action);
+  });
+
+  test("should handle trigger for kill state", async () => {
+    const invocationId = "test-invocation-kill";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 100, // Way over
+    });
+
+    const decision = await checkLimits({ invocationId });
+    decision.state = "kill"; // Force kill state for testing
+
+    const result = await handleTrigger({ invocationId }, decision);
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("terminated");
+
+    // Should be cleared from active invocations
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics).toBeNull();
+  });
+
+  test("should get session active invocations", async () => {
+    const sessionId = "test-session-watchdog";
+
+    await recordExecutionMetric({ invocationId: "inv-1", sessionId }, { toolCallCount: 1 });
+    await recordExecutionMetric({ invocationId: "inv-2", sessionId }, { toolCallCount: 2 });
+    await recordExecutionMetric({ invocationId: "inv-3", sessionId: "other" }, { toolCallCount: 3 });
+
+    const invocations = await getSessionActiveInvocations(sessionId);
+
+    expect(invocations.length).toBe(2);
+    expect(invocations.find(i => i.invocationId === "inv-1")).toBeDefined();
+    expect(invocations.find(i => i.invocationId === "inv-2")).toBeDefined();
+  });
+
+  test("should clear invocation", async () => {
+    const invocationId = "inv-to-clear";
+
+    await recordExecutionMetric({ invocationId }, { toolCallCount: 5 });
+
+    let metrics = await getActiveInvocation(invocationId);
+    expect(metrics).not.toBeNull();
+
+    await clearInvocation(invocationId);
+
+    metrics = await getActiveInvocation(invocationId);
+    expect(metrics).toBeNull();
+  });
+
+  test("should get watchdog stats", async () => {
+    await recordExecutionMetric({ invocationId: "stats-inv-1" }, { toolCallCount: 5 });
+    await recordExecutionMetric({ invocationId: "stats-inv-2" }, { toolCallCount: 3 });
+
+    // Trigger a watchdog decision to log an event
+    await checkLimits({ invocationId: "stats-inv-1" });
+
+    const stats = await getWatchdogStats();
+
+    expect(stats.activeInvocations).toBe(2);
+    expect(stats.config.enabled).toBe(true);
+    expect(stats.eventsLogged).toBeGreaterThan(0);
+  });
+
+  test("should return healthy for unknown invocation", async () => {
+    const decision = await checkLimits({ invocationId: "unknown-invocation" });
+
+    expect(decision.state).toBe("healthy");
+    expect(decision.reason).toContain("No execution metrics");
+  });
+});

--- a/src/__tests__/policy/approval-queue.test.ts
+++ b/src/__tests__/policy/approval-queue.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for policy/approval-queue.ts
+ * 
+ * Run with: bun test src/__tests__/policy/approval-queue.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  enqueue,
+  approve,
+  deny,
+  listPending,
+  loadState,
+  findByEventId,
+  findById,
+  isPending,
+  getLoadedAt,
+} from "../../policy/approval-queue";
+import { loadRules, type ToolRequestContext, type PolicyDecision } from "../../policy/engine";
+
+const APPROVAL_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const APPROVAL_QUEUE_FILE = join(APPROVAL_DIR, "approval-queue.jsonl");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-" + Math.random().toString(36).slice(2),
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+// Helper to create a test decision
+const createDecision = (overrides: Partial<PolicyDecision> = {}): PolicyDecision => ({
+  requestId: "req-" + Math.random().toString(36).slice(2),
+  action: "require_approval",
+  reason: "Test approval required",
+  evaluatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("Approval Queue - Enqueue", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should enqueue a request for approval", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(entry).toBeDefined();
+    expect(entry.id).toBeDefined();
+    expect(entry.eventId).toBe(request.eventId);
+    expect(entry.status).toBe("pending");
+    expect(entry.request).toEqual(request);
+    expect(entry.decision).toEqual(decision);
+    expect(entry.requestedAt).toBeDefined();
+  });
+
+  it("should persist entry to queue file", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(existsSync(APPROVAL_QUEUE_FILE)).toBe(true);
+    
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    const found = lines.some(line => {
+      const parsed = JSON.parse(line);
+      return parsed.id === entry.id;
+    });
+    expect(found).toBe(true);
+  });
+
+  it("should generate unique IDs for each entry", async () => {
+    const request1 = createRequest();
+    const request2 = createRequest();
+    const decision = createDecision();
+    
+    const entry1 = await enqueue(request1, decision);
+    const entry2 = await enqueue(request2, decision);
+    
+    expect(entry1.id).not.toBe(entry2.id);
+  });
+
+  it("should set default expiry time", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(entry.expiresAt).toBeDefined();
+    
+    const expiryDate = new Date(entry.expiresAt!);
+    const now = new Date();
+    const diffHours = (expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60);
+    
+    expect(diffHours).toBeGreaterThan(23);
+    expect(diffHours).toBeLessThan(25);
+  });
+});
+
+describe("Approval Queue - Approve", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should approve a pending request", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    const result = await approve(request.eventId, "operator-1", "Looks good");
+    
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("approved");
+    expect(result?.approvedBy).toBe("operator-1");
+    expect(result?.approvedAt).toBeDefined();
+    expect(result?.resolutionReason).toBe("Looks good");
+  });
+
+  it("should persist approval to queue file", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    await approve(request.eventId, "operator-1");
+    
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Find the approval entry
+    const approvalLine = lines.find(line => {
+      const parsed = JSON.parse(line);
+      return parsed.eventId === request.eventId && parsed.status === "approved";
+    });
+    
+    expect(approvalLine).toBeDefined();
+  });
+
+  it("should be idempotent for already approved requests", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    const first = await approve(request.eventId, "operator-1", "First approval");
+    const second = await approve(request.eventId, "operator-2", "Second approval");
+    
+    expect(first?.approvedBy).toBe("operator-1");
+    expect(second?.approvedBy).toBe("operator-1"); // Should remain first approver
+    expect(second?.resolutionReason).toBe("First approval");
+  });
+
+  it("should return null for non-existent event", async () => {
+    const result = await approve("non-existent-event", "operator-1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("Approval Queue - Deny", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should deny a pending request", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    const result = await deny(request.eventId, "operator-1", "Not allowed");
+    
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("denied");
+    expect(result?.deniedBy).toBe("operator-1");
+    expect(result?.deniedAt).toBeDefined();
+    expect(result?.resolutionReason).toBe("Not allowed");
+  });
+
+  it("should be idempotent for already denied requests", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    const first = await deny(request.eventId, "operator-1", "First denial");
+    const second = await deny(request.eventId, "operator-2", "Second denial");
+    
+    expect(first?.deniedBy).toBe("operator-1");
+    expect(second?.deniedBy).toBe("operator-1"); // Should remain first denier
+  });
+});
+
+describe("Approval Queue - List Pending", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should list only pending requests", async () => {
+    const request1 = createRequest();
+    const request2 = createRequest();
+    const request3 = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request1, decision);
+    await enqueue(request2, decision);
+    await enqueue(request3, decision);
+    
+    await approve(request1.eventId, "operator-1");
+    
+    const pending = listPending();
+    
+    expect(pending).toHaveLength(2);
+    expect(pending.every(e => e.status === "pending")).toBe(true);
+  });
+
+  it("should sort pending by oldest first", async () => {
+    const decision = createDecision();
+    
+    const entry1 = await enqueue(createRequest({ eventId: "event-1" }), decision);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const entry2 = await enqueue(createRequest({ eventId: "event-2" }), decision);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const entry3 = await enqueue(createRequest({ eventId: "event-3" }), decision);
+    
+    const pending = listPending();
+    
+    expect(pending[0].eventId).toBe("event-1");
+    expect(pending[1].eventId).toBe("event-2");
+    expect(pending[2].eventId).toBe("event-3");
+  });
+});
+
+describe("Approval Queue - Persistence", () => {
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should recover state after restart", async () => {
+    const decision = createDecision();
+    
+    // Create some entries
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+    
+    const entry1 = await enqueue(createRequest({ eventId: "restart-event-1" }), decision);
+    const entry2 = await enqueue(createRequest({ eventId: "restart-event-2" }), decision);
+    
+    await approve(entry1.eventId, "operator-1");
+    
+    // Simulate restart - reload state from disk
+    await loadState();
+    
+    // Should recover state
+    const pending = listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].eventId).toBe("restart-event-2");
+    
+    const recoveredEntry2 = await findById(entry2.id);
+    expect(recoveredEntry2).toBeDefined();
+    expect(recoveredEntry2?.status).toBe("pending");
+  });
+
+  it("should find entry by eventId", async () => {
+    const decision = createDecision();
+    
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+    
+    const entry = await enqueue(createRequest({ eventId: "find-me-event" }), decision);
+    
+    const found = await findByEventId("find-me-event");
+    expect(found).toBeDefined();
+    expect(found?.id).toBe(entry.id);
+  });
+});

--- a/src/__tests__/policy/audit-log.test.ts
+++ b/src/__tests__/policy/audit-log.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for policy/audit-log.ts
+ * 
+ * Run with: bun test src/__tests__/policy/audit-log.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  log,
+  logPolicyDecision,
+  logApproval,
+  logDenial,
+  query,
+  exportEntries,
+  getStats,
+  cleanupRetention,
+  getRetentionPolicy,
+  type AuditEntry,
+  type AuditAction,
+} from "../../policy/audit-log";
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
+
+describe("Audit Log - Basic Operations", () => {
+  beforeEach(async () => {
+    // Clean audit log before test to ensure isolation
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should log an audit entry", async () => {
+    const entry: AuditEntry = {
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      channelId: "telegram:123",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Tool denied by policy",
+      matchedRuleId: "global-deny-bash",
+    };
+    
+    await log(entry);
+    
+    expect(existsSync(AUDIT_LOG_FILE)).toBe(true);
+    
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    expect(lines).toHaveLength(1);
+    
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.eventId).toBe("event-1");
+    expect(parsed.action).toBe("deny");
+  });
+
+  it("should append multiple entries", async () => {
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Denied",
+    });
+    
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-2",
+      requestId: "req-2",
+      source: "discord",
+      toolName: "View",
+      action: "allow",
+      reason: "Allowed",
+    });
+    
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe("Audit Log - Policy Decision Logging", () => {
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should log a policy decision", async () => {
+    await logPolicyDecision(
+      "event-1",
+      "req-1",
+      "telegram",
+      "Bash",
+      "deny",
+      "Global policy denies Bash",
+      { matchedRuleId: "global-deny-bash" }
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("deny");
+    expect(entries[0].matchedRuleId).toBe("global-deny-bash");
+  });
+
+  it("should log an approval action", async () => {
+    await logApproval(
+      "event-1",
+      "req-1",
+      "telegram",
+      "Edit",
+      "operator-1",
+      "Looks good"
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("approved");
+    expect(entries[0].operatorId).toBe("operator-1");
+    expect(entries[0].reason).toBe("Looks good");
+  });
+
+  it("should log a denial action", async () => {
+    await logDenial(
+      "event-1",
+      "req-1",
+      "discord",
+      "Bash",
+      "operator-2",
+      "Not allowed"
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("denied");
+    expect(entries[0].operatorId).toBe("operator-2");
+  });
+});
+
+describe("Audit Log - Querying", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    
+    // Create some test entries
+    await logPolicyDecision("event-1", "req-1", "telegram", "Bash", "deny", "Denied");
+    await logPolicyDecision("event-2", "req-2", "telegram", "View", "allow", "Allowed");
+    await logPolicyDecision("event-3", "req-3", "discord", "Edit", "require_approval", "Needs approval");
+    await logApproval("event-4", "req-4", "telegram", "Edit", "operator-1", "Approved");
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return all entries with no filters", async () => {
+    const entries = await query({});
+    expect(entries).toHaveLength(4);
+  });
+
+  it("should filter by source", async () => {
+    const entries = await query({ source: "telegram" });
+    expect(entries).toHaveLength(3);
+    expect(entries.every(e => e.source === "telegram")).toBe(true);
+  });
+
+  it("should filter by action", async () => {
+    const entries = await query({ action: "deny" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("deny");
+  });
+
+  it("should filter by toolName", async () => {
+    const entries = await query({ toolName: "Edit" });
+    expect(entries).toHaveLength(2); // require_approval and approved
+  });
+
+  it("should filter by operatorId", async () => {
+    const entries = await query({ operatorId: "operator-1" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].operatorId).toBe("operator-1");
+  });
+
+  it("should filter by eventId", async () => {
+    const entries = await query({ eventId: "event-2" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].eventId).toBe("event-2");
+  });
+
+  it("should sort by timestamp descending (newest first)", async () => {
+    // Add another entry with a newer timestamp
+    await log({
+      timestamp: new Date(Date.now() + 10000).toISOString(), // 10 seconds in future
+      eventId: "event-5",
+      requestId: "req-5",
+      source: "slack",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Latest",
+    });
+    
+    const entries = await query({});
+    expect(entries[0].eventId).toBe("event-5");
+  });
+});
+
+describe("Audit Log - Export", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should export entries within date range", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Test",
+    });
+    
+    const entries = await exportEntries(yesterday, tomorrow);
+    expect(entries).toHaveLength(1);
+  });
+});
+
+describe("Audit Log - Statistics", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return correct statistics", async () => {
+    await logPolicyDecision("event-1", "req-1", "telegram", "Bash", "deny", "Deny");
+    await logPolicyDecision("event-2", "req-2", "telegram", "View", "allow", "Allow");
+    await logPolicyDecision("event-3", "req-3", "discord", "Edit", "require_approval", "Approve");
+    
+    const stats = await getStats();
+    
+    expect(stats.totalEntries).toBe(3);
+    expect(stats.byAction.deny).toBe(1);
+    expect(stats.byAction.allow).toBe(1);
+    expect(stats.byAction.require_approval).toBe(1);
+    expect(stats.bySource.telegram).toBe(2);
+    expect(stats.bySource.discord).toBe(1);
+  });
+
+  it("should return empty stats for no entries", async () => {
+    const stats = await getStats();
+    
+    expect(stats.totalEntries).toBe(0);
+    expect(stats.oldestTimestamp).toBeNull();
+    expect(stats.newestTimestamp).toBeNull();
+  });
+});
+
+describe("Audit Log - Retention", () => {
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should report retention policy", () => {
+    const policy = getRetentionPolicy();
+    
+    expect(policy.defaultRetentionDays).toBe(30);
+    expect(policy.defaultMaxFileSizeBytes).toBe(10 * 1024 * 1024);
+    expect(policy.recommendation).toContain("30 days");
+  });
+
+  it("should identify entries older than retention period", async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    
+    // Create an old entry
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 60); // 60 days ago
+    await log({
+      timestamp: oldDate.toISOString(),
+      eventId: "old-event",
+      requestId: "old-req",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Old entry",
+    });
+    
+    // Create a recent entry
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "new-event",
+      requestId: "new-req",
+      source: "telegram",
+      toolName: "View",
+      action: "allow",
+      reason: "New entry",
+    });
+    
+    const result = await cleanupRetention({ maxAgeDays: 30 });
+    
+    expect(result.deleted).toBe(1);
+    expect(result.remaining).toBe(1);
+  });
+});

--- a/src/__tests__/policy/channel-policies.test.ts
+++ b/src/__tests__/policy/channel-policies.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for policy/channel-policies.ts
+ * 
+ * Run with: bun test src/__tests__/policy/channel-policies.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { writeFile, rm, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  getScopedRules,
+  mergeScopedPolicies,
+  validateScopedPolicyConfig,
+  createDefaultScopedPolicyConfig,
+  getExampleScopedPolicyConfig,
+  reloadScopedPolicy,
+  type ScopedPolicyConfig,
+} from "../../policy/channel-policies";
+import { loadRules, type ToolRequestContext, type PolicyRule } from "../../policy/engine";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SCOPED_POLICY_FILE = join(POLICY_DIR, "scoped-policies.json");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-1",
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+describe("Channel Policies - Scoped Rules", () => {
+  beforeEach(async () => {
+    // Clear any cached config
+    reloadScopedPolicy();
+    
+    // Ensure directory exists
+    await mkdir(POLICY_DIR, { recursive: true });
+    
+    // Clean up
+    try {
+      await rm(SCOPED_POLICY_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+    
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(SCOPED_POLICY_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return empty array when no scoped policy file exists", () => {
+    const request = createRequest();
+    const rules = getScopedRules(request);
+    expect(Array.isArray(rules)).toBe(true);
+  });
+
+  it("should resolve channel-specific deny rules", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "telegram:123": {
+              channelId: "telegram:123",
+              denyRules: [
+                {
+                  id: "channel-deny-bash",
+                  priority: 200,
+                  tool: "Bash",
+                  action: "deny",
+                  reason: "Bash denied in this channel",
+                },
+              ],
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const request = createRequest({ toolName: "Bash" });
+    const rules = getScopedRules(request);
+    
+    // Should have the channel deny rule
+    const denyRule = rules.find(r => r.id === "channel-deny-bash");
+    expect(denyRule).toBeDefined();
+    expect(denyRule?.action).toBe("deny");
+  });
+
+  it("should resolve user-specific overrides", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "telegram:123": {
+              channelId: "telegram:123",
+              userOverrides: {
+                "admin-user": {
+                  userId: "admin-user",
+                  allowRules: [
+                    {
+                      id: "admin-allow-all",
+                      priority: 200,
+                      tool: "*",
+                      action: "allow",
+                      reason: "Admin has full access",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const request = createRequest({ userId: "admin-user", toolName: "Bash" });
+    const rules = getScopedRules(request);
+    
+    const adminRule = rules.find(r => r.id === "admin-allow-all");
+    expect(adminRule).toBeDefined();
+    expect(adminRule?.action).toBe("allow");
+  });
+
+  it("should handle discord and telegram as different contexts", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          defaultRules: [
+            {
+              id: "telegram-deny-bash",
+              priority: 100,
+              tool: "Bash",
+              action: "deny",
+            },
+          ],
+        },
+        discord: {
+          source: "discord",
+          defaultRules: [
+            {
+              id: "discord-allow-bash",
+              priority: 100,
+              tool: "Bash",
+              action: "allow",
+            },
+          ],
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const telegramRequest = createRequest({ source: "telegram", toolName: "Bash" });
+    const telegramRules = getScopedRules(telegramRequest);
+    const telegramDeny = telegramRules.find(r => r.id === "telegram-deny-bash");
+    expect(telegramDeny?.action).toBe("deny");
+    
+    const discordRequest = createRequest({ source: "discord", toolName: "Bash" });
+    const discordRules = getScopedRules(discordRequest);
+    const discordAllow = discordRules.find(r => r.id === "discord-allow-bash");
+    expect(discordAllow?.action).toBe("allow");
+  });
+});
+
+describe("Channel Policies - Merge Scoped Policies", () => {
+  it("should merge global and scoped rules without duplicates", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "global-allow", tool: "View", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "scoped-deny", tool: "Edit", action: "deny" },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged).toHaveLength(2);
+    expect(merged.find(r => r.id === "global-allow")).toBeDefined();
+    expect(merged.find(r => r.id === "scoped-deny")).toBeDefined();
+  });
+
+  it("should prefer scoped rules over global rules with same ID", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "same-id", tool: "View", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "same-id", tool: "View", action: "deny" },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged).toHaveLength(1);
+    expect(merged[0].action).toBe("deny");
+  });
+
+  it("should filter out disabled rules", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "disabled-global", tool: "View", action: "allow", enabled: false },
+      { id: "enabled-global", tool: "Edit", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "disabled-scoped", tool: "Bash", action: "deny", enabled: false },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged.find(r => r.id === "disabled-global")).toBeUndefined();
+    expect(merged.find(r => r.id === "enabled-global")).toBeDefined();
+    expect(merged.find(r => r.id === "disabled-scoped")).toBeUndefined();
+  });
+});
+
+describe("Channel Policies - Validation", () => {
+  it("should validate a correct scoped policy config", () => {
+    const config = getExampleScopedPolicyConfig();
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should detect missing version", () => {
+    const config = {
+      sources: {},
+      globalRules: [],
+    } as any;
+    
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes("version"))).toBe(true);
+  });
+
+  it("should detect mismatched channel IDs", () => {
+    const config: ScopedPolicyConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "channel-1": {
+              channelId: "different-id", // Mismatch!
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes("mismatch"))).toBe(true);
+  });
+});
+
+describe("Channel Policies - Default Config", () => {
+  it("should create a valid default config", () => {
+    const config = createDefaultScopedPolicyConfig();
+    expect(config.version).toBe(1);
+    expect(config.sources).toEqual({});
+    expect(config.globalRules).toEqual([]);
+  });
+
+  it("should have proper structure in example config", () => {
+    const config = getExampleScopedPolicyConfig();
+    
+    // Should have telegram and discord sources
+    expect(config.sources["telegram"]).toBeDefined();
+    expect(config.sources["discord"]).toBeDefined();
+    
+    // Telegram should have channel config
+    expect(config.sources["telegram"].channels?.["telegram:123"]).toBeDefined();
+    
+    // Should have global deny rule
+    const globalDeny = config.globalRules.find(r => r.id === "global-deny-dangerous");
+    expect(globalDeny).toBeDefined();
+    expect(globalDeny?.action).toBe("deny");
+  });
+});

--- a/src/__tests__/policy/engine.test.ts
+++ b/src/__tests__/policy/engine.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Tests for policy/engine.ts
+ * 
+ * Run with: bun test src/__tests__/policy/engine.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  evaluate,
+  loadRules,
+  validateRules,
+  getRules,
+  clearCache,
+  isCacheEnabled,
+  type ToolRequestContext,
+  type PolicyRule,
+} from "../../policy/engine";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const POLICY_FILE = join(POLICY_DIR, "policies.json");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-1",
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+// Helper to write a policy file
+async function writePolicyFile(rules: PolicyRule[], cache?: { enabled: boolean; maxEntries: number; ttlMs: number }): Promise<void> {
+  const policy = {
+    version: 1,
+    rules,
+    cache: cache || { enabled: false, maxEntries: 1000, ttlMs: 60000 },
+    updatedAt: new Date().toISOString(),
+  };
+  await mkdir(POLICY_DIR, { recursive: true });
+  await writeFile(POLICY_FILE, JSON.stringify(policy, null, 2), "utf8");
+}
+
+describe("Policy Engine - Core Evaluation", () => {
+  beforeEach(async () => {
+    clearCache();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    clearCache();
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should deny request when no rules match", async () => {
+    await writePolicyFile([]);
+    
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBeUndefined();
+    expect(decision.reason).toContain("No matching policy rule");
+  });
+
+  it("should allow request when explicit allow rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-telegram",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "*",
+        action: "allow",
+        reason: "Allow all tools on telegram",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("allow");
+    expect(decision.matchedRuleId).toBe("allow-telegram");
+  });
+
+  it("should deny request when explicit deny rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-telegram",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "*",
+        action: "allow",
+      },
+      {
+        id: "deny-bash",
+        priority: 200,
+        tool: "Bash",
+        action: "deny",
+        reason: "Deny bash tool",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("deny-bash");
+  });
+
+  it("should require_approval when require_approval rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "approval-edit",
+        priority: 100,
+        tool: "Edit",
+        action: "require_approval",
+        reason: "Edit requires approval",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Edit" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("require_approval");
+    expect(decision.matchedRuleId).toBe("approval-edit");
+  });
+
+  it("should evaluate rules by highest priority first", async () => {
+    await writePolicyFile([
+      {
+        id: "low-priority-allow",
+        priority: 50,
+        tool: "Bash",
+        action: "allow",
+      },
+      {
+        id: "high-priority-deny",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("high-priority-deny");
+  });
+
+  it("should use specificity as tiebreaker when priorities equal", async () => {
+    await writePolicyFile([
+      {
+        id: "global-allow",
+        priority: 100,
+        tool: "Bash",
+        action: "allow",
+        reason: "Global allow",
+      },
+      {
+        id: "telegram-deny",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "Bash",
+        action: "deny",
+        reason: "Telegram specific deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    // More specific rule (telegram-deny) should win
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("telegram-deny");
+  });
+
+  it("should deny when no allow rule matches but deny rule exists", async () => {
+    await writePolicyFile([
+      {
+        id: "deny-bash",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Bash" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+
+  it("should match wildcard tool", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "AnyTool" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("allow");
+  });
+
+  it("should match tool array", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-view-edit",
+        priority: 100,
+        tool: ["View", "Edit", "GrepTool"],
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const viewRequest = createRequest({ toolName: "View" });
+    expect(evaluate(viewRequest).action).toBe("allow");
+    
+    const editRequest = createRequest({ toolName: "Edit" });
+    expect(evaluate(editRequest).action).toBe("allow");
+    
+    const bashRequest = createRequest({ toolName: "Bash" });
+    expect(evaluate(bashRequest).action).toBe("deny");
+  });
+
+  it("should match source array", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-multiple-sources",
+        priority: 100,
+        scope: { source: ["telegram", "discord"] },
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const telegramRequest = createRequest({ source: "telegram" });
+    expect(evaluate(telegramRequest).action).toBe("allow");
+    
+    const discordRequest = createRequest({ source: "discord" });
+    expect(evaluate(discordRequest).action).toBe("allow");
+    
+    const slackRequest = createRequest({ source: "slack" });
+    expect(evaluate(slackRequest).action).toBe("deny");
+  });
+
+  it("should skip disabled rules", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-disabled",
+        priority: 100,
+        enabled: false,
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+
+  it("should handle userId scope correctly", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-admin",
+        priority: 100,
+        scope: { userId: "admin-user" },
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const adminRequest = createRequest({ userId: "admin-user" });
+    expect(evaluate(adminRequest).action).toBe("allow");
+    
+    const regularRequest = createRequest({ userId: "regular-user" });
+    expect(evaluate(regularRequest).action).toBe("deny");
+  });
+
+  it("should handle skillName scope correctly", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-code-review",
+        priority: 100,
+        scope: { skillName: "code-review" },
+        tool: ["View", "GlobTool", "GrepTool"],
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const codeReviewRequest = createRequest({ 
+      skillName: "code-review",
+      toolName: "View",
+    });
+    expect(evaluate(codeReviewRequest).action).toBe("allow");
+    
+    const otherSkillRequest = createRequest({ 
+      skillName: "other-skill",
+      toolName: "View",
+    });
+    expect(evaluate(otherSkillRequest).action).toBe("deny");
+  });
+});
+
+describe("Policy Engine - Time Window Conditions", () => {
+  afterEach(async () => {
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should deny request outside time window", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    const lastWeek = new Date(Date.now() - 7 * 86400000).toISOString();
+    const nextWeek = new Date(Date.now() + 7 * 86400000).toISOString();
+    
+    await writePolicyFile([
+      {
+        id: "allow-business-hours",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+        conditions: {
+          timeWindow: { start: lastWeek, end: yesterday }, // Past window
+        },
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+});
+
+describe("Policy Engine - Validation", () => {
+  it("should return valid for correct rules", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "valid-rule",
+        tool: "Bash",
+        action: "allow",
+        reason: "Valid rule",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should reject rule without id", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "",
+        tool: "Bash",
+        action: "allow",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "id")).toBe(true);
+  });
+
+  it("should reject rule without tool", () => {
+    // Cast to PolicyRule[] to test validation catches missing tool
+    const rules = [
+      {
+        id: "no-tool",
+        action: "allow",
+      },
+    ] as unknown as PolicyRule[];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "tool")).toBe(true);
+  });
+
+  it("should reject rule with invalid action", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "invalid-action",
+        tool: "Bash",
+        action: "invalid" as any,
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "action")).toBe(true);
+  });
+
+  it("should warn about unscoped allow rules", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "unscoped-allow",
+        tool: "*",
+        action: "allow",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.warnings.some(w => w.field === "scope")).toBe(true);
+  });
+
+  it("should detect duplicate rule IDs", () => {
+    const rules: PolicyRule[] = [
+      { id: "duplicate", tool: "Bash", action: "allow" },
+      { id: "duplicate", tool: "Edit", action: "deny" },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes("Duplicate"))).toBe(true);
+  });
+
+  it("should warn on invalid time window dates", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "bad-timewindow",
+        tool: "Bash",
+        action: "allow",
+        conditions: {
+          timeWindow: { start: "not-a-date", end: "also-not-a-date" },
+        },
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Policy Engine - Cache", () => {
+  afterEach(async () => {
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should cache decisions when cache enabled", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    expect(isCacheEnabled()).toBe(true);
+    
+    const request = createRequest();
+    const decision1 = evaluate(request);
+    expect(decision1.action).toBe("allow");
+    
+    // Second evaluation should use cache
+    const decision2 = evaluate(request);
+    expect(decision2.action).toBe("allow");
+  });
+
+  it("should clear cache on reload", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const request = createRequest();
+    evaluate(request);
+    
+    // Change policy
+    await writePolicyFile([
+      {
+        id: "deny-all",
+        priority: 100,
+        tool: "*",
+        action: "deny",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const decision = evaluate(request);
+    
+    // Should reflect new policy, not cached
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("deny-all");
+  });
+
+  it("should not cache require_approval decisions", async () => {
+    await writePolicyFile([
+      {
+        id: "approval-edit",
+        priority: 100,
+        tool: "Edit",
+        action: "require_approval",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Edit" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("require_approval");
+    expect(decision.cacheable).toBe(false);
+  });
+});

--- a/src/__tests__/policy/skill-overlays.test.ts
+++ b/src/__tests__/policy/skill-overlays.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for policy/skill-overlays.ts
+ * 
+ * Run with: bun test src/__tests__/policy/skill-overlays.test.ts
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  parseSkillMetadata,
+  getSkillOverlayFromContent,
+  overlayToRules,
+  evaluateSkillPolicy,
+  validateRequiredTools,
+  getExampleSkillOverlays,
+  type SkillOverlay,
+} from "../../policy/skill-overlays";
+
+describe("Skill Overlays - Metadata Parsing", () => {
+  it("should parse requiredTools from SKILL.md frontmatter", () => {
+    const content = `---
+requiredTools:
+  - View
+  - GlobTool
+  - GrepTool
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.requiredTools).toEqual(["View", "GlobTool", "GrepTool"]);
+  });
+
+  it("should parse preferredTools from SKILL.md frontmatter", () => {
+    const content = `---
+preferredTools:
+  - View
+  - Bash
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.preferredTools).toEqual(["View", "Bash"]);
+  });
+
+  it("should parse deniedTools from SKILL.md frontmatter", () => {
+    const content = `---
+deniedTools:
+  - Bash
+  - Edit
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.deniedTools).toEqual(["Bash", "Edit"]);
+  });
+
+  it("should parse all policy fields together", () => {
+    const content = `---
+requiredTools:
+  - View
+preferredTools:
+  - View
+  - GrepTool
+deniedTools:
+  - Bash
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "code-review");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.skillName).toBe("code-review");
+    expect(overlay?.requiredTools).toEqual(["View"]);
+    expect(overlay?.preferredTools).toEqual(["View", "GrepTool"]);
+    expect(overlay?.deniedTools).toEqual(["Bash"]);
+  });
+
+  it("should return null when no policy fields present", () => {
+    const content = `---
+description: A test skill
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).toBeNull();
+  });
+
+  it("should return null for content without frontmatter", () => {
+    const content = `# Skill Content
+This is just regular markdown content.
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).toBeNull();
+  });
+
+  it("should handle empty tool lists", () => {
+    const content = `---
+requiredTools: []
+preferredTools: []
+deniedTools: []
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.requiredTools).toEqual([]);
+    expect(overlay?.preferredTools).toEqual([]);
+    expect(overlay?.deniedTools).toEqual([]);
+  });
+});
+
+describe("Skill Overlays - Overlay to Rules Conversion", () => {
+  it("should convert denied tools to deny rules", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const rules = overlayToRules(overlay);
+    
+    expect(rules).toHaveLength(2);
+    
+    const bashRule = rules.find(r => r.tool === "Bash");
+    expect(bashRule).toBeDefined();
+    expect(bashRule?.action).toBe("deny");
+    expect(bashRule?.scope?.skillName).toBe("code-review");
+    expect(bashRule?.id).toContain("code-review");
+    
+    const editRule = rules.find(r => r.tool === "Edit");
+    expect(editRule).toBeDefined();
+    expect(editRule?.action).toBe("deny");
+  });
+
+  it("should not create rules for empty deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "read-only",
+      deniedTools: [],
+    };
+    
+    const rules = overlayToRules(overlay);
+    expect(rules).toHaveLength(0);
+  });
+
+  it("should use custom base priority when provided", () => {
+    const overlay: SkillOverlay = {
+      skillName: "test",
+      deniedTools: ["Bash"],
+    };
+    
+    const rules = overlayToRules(overlay, 200);
+    expect(rules[0].priority).toBe(250); // base + 50
+  });
+
+  it("should not create rules for preferredTools or requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "test",
+      requiredTools: ["View"],
+      preferredTools: ["View", "GrepTool"],
+    };
+    
+    const rules = overlayToRules(overlay);
+    expect(rules).toHaveLength(0);
+  });
+});
+
+describe("Skill Overlays - Policy Evaluation", () => {
+  it("should deny when tool is in deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "Bash");
+    
+    expect(result.allowed).toBe(false);
+    expect(result.deniedTools).toContain("Bash");
+    expect(result.skillOverlay).toBe(overlay);
+  });
+
+  it("should allow when tool is not in deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "View");
+    
+    expect(result.allowed).toBe(true);
+    expect(result.deniedTools).toBeUndefined();
+  });
+
+  it("should handle empty deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "open-skill",
+      deniedTools: [],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "Bash");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("should handle overlay with no deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "View");
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("Skill Overlays - Required Tools Validation", () => {
+  it("should validate all required tools are available", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+    };
+    
+    const availableTools = ["View", "GlobTool", "GrepTool", "Bash"];
+    const result = validateRequiredTools(overlay, availableTools);
+    
+    expect(result.valid).toBe(true);
+    expect(result.missingTools).toHaveLength(0);
+  });
+
+  it("should detect missing required tools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+    };
+    
+    const availableTools = ["View", "Bash"];
+    const result = validateRequiredTools(overlay, availableTools);
+    
+    expect(result.valid).toBe(false);
+    expect(result.missingTools).toContain("GlobTool");
+    expect(result.missingTools).toContain("GrepTool");
+  });
+
+  it("should handle empty requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+      requiredTools: [],
+    };
+    
+    const result = validateRequiredTools(overlay, []);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should handle undefined requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+    };
+    
+    const result = validateRequiredTools(overlay, []);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("Skill Overlays - Example Configurations", () => {
+  it("should provide valid example overlays", () => {
+    const examples = getExampleSkillOverlays();
+    
+    // Code review should be read-only
+    const codeReview = examples["code-review"];
+    expect(codeReview.deniedTools).toContain("Bash");
+    expect(codeReview.deniedTools).toContain("Edit");
+    expect(codeReview.deniedTools).toContain("Write");
+    expect(codeReview.requiredTools).toContain("View");
+    
+    // Admin should have full access
+    const admin = examples["admin"];
+    expect(admin.deniedTools).toHaveLength(0);
+    expect(admin.requiredTools).toContain("Bash");
+    
+    // Web scrape needs network
+    const webScrape = examples["web-scrape"];
+    expect(webScrape.requiredTools).toContain("WebFetch");
+    expect(webScrape.requiredTools).toContain("Bash");
+  });
+});

--- a/src/__tests__/policy/wiring.test.ts
+++ b/src/__tests__/policy/wiring.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { evaluate } from "../../../src/policy/engine";
+import { enqueue, loadState, listPending, findByEventId } from "../../../src/policy/approval-queue";
+import { initGovernanceClient, getGovernanceClient, type GovernanceClient } from "../../../src/governance/client";
+
+describe("Policy Wiring Integration", () => {
+  beforeEach(async () => {
+    // Reset and reinitialize
+    await loadState();
+    initGovernanceClient({ policyEnabled: true, approvalEnabled: true });
+  });
+
+  describe("GovernanceClient", () => {
+    it("should evaluate tool requests through policy engine", () => {
+      const gc = getGovernanceClient();
+      const request = {
+        eventId: "test-event-1",
+        source: "telegram",
+        channelId: "telegram:123",
+        userId: "user1",
+        toolName: "Read",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = gc.evaluateToolRequest(request);
+      expect(decision).toBeDefined();
+      expect(decision.action).toMatch(/^(allow|deny|require_approval)$/);
+    });
+
+    it("should detect allow decisions", () => {
+      const gc = getGovernanceClient();
+      const request = {
+        eventId: "test-event-2",
+        source: "telegram",
+        channelId: "telegram:123",
+        toolName: "Read",
+        timestamp: new Date().toISOString(),
+      };
+
+      const allowed = gc.isToolAllowed(request);
+      expect(typeof allowed).toBe("boolean");
+    });
+
+    it("should detect require_approval decisions", () => {
+      const gc = getGovernanceClient();
+      const request = {
+        eventId: "test-event-3",
+        source: "discord",
+        channelId: "discord:456",
+        toolName: "Edit",
+        timestamp: new Date().toISOString(),
+      };
+
+      const requiresApproval = gc.requiresApproval(request);
+      expect(typeof requiresApproval).toBe("boolean");
+    });
+  });
+
+  describe("Policy Engine evaluate()", () => {
+    it("should return deny when no rules match (default deny)", () => {
+      const request = {
+        eventId: "test-event-deny",
+        source: "unknown",
+        toolName: "SomeTool",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = evaluate(request);
+      expect(decision.action).toBe("deny");
+      expect(decision.reason).toContain("No matching policy rule");
+    });
+
+    it("should include requestId and evaluatedAt in decision", () => {
+      const request = {
+        eventId: "test-event-meta",
+        source: "telegram",
+        toolName: "View",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = evaluate(request);
+      expect(decision.requestId).toBeDefined();
+      expect(decision.evaluatedAt).toBeDefined();
+    });
+  });
+
+  describe("Approval Queue enqueue()", () => {
+    it("should enqueue require_approval requests", async () => {
+      const request = {
+        eventId: "test-approval-event",
+        source: "telegram",
+        toolName: "Edit",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = {
+        requestId: "test-req-id",
+        action: "require_approval" as const,
+        reason: "Edit requires approval",
+        evaluatedAt: new Date().toISOString(),
+      };
+
+      const entry = await enqueue(request, decision);
+      expect(entry).toBeDefined();
+      expect(entry.id).toBeDefined();
+      expect(entry.status).toBe("pending");
+      expect(entry.eventId).toBe("test-approval-event");
+    });
+
+    it("should find enqueued approval by eventId", async () => {
+      const eventId = "test-find-event-" + Date.now();
+      const request = {
+        eventId,
+        source: "discord",
+        toolName: "Bash",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = {
+        requestId: "test-req-id-2",
+        action: "require_approval" as const,
+        reason: "Bash requires approval",
+        evaluatedAt: new Date().toISOString(),
+      };
+
+      await enqueue(request, decision);
+      const found = await findByEventId(eventId);
+      expect(found).toBeDefined();
+      expect(found?.eventId).toBe(eventId);
+    });
+
+    it("should list pending approvals", async () => {
+      const pending = listPending();
+      expect(Array.isArray(pending)).toBe(true);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,7 @@ const DEFAULT_SETTINGS: Settings = {
     prompt: "",
     excludeWindows: [],
     forwardToTelegram: true,
+    forwardToDiscord: true,
   },
   telegram: { token: "", allowedUserIds: [] },
   discord: { token: "", allowedUserIds: [], listenChannels: [] },
@@ -75,6 +76,7 @@ export interface HeartbeatConfig {
   prompt: string;
   excludeWindows: HeartbeatExcludeWindow[];
   forwardToTelegram: boolean;
+  forwardToDiscord: boolean;
 }
 
 export interface TelegramConfig {
@@ -217,7 +219,7 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)
@@ -242,6 +244,7 @@ function parseSettings(raw: Record<string, any>): Settings {
       prompt: raw.heartbeat?.prompt ?? "",
       excludeWindows: parseExcludeWindows(raw.heartbeat?.excludeWindows),
       forwardToTelegram: raw.heartbeat?.forwardToTelegram ?? false,
+      forwardToDiscord: raw.heartbeat?.forwardToDiscord ?? true,
     },
     telegram: {
       token: raw.telegram?.token ?? "",
@@ -249,7 +252,9 @@ function parseSettings(raw: Record<string, any>): Settings {
     },
     discord: {
       token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
-      allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
+      allowedUserIds: discordUserIds && discordUserIds.length > 0
+        ? discordUserIds
+        : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -1,0 +1,653 @@
+/**
+ * Pricing & Budget Engine
+ * 
+ * Evaluates spend/usage against configured budget policies and returns governance actions.
+ * 
+ * BUDGET MODEL:
+ * - Budgets are scoped (session, daily, monthly)
+ * - Thresholds: warn, degrade, reroute, block
+ * - Actions are policy-driven, not hard-coded
+ * - Cost is always labeled as ESTIMATED
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { randomUUID } from "crypto";
+import { 
+  getAggregates, 
+  getSessionUsage, 
+  type UsageFilters 
+} from "./usage-tracker";
+
+const CLAUDECLAW_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const BUDGET_POLICIES_FILE = join(CLAUDECLAW_DIR, "budget-policies.json");
+const PRICING_FILE = join(CLAUDECLAW_DIR, "pricing.json");
+
+export type BudgetPeriod = "session" | "daily" | "monthly";
+export type BudgetState = "healthy" | "warn" | "degrade" | "reroute" | "block";
+
+export interface BudgetThreshold {
+  warnAt?: number;
+  degradeAt?: number;
+  rerouteAt?: number;
+  blockAt?: number;
+}
+
+export interface BudgetActionDefaults {
+  degradeToModel?: string;
+  rerouteToProvider?: string;
+}
+
+export interface BudgetScope {
+  source?: string | string[];
+  channelId?: string | string[];
+  userId?: string | string[];
+  sessionId?: string | string[];
+  model?: string | string[];
+  provider?: string | string[];
+}
+
+export interface BudgetPolicy {
+  id: string;
+  name: string;
+  scope: BudgetScope;
+  thresholds: BudgetThreshold;
+  period: BudgetPeriod;
+  currency: string;
+  actionDefaults?: BudgetActionDefaults;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PricingTier {
+  provider: string;
+  model: string;
+  inputCostPerMillion: number;
+  outputCostPerMillion: number;
+  cacheReadCostPerMillion?: number;
+  cacheCreationCostPerMillion?: number;
+  currency: string;
+}
+
+export interface PricingConfig {
+  version: string;
+  updatedAt: string;
+  tiers: PricingTier[];
+}
+
+export interface BudgetEvaluation {
+  policyId: string;
+  policyName: string;
+  state: BudgetState;
+  currentSpend: number;
+  threshold: number | null;
+  percentage: number;
+  period: BudgetPeriod;
+  currency: string;
+  actions: {
+    shouldWarn: boolean;
+    shouldDegrade: boolean;
+    shouldReroute: boolean;
+    shouldBlock: boolean;
+    degradeToModel?: string;
+    rerouteToProvider?: string;
+  };
+  evaluatedAt: string;
+}
+
+export interface BudgetStateSummary {
+  policyId: string;
+  policyName: string;
+  state: BudgetState;
+  currentSpend: number;
+  threshold: number | null;
+  percentage: number;
+  period: BudgetPeriod;
+  currency: string;
+}
+
+// In-memory cache
+let budgetPolicies: BudgetPolicy[] | null = null;
+let pricingConfig: PricingConfig | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+export function resetBudgetEngine(): void {
+  budgetPolicies = null;
+  pricingConfig = null;
+  initializationPromise = null;
+}
+
+/**
+ * Initialize the budget engine.
+ */
+export async function initBudgetEngine(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  await loadBudgetPolicies();
+  await loadPricing();
+}
+
+async function loadBudgetPolicies(): Promise<BudgetPolicy[]> {
+  if (budgetPolicies !== null) {
+    return budgetPolicies;
+  }
+
+  try {
+    if (existsSync(BUDGET_POLICIES_FILE)) {
+      const data = await Bun.file(BUDGET_POLICIES_FILE).json();
+      if (Array.isArray(data.policies)) {
+        budgetPolicies = data.policies;
+        return budgetPolicies;
+      }
+    }
+  } catch {
+    // Fall through to defaults
+  }
+
+  // Default empty policies
+  budgetPolicies = [];
+  return budgetPolicies;
+}
+
+async function loadPricing(): Promise<PricingConfig> {
+  if (pricingConfig !== null) {
+    return pricingConfig;
+  }
+
+  try {
+    if (existsSync(PRICING_FILE)) {
+      const data = await Bun.file(PRICING_FILE).json();
+      if (data.version && Array.isArray(data.tiers)) {
+        pricingConfig = data;
+        return pricingConfig;
+      }
+    }
+  } catch {
+    // Fall through to defaults
+  }
+
+  // Default pricing (Anthropic-focused, others can be added)
+  pricingConfig = {
+    version: "1.0.0",
+    updatedAt: new Date().toISOString(),
+    tiers: [
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet",
+        inputCostPerMillion: 3.0,
+        outputCostPerMillion: 15.0,
+        cacheReadCostPerMillion: 0.3,
+        cacheCreationCostPerMillion: 3.75,
+        currency: "USD",
+      },
+      {
+        provider: "anthropic",
+        model: "claude-3-haiku",
+        inputCostPerMillion: 0.25,
+        outputCostPerMillion: 1.25,
+        cacheReadCostPerMillion: 0.03,
+        cacheCreationCostPerMillion: 0.03,
+        currency: "USD",
+      },
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        inputCostPerMillion: 5.0,
+        outputCostPerMillion: 15.0,
+        currency: "USD",
+      },
+      {
+        provider: "openai",
+        model: "gpt-4o-mini",
+        inputCostPerMillion: 0.15,
+        outputCostPerMillion: 0.6,
+        currency: "USD",
+      },
+      {
+        provider: "google",
+        model: "glm-4",
+        inputCostPerMillion: 0.27,
+        outputCostPerMillion: 1.07,
+        currency: "USD",
+      },
+    ],
+  };
+
+  await savePricing();
+  return pricingConfig;
+}
+
+async function savePricing(): Promise<void> {
+  if (!pricingConfig) return;
+  pricingConfig.updatedAt = new Date().toISOString();
+  await Bun.write(PRICING_FILE, JSON.stringify(pricingConfig, null, 2) + "\n");
+}
+
+async function saveBudgetPolicies(): Promise<void> {
+  if (!budgetPolicies) return;
+  await Bun.write(
+    BUDGET_POLICIES_FILE,
+    JSON.stringify({ policies: budgetPolicies, updatedAt: new Date().toISOString() }, null, 2) + "\n"
+  );
+}
+
+/**
+ * Load pricing configuration.
+ */
+export async function loadPricingConfig(): Promise<PricingConfig> {
+  await initBudgetEngine();
+  return pricingConfig!;
+}
+
+/**
+ * Load budget policies.
+ */
+export async function loadPolicies(): Promise<BudgetPolicy[]> {
+  await initBudgetEngine();
+  return budgetPolicies!;
+}
+
+/**
+ * Add or update a budget policy.
+ */
+export async function upsertBudgetPolicy(
+  policyData: Omit<BudgetPolicy, "id" | "createdAt" | "updatedAt"> & { id?: string }
+): Promise<BudgetPolicy> {
+  await initBudgetEngine();
+
+  const now = new Date().toISOString();
+  const policyId = policyData.id;
+  
+  if (policyId) {
+    // Update existing
+    const index = budgetPolicies!.findIndex(p => p.id === policyId);
+    if (index >= 0) {
+      budgetPolicies![index] = {
+        ...budgetPolicies![index],
+        ...policyData,
+        id: policyId,
+        updatedAt: now,
+      };
+      await saveBudgetPolicies();
+      return budgetPolicies![index];
+    }
+  }
+
+  // Create new
+  const newPolicy: BudgetPolicy = {
+    ...policyData,
+    id: policyId || randomUUID(),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  budgetPolicies!.push(newPolicy);
+  await saveBudgetPolicies();
+  return newPolicy;
+}
+
+/**
+ * Delete a budget policy.
+ */
+export async function deleteBudgetPolicy(policyId: string): Promise<boolean> {
+  await initBudgetEngine();
+
+  const index = budgetPolicies!.findIndex(p => p.id === policyId);
+  if (index < 0) {
+    return false;
+  }
+
+  budgetPolicies!.splice(index, 1);
+  await saveBudgetPolicies();
+  return true;
+}
+
+/**
+ * Calculate estimated cost from usage metrics.
+ */
+export function calculateEstimatedCost(
+  usage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheCreationInputTokens?: number;
+    cacheReadInputTokens?: number;
+  },
+  provider: string,
+  model: string
+): { totalCost: number; breakdown: { inputCost: number; outputCost: number; cacheCost: number } } | null {
+  if (!pricingConfig) {
+    return null;
+  }
+
+  const tier = pricingConfig.tiers.find(t => t.provider === provider && t.model === model);
+  if (!tier) {
+    // Try just provider-level default
+    const providerTier = pricingConfig.tiers.find(t => t.provider === provider);
+    if (!providerTier) {
+      return null;
+    }
+  }
+
+  const selectedTier = tier || pricingConfig.tiers.find(t => t.provider === provider)!;
+
+  const inputCost = ((usage.inputTokens ?? 0) / 1_000_000) * selectedTier.inputCostPerMillion;
+  const outputCost = ((usage.outputTokens ?? 0) / 1_000_000) * selectedTier.outputCostPerMillion;
+  
+  let cacheCost = 0;
+  if (selectedTier.cacheCreationCostPerMillion && usage.cacheCreationInputTokens) {
+    cacheCost += (usage.cacheCreationInputTokens / 1_000_000) * selectedTier.cacheCreationCostPerMillion;
+  }
+  if (selectedTier.cacheReadCostPerMillion && usage.cacheReadInputTokens) {
+    cacheCost += (usage.cacheReadInputTokens / 1_000_000) * selectedTier.cacheReadCostPerMillion;
+  }
+
+  const totalCost = inputCost + outputCost + cacheCost;
+
+  return {
+    totalCost,
+    breakdown: {
+      inputCost,
+      outputCost,
+      cacheCost,
+    },
+  };
+}
+
+function matchesScope(record: { source?: string; channelId?: string; sessionId?: string; provider?: string; model?: string }, scope: BudgetScope): boolean {
+  // Check source
+  if (scope.source) {
+    const sources = Array.isArray(scope.source) ? scope.source : [scope.source];
+    if (!record.source || !sources.includes(record.source)) {
+      return false;
+    }
+  }
+
+  // Check channelId
+  if (scope.channelId) {
+    const channels = Array.isArray(scope.channelId) ? scope.channelId : [scope.channelId];
+    if (!record.channelId || !channels.includes(record.channelId)) {
+      return false;
+    }
+  }
+
+  // Check sessionId
+  if (scope.sessionId) {
+    const sessions = Array.isArray(scope.sessionId) ? scope.sessionId : [scope.sessionId];
+    if (!record.sessionId || !sessions.includes(record.sessionId)) {
+      return false;
+    }
+  }
+
+  // Check provider
+  if (scope.provider) {
+    const providers = Array.isArray(scope.provider) ? scope.provider : [scope.provider];
+    if (!record.provider || !providers.includes(record.provider)) {
+      return false;
+    }
+  }
+
+  // Check model
+  if (scope.model) {
+    const models = Array.isArray(scope.model) ? scope.model : [scope.model];
+    if (!record.model || !models.includes(record.model)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getPeriodBounds(period: BudgetPeriod): { startDate: string; endDate: string } {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const day = now.getUTCDate();
+
+  let startDate: string;
+  let endDate: string;
+
+  switch (period) {
+    case "session":
+      // Session is unbounded in time - use all records
+      startDate = "1970-01-01T00:00:00Z";
+      endDate = "2099-12-31T23:59:59Z";
+      break;
+
+    case "daily":
+      startDate = new Date(Date.UTC(year, month, day, 0, 0, 0, 0)).toISOString();
+      endDate = new Date(Date.UTC(year, month, day, 23, 59, 59, 999)).toISOString();
+      break;
+
+    case "monthly":
+      startDate = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)).toISOString();
+      endDate = new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999)).toISOString();
+      break;
+  }
+
+  return { startDate, endDate };
+}
+
+/**
+ * Evaluate budget for a given context.
+ */
+export async function evaluateBudget(
+  context: {
+    sessionId?: string;
+    channelId?: string;
+    source?: string;
+    userId?: string;
+    provider?: string;
+    model?: string;
+  }
+): Promise<BudgetEvaluation[]> {
+  await initBudgetEngine();
+
+  const evaluations: BudgetEvaluation[] = [];
+
+  for (const policy of budgetPolicies!) {
+    if (!policy.enabled) {
+      continue;
+    }
+
+    // Check if context matches policy scope
+    if (!matchesScope(context, policy.scope)) {
+      continue;
+    }
+
+    // Get period bounds
+    const { startDate, endDate } = getPeriodBounds(policy.period);
+
+    // Get usage for the period
+    const filters: UsageFilters = {
+      startDate,
+      endDate,
+      sessionId: policy.period === "session" ? context.sessionId : undefined,
+      channelId: context.channelId,
+      source: context.source,
+      provider: context.provider,
+      model: context.model,
+    };
+
+    const aggregates = await getAggregates(filters);
+
+    const currentSpend = aggregates.totalEstimatedCost;
+    const { thresholds } = policy;
+
+    // Determine state
+    let state: BudgetState = "healthy";
+    let threshold: number | null = null;
+    let percentage = 0;
+
+    if (thresholds.blockAt !== undefined && currentSpend >= thresholds.blockAt) {
+      state = "block";
+      threshold = thresholds.blockAt;
+      percentage = (currentSpend / thresholds.blockAt) * 100;
+    } else if (thresholds.rerouteAt !== undefined && currentSpend >= thresholds.rerouteAt) {
+      state = "reroute";
+      threshold = thresholds.rerouteAt;
+      percentage = (currentSpend / thresholds.rerouteAt) * 100;
+    } else if (thresholds.degradeAt !== undefined && currentSpend >= thresholds.degradeAt) {
+      state = "degrade";
+      threshold = thresholds.degradeAt;
+      percentage = (currentSpend / thresholds.degradeAt) * 100;
+    } else if (thresholds.warnAt !== undefined && currentSpend >= thresholds.warnAt) {
+      state = "warn";
+      threshold = thresholds.warnAt;
+      percentage = (currentSpend / thresholds.warnAt) * 100;
+    }
+
+    // Determine actions
+    const actions = {
+      shouldWarn: state !== "healthy",
+      shouldDegrade: state === "degrade" || state === "reroute" || state === "block",
+      shouldReroute: state === "reroute" || state === "block",
+      shouldBlock: state === "block",
+      degradeToModel: policy.actionDefaults?.degradeToModel,
+      rerouteToProvider: policy.actionDefaults?.rerouteToProvider,
+    };
+
+    evaluations.push({
+      policyId: policy.id,
+      policyName: policy.name,
+      state,
+      currentSpend,
+      threshold,
+      percentage,
+      period: policy.period,
+      currency: policy.currency,
+      actions,
+      evaluatedAt: new Date().toISOString(),
+    });
+  }
+
+  return evaluations;
+}
+
+/**
+ * Get current budget state for a scope.
+ */
+export async function getBudgetState(
+  scope: BudgetScope
+): Promise<BudgetStateSummary[]> {
+  await initBudgetEngine();
+
+  const summaries: BudgetStateSummary[] = [];
+
+  for (const policy of budgetPolicies!) {
+    if (!policy.enabled) {
+      continue;
+    }
+
+    // Check if policy matches the requested scope
+    if (!matchesScope(scope as { source?: string; channelId?: string; sessionId?: string; provider?: string; model?: string }, policy.scope)) {
+      continue;
+    }
+
+    // Get period bounds
+    const { startDate, endDate } = getPeriodBounds(policy.period);
+
+    // Get usage for the period
+    const filters: UsageFilters = {
+      startDate,
+      endDate,
+    };
+
+    const aggregates = await getAggregates(filters);
+    const currentSpend = aggregates.totalEstimatedCost;
+
+    // Determine state
+    let state: BudgetState = "healthy";
+    let threshold: number | null = null;
+    let percentage = 0;
+
+    const { thresholds } = policy;
+
+    if (thresholds.blockAt !== undefined && currentSpend >= thresholds.blockAt) {
+      state = "block";
+      threshold = thresholds.blockAt;
+      percentage = (currentSpend / thresholds.blockAt) * 100;
+    } else if (thresholds.rerouteAt !== undefined && currentSpend >= thresholds.rerouteAt) {
+      state = "reroute";
+      threshold = thresholds.rerouteAt;
+      percentage = (currentSpend / thresholds.rerouteAt) * 100;
+    } else if (thresholds.degradeAt !== undefined && currentSpend >= thresholds.degradeAt) {
+      state = "degrade";
+      threshold = thresholds.degradeAt;
+      percentage = (currentSpend / thresholds.degradeAt) * 100;
+    } else if (thresholds.warnAt !== undefined && currentSpend >= thresholds.warnAt) {
+      state = "warn";
+      threshold = thresholds.warnAt;
+      percentage = (currentSpend / thresholds.warnAt) * 100;
+    }
+
+    summaries.push({
+      policyId: policy.id,
+      policyName: policy.name,
+      state,
+      currentSpend,
+      threshold,
+      percentage,
+      period: policy.period,
+      currency: policy.currency,
+    });
+  }
+
+  return summaries;
+}
+
+/**
+ * Create default budget policies for a channel.
+ */
+export async function createDefaultPoliciesForChannel(
+  channelId: string,
+  options: {
+    dailyLimit?: number;
+    monthlyLimit?: number;
+  } = {}
+): Promise<BudgetPolicy[]> {
+  const policies: BudgetPolicy[] = [];
+
+  if (options.dailyLimit) {
+    const dailyPolicy = await upsertBudgetPolicy({
+      id: randomUUID(),
+      name: `Daily budget for ${channelId}`,
+      scope: { channelId },
+      thresholds: {
+        warnAt: options.dailyLimit! * 0.7,
+        degradeAt: options.dailyLimit! * 0.85,
+        blockAt: options.dailyLimit!,
+      },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+    policies.push(dailyPolicy);
+  }
+
+  if (options.monthlyLimit) {
+    const monthlyPolicy = await upsertBudgetPolicy({
+      id: randomUUID(),
+      name: `Monthly budget for ${channelId}`,
+      scope: { channelId },
+      thresholds: {
+        warnAt: options.monthlyLimit! * 0.7,
+        degradeAt: options.monthlyLimit! * 0.85,
+        blockAt: options.monthlyLimit!,
+      },
+      period: "monthly",
+      currency: "USD",
+      enabled: true,
+    });
+    policies.push(monthlyPolicy);
+  }
+
+  return policies;
+}

--- a/src/governance/client.ts
+++ b/src/governance/client.ts
@@ -1,0 +1,163 @@
+/**
+ * GovernanceClient - Unified interface to governance operations
+ * 
+ * Provides a single entry point for policy evaluation, approval management,
+ * and governance telemetry across the codebase.
+ */
+
+import { evaluate, loadRules, type ToolRequestContext, type PolicyDecision } from "../policy/engine";
+import { enqueue, listPending, findByEventId, findById, loadState as loadApprovalState, type ApprovalEntry } from "../policy/approval-queue";
+import { logPolicyDecision } from "../policy/audit-log";
+import * as governance from "./index";
+
+export interface GovernanceClientConfig {
+  policyEnabled?: boolean;
+  approvalEnabled?: boolean;
+}
+
+export class GovernanceClient {
+  private config: GovernanceClientConfig;
+
+  constructor(config: GovernanceClientConfig = {}) {
+    this.config = {
+      policyEnabled: config.policyEnabled ?? true,
+      approvalEnabled: config.approvalEnabled ?? true,
+    };
+  }
+
+  // --- Policy Engine ---
+  
+  /**
+   * Evaluate a tool request against policy rules.
+   */
+  evaluateToolRequest(request: ToolRequestContext): PolicyDecision {
+    if (!this.config.policyEnabled) {
+      const decision = {
+        requestId: crypto.randomUUID(),
+        action: "allow",
+        reason: "Policy engine disabled",
+        evaluatedAt: new Date().toISOString(),
+        cacheable: false,
+      };
+      return decision;
+    }
+    const decision = evaluate(request);
+
+    // Log every policy decision to audit trail (fire-and-forget)
+    logPolicyDecision(
+      request.eventId,
+      decision.requestId,
+      request.source,
+      request.toolName,
+      decision.action,
+      decision.reason,
+      {
+        channelId: request.channelId,
+        threadId: request.threadId,
+        userId: request.userId,
+        skillName: request.skillName,
+        matchedRuleId: decision.matchedRuleId,
+      }
+    ).catch(err => {
+      console.error("[governance] Failed to write audit log:", err);
+    });
+
+    return decision;
+  }
+
+  /**
+   * Load/reload policy rules from disk.
+   */
+  async reloadPolicies(): Promise<void> {
+    await loadRules();
+  }
+
+  // --- Approval Queue ---
+  
+  /**
+   * Request approval for a tool execution.
+   * Returns the approval entry if decision is require_approval.
+   */
+  async requestApproval(request: ToolRequestContext, decision: PolicyDecision): Promise<ApprovalEntry | null> {
+    if (!this.config.approvalEnabled || decision.action !== "require_approval") {
+      return null;
+    }
+    return enqueue(request, decision);
+  }
+
+  /**
+   * Get all pending approvals.
+   */
+  getPendingApprovals(): ApprovalEntry[] {
+    return listPending();
+  }
+
+  /**
+   * Find approval by event ID.
+   */
+  async findApprovalByEvent(eventId: string): Promise<ApprovalEntry | null> {
+    return findByEventId(eventId);
+  }
+
+  /**
+   * Find approval by approval ID.
+   */
+  getApprovalById(id: string): ApprovalEntry | null {
+    return findById(id);
+  }
+
+  // --- Governance Telemetry ---
+  
+  /**
+   * Get governance telemetry summary.
+   */
+  async getTelemetry() {
+    return governance.getTelemetry({});
+  }
+
+  /**
+   * Get usage stats.
+   */
+  async getUsageStats() {
+    return governance.getUsageStats();
+  }
+
+  /**
+   * Get budget state.
+   */
+  async getBudgetState(channelId?: string) {
+    return governance.getBudgetState(channelId);
+  }
+
+  /**
+   * Check if a tool is allowed (shortcut for allow action).
+   */
+  isToolAllowed(request: ToolRequestContext): boolean {
+    const decision = this.evaluateToolRequest(request);
+    return decision.action === "allow";
+  }
+
+  /**
+   * Check if a tool requires approval (shortcut for require_approval action).
+   */
+  requiresApproval(request: ToolRequestContext): boolean {
+    const decision = this.evaluateToolRequest(request);
+    return decision.action === "require_approval";
+  }
+}
+
+// --- Singleton Instance ---
+
+let governanceClientInstance: GovernanceClient | null = null;
+
+export function getGovernanceClient(): GovernanceClient {
+  if (!governanceClientInstance) {
+    governanceClientInstance = new GovernanceClient();
+  }
+  return governanceClientInstance;
+}
+
+export function initGovernanceClient(config?: GovernanceClientConfig): GovernanceClient {
+  governanceClientInstance = new GovernanceClient(config);
+  return governanceClientInstance;
+}

--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -1,0 +1,104 @@
+/**
+ * Governance Module Index
+ * 
+ * Exposes all governance modules from a single entry point.
+ */
+
+// Usage Tracker
+export {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  recordInvocationFailure,
+  recordInvocationKilled,
+  getInvocation,
+  getSessionUsage,
+  getChannelUsage,
+  getAggregates,
+  getUsageStats,
+  getAllUsageRecords,
+  resetUsageTracker,
+  type InvocationStatus,
+  type UsageMetrics,
+  type EstimatedCost,
+  type InvocationUsageRecord,
+  type InvocationContext,
+  type UsageFilters,
+} from "./usage-tracker";
+
+// Budget Engine
+export {
+  initBudgetEngine,
+  evaluateBudget,
+  getBudgetState,
+  upsertBudgetPolicy,
+  deleteBudgetPolicy,
+  loadPricingConfig,
+  loadPolicies,
+  calculateEstimatedCost,
+  createDefaultPoliciesForChannel,
+  resetBudgetEngine,
+  type BudgetPeriod,
+  type BudgetState,
+  type BudgetThreshold,
+  type BudgetActionDefaults,
+  type BudgetScope,
+  type BudgetPolicy,
+  type PricingTier,
+  type PricingConfig,
+  type BudgetEvaluation,
+  type BudgetStateSummary,
+} from "./budget-engine";
+
+// Model Router
+export {
+  selectModel,
+  getFallbackChain,
+  isModelAllowed,
+  configureRouter,
+  getRouterConfig,
+  type ModelRoutingDecision,
+  type ModelRequestContext,
+} from "./model-router";
+
+// Watchdog
+export {
+  initWatchdog,
+  recordExecutionMetric,
+  incrementToolCall,
+  incrementTurnCount,
+  checkLimits,
+  handleTrigger,
+  getActiveInvocation,
+  getSessionActiveInvocations,
+  clearInvocation,
+  getWatchdogStats,
+  configureWatchdog,
+  getWatchdogConfig,
+  resetWatchdog,
+  type WatchdogState,
+  type WatchdogLimits,
+  type ExecutionMetrics,
+  type WatchdogDecision,
+  type WatchdogConfig,
+} from "./watchdog";
+
+// Telemetry
+export {
+  getTelemetry,
+  getTelemetrySummary,
+  getProviderBreakdown,
+  getModelBreakdown,
+  getChannelBreakdown,
+  getBudgetHealth,
+  type GovernanceTelemetry,
+  type TelemetryFilters,
+} from "./telemetry";
+
+// GovernanceClient
+export {
+  GovernanceClient,
+  getGovernanceClient,
+  initGovernanceClient,
+  type GovernanceClientConfig,
+} from "./client";

--- a/src/governance/model-router.ts
+++ b/src/governance/model-router.ts
@@ -1,0 +1,358 @@
+/**
+ * Governance-Aware Model Router
+ * 
+ * Selects provider/model combinations using policy, task context, capability requirements,
+ * and budget state. Replaces the naive keyword-based router with an auditable,
+ * policy-driven approach.
+ */
+
+import { randomUUID } from "crypto";
+import { evaluateBudget, type BudgetEvaluation, type BudgetState } from "./budget-engine";
+import { classifyTask, selectModel as legacySelectModel } from "../model-router";
+import type { AgenticMode } from "../config";
+
+export type { BudgetState };
+
+export interface ModelRoutingDecision {
+  requestId: string;
+  selectedProvider: string;
+  selectedModel: string;
+  reason: string;
+  matchedPolicyId?: string;
+  budgetState?: BudgetState;
+  fallbackChain?: Array<{ provider: string; model: string }>;
+  decidedAt: string;
+}
+
+export interface ModelRequestContext {
+  prompt?: string;
+  taskType?: string;
+  capability?: string;
+  preferredProvider?: string;
+  preferredModel?: string;
+  explicitOverride?: {
+    provider?: string;
+    model?: string;
+    allowed: boolean;
+  };
+  sessionId?: string;
+  channelId?: string;
+  source?: string;
+  userId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface RouterConfig {
+  defaultProvider: string;
+  defaultModel: string;
+  modes?: AgenticMode[];
+  defaultMode?: string;
+  fallbackChain: Array<{ provider: string; model: string }>;
+  degradeToModel?: string;
+  rerouteToProvider?: string;
+}
+
+// Configuration for the router
+let routerConfig: RouterConfig = {
+  defaultProvider: "anthropic",
+  defaultModel: "claude-3-5-sonnet",
+  fallbackChain: [
+    { provider: "anthropic", model: "claude-3-5-sonnet" },
+    { provider: "anthropic", model: "claude-3-haiku" },
+    { provider: "openai", model: "gpt-4o-mini" },
+  ],
+};
+
+/**
+ * Configure the model router.
+ */
+export function configureRouter(config: Partial<RouterConfig>): void {
+  routerConfig = {
+    ...routerConfig,
+    ...config,
+    fallbackChain: config.fallbackChain ?? routerConfig.fallbackChain,
+  };
+}
+
+/**
+ * Get current router configuration.
+ */
+export function getRouterConfig(): RouterConfig {
+  return { ...routerConfig };
+}
+
+function determineBudgetState(evaluations: BudgetEvaluation[]): BudgetState {
+  if (evaluations.length === 0) {
+    return "healthy";
+  }
+
+  // Use the worst state across all applicable policies
+  const statePriority: Record<BudgetState, number> = {
+    healthy: 0,
+    warn: 1,
+    degrade: 2,
+    reroute: 3,
+    block: 4,
+  };
+
+  let worstState: BudgetState = "healthy";
+  let highestPriority = 0;
+
+  for (const eval_ of evaluations) {
+    const priority = statePriority[eval_.state];
+    if (priority > highestPriority) {
+      highestPriority = priority;
+      worstState = eval_.state;
+    }
+  }
+
+  return worstState;
+}
+
+function findCheaperAlternative(
+  currentProvider: string,
+  currentModel: string
+): { provider: string; model: string } | null {
+  // Define cheaper alternatives per provider
+  const cheaperAlternatives: Record<string, Record<string, { provider: string; model: string }>> = {
+    "anthropic": {
+      "claude-3-5-sonnet": { provider: "anthropic", model: "claude-3-haiku" },
+      "claude-3-opus": { provider: "anthropic", model: "claude-3-5-sonnet" },
+    },
+    "openai": {
+      "gpt-4o": { provider: "openai", model: "gpt-4o-mini" },
+      "gpt-4": { provider: "openai", model: "gpt-4o-mini" },
+    },
+  };
+
+  const providerAlternatives = cheaperAlternatives[currentProvider];
+  if (!providerAlternatives) {
+    return null;
+  }
+
+  return providerAlternatives[currentModel] || null;
+}
+
+function findRerouteAlternative(
+  currentProvider: string,
+  rerouteToProvider?: string
+): { provider: string; model: string } | null {
+  // Provider-level reroute mapping
+  const providerDefaults: Record<string, { provider: string; model: string }> = {
+    "anthropic": { provider: "anthropic", model: "claude-3-haiku" },
+    "openai": { provider: "openai", model: "gpt-4o-mini" },
+    "google": { provider: "google", model: "glm-4" },
+  };
+
+  if (rerouteToProvider && providerDefaults[rerouteToProvider]) {
+    return providerDefaults[rerouteToProvider];
+  }
+
+  // Fall back to finding any cheaper provider
+  for (const [provider, defaultModel] of Object.entries(providerDefaults)) {
+    if (provider !== currentProvider) {
+      return defaultModel;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Select a model based on request context and budget state.
+ */
+export async function selectModel(requestContext: ModelRequestContext): Promise<ModelRoutingDecision> {
+  const requestId = randomUUID();
+  const now = new Date().toISOString();
+
+  // Evaluate budget first
+  const budgetEvaluations = await evaluateBudget({
+    sessionId: requestContext.sessionId,
+    channelId: requestContext.channelId,
+    source: requestContext.source,
+    userId: requestContext.userId,
+    provider: requestContext.preferredProvider,
+    model: requestContext.preferredModel,
+  });
+
+  const budgetState = determineBudgetState(budgetEvaluations);
+  const worstEvaluation = budgetEvaluations.find(e => e.state === budgetState) ?? budgetEvaluations[0];
+
+  // Check for explicit override
+  if (requestContext.explicitOverride?.allowed && 
+      (requestContext.explicitOverride.provider || requestContext.explicitOverride.model)) {
+    // Override is allowed - use it but still consider budget state
+    if (budgetState === "block") {
+      return {
+        requestId,
+        selectedProvider: "",
+        selectedModel: "",
+        reason: "Execution blocked: budget limit exceeded",
+        budgetState,
+        fallbackChain: routerConfig.fallbackChain,
+        decidedAt: now,
+      };
+    }
+
+    return {
+      requestId,
+      selectedProvider: requestContext.explicitOverride.provider || routerConfig.defaultProvider,
+      selectedModel: requestContext.explicitOverride.model || routerConfig.defaultModel,
+      reason: "Explicit override applied (allowed by policy)",
+      matchedPolicyId: worstEvaluation?.policyId,
+      budgetState,
+      fallbackChain: routerConfig.fallbackChain,
+      decidedAt: now,
+    };
+  }
+
+  // Determine base model selection
+  let selectedProvider = routerConfig.defaultProvider;
+  let selectedModel = routerConfig.defaultModel;
+  let reason = "Default model selection";
+  let finalBudgetState: BudgetState = budgetState;
+
+  // If blocked, return early
+  if (budgetState === "block") {
+    finalBudgetState = "block";
+    return {
+      requestId,
+      selectedProvider: "",
+      selectedModel: "",
+      reason: "Execution blocked: budget limit exceeded",
+      budgetState: finalBudgetState,
+      matchedPolicyId: worstEvaluation?.policyId,
+      fallbackChain: routerConfig.fallbackChain,
+      decidedAt: now,
+    };
+  }
+
+  // Use task type / capability if provided
+  if (requestContext.taskType && routerConfig.modes && routerConfig.modes.length > 0) {
+    // Use legacy classification for task type
+    if (requestContext.prompt && routerConfig.defaultMode) {
+      const legacyResult = legacySelectModel(
+        requestContext.prompt,
+        routerConfig.modes,
+        routerConfig.defaultMode
+      );
+      selectedModel = legacyResult.model;
+      reason = `Task classified as "${legacyResult.taskType}": ${legacyResult.reasoning}`;
+    }
+  } else if (requestContext.capability) {
+    // Map capability to model
+    const capabilityModelMap: Record<string, { provider: string; model: string }> = {
+      "coding": { provider: "anthropic", model: "claude-3-5-sonnet" },
+      "analysis": { provider: "anthropic", model: "claude-3-5-sonnet" },
+      "creative": { provider: "anthropic", model: "claude-3-5-sonnet" },
+      "fast": { provider: "anthropic", model: "claude-3-haiku" },
+      "simple": { provider: "anthropic", model: "claude-3-haiku" },
+    };
+    const mapped = capabilityModelMap[requestContext.capability.toLowerCase()];
+    if (mapped) {
+      selectedProvider = mapped.provider;
+      selectedModel = mapped.model;
+      reason = `Capability "${requestContext.capability}" mapped to ${mapped.provider}/${mapped.model}`;
+    }
+  }
+
+  // Apply preferred provider/model if set
+  if (requestContext.preferredProvider) {
+    selectedProvider = requestContext.preferredProvider;
+  }
+  if (requestContext.preferredModel) {
+    selectedModel = requestContext.preferredModel;
+  }
+
+  // Apply budget-aware modifications
+  // Note: "block" is handled earlier with early return, so remaining states are "healthy"|"warn"|"degrade"|"reroute"
+  const currentBudgetState = budgetState as "healthy" | "warn" | "degrade" | "reroute";
+  if (currentBudgetState === "degrade" && worstEvaluation?.actions.degradeToModel) {
+    const degradeParts = worstEvaluation.actions.degradeToModel.split("/");
+    if (degradeParts.length === 2) {
+      selectedProvider = degradeParts[0];
+      selectedModel = degradeParts[1];
+    } else {
+      selectedModel = worstEvaluation.actions.degradeToModel;
+    }
+    reason = `Budget degrade: switched to ${selectedProvider}/${selectedModel}`;
+  } else if (currentBudgetState === "reroute" && worstEvaluation?.actions.rerouteToProvider) {
+    const reroute = findRerouteAlternative(selectedProvider, worstEvaluation.actions.rerouteToProvider);
+    if (reroute) {
+      selectedProvider = reroute.provider;
+      selectedModel = reroute.model;
+      reason = `Budget reroute: switched to ${selectedProvider}/${selectedModel}`;
+    } else if (routerConfig.rerouteToProvider) {
+      const fallback = findRerouteAlternative(selectedProvider, routerConfig.rerouteToProvider);
+      if (fallback) {
+        selectedProvider = fallback.provider;
+        selectedModel = fallback.model;
+        reason = `Budget reroute: switched to ${selectedProvider}/${selectedModel}`;
+      }
+    }
+  } else if (currentBudgetState === "warn") {
+    reason += ` (budget warning: ${worstEvaluation?.percentage.toFixed(1)}% of threshold)`;
+  }
+  // "healthy" state requires no special action
+
+  // Build fallback chain based on budget state (block case handled earlier)
+  let fallbackChain = routerConfig.fallbackChain;
+  if (currentBudgetState === "degrade" || currentBudgetState === "reroute") {
+    // Filter fallback chain to cheaper options
+    fallbackChain = routerConfig.fallbackChain.filter(
+      (f) => f.provider !== selectedProvider || f.model !== selectedModel
+    );
+  }
+
+  return {
+    requestId,
+    selectedProvider,
+    selectedModel,
+    reason,
+    matchedPolicyId: worstEvaluation?.policyId,
+    budgetState,
+    fallbackChain,
+    decidedAt: now,
+  };
+}
+
+/**
+ * Get the fallback chain for a request context.
+ */
+export async function getFallbackChain(requestContext: ModelRequestContext): Promise<Array<{ provider: string; model: string }>> {
+  const decision = await selectModel(requestContext);
+  return decision.fallbackChain || routerConfig.fallbackChain;
+}
+
+/**
+ * Check if a specific model selection is allowed given the context.
+ */
+export async function isModelAllowed(
+  provider: string,
+  model: string,
+  context: ModelRequestContext
+): Promise<{ allowed: boolean; reason: string }> {
+  // Evaluate budget
+  const evaluations = await evaluateBudget({
+    sessionId: context.sessionId,
+    channelId: context.channelId,
+    source: context.source,
+    userId: context.userId,
+    provider,
+    model,
+  });
+
+  const budgetState = determineBudgetState(evaluations);
+
+  if (budgetState === "block") {
+    return {
+      allowed: false,
+      reason: `Model ${provider}/${model} blocked: budget limit exceeded`,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: "Model selection allowed",
+  };
+}

--- a/src/governance/telemetry.ts
+++ b/src/governance/telemetry.ts
@@ -1,0 +1,311 @@
+/**
+ * Governance Telemetry
+ * 
+ * Exposes persisted governance state and derived aggregates to API/dashboard consumers.
+ * 
+ * PRINCIPLES:
+ * - Telemetry is read-side only
+ * - Telemetry derives from persisted usage/governance records
+ * - Cached aggregates may exist, but persisted records remain canonical
+ * - Real-time updates are optional and only added if architecture supports them
+ */
+
+import { getAggregates, type UsageFilters } from "./usage-tracker";
+import { getBudgetState, type BudgetScope } from "./budget-engine";
+
+export interface GovernanceTelemetry {
+  // Session stats
+  totalSessions: number;
+  activeSessions: number;
+  
+  // Cost stats
+  estimatedTotalCost: number;
+  currency: string;
+  
+  // Channel stats
+  channelStats: Record<string, {
+    sessions: number;
+    estimatedCost: number;
+    tokens: number;
+    invocations: number;
+  }>;
+  
+  // Provider stats
+  providerStats: Record<string, {
+    calls: number;
+    tokens: number;
+    estimatedCost: number;
+  }>;
+  
+  // Model stats
+  modelStats: Record<string, {
+    calls: number;
+    tokens: number;
+    estimatedCost: number;
+  }>;
+  
+  // Budget states
+  budgetStates: Record<string, {
+    status: string;
+    scope: string;
+    currentSpend?: number;
+    threshold?: number;
+  }>;
+  
+  // Watchdog stats
+  watchdog: {
+    triggered: number;
+    warned: number;
+    killed: number;
+    suspended: number;
+  };
+  
+  // Invocation stats
+  invocationStats: {
+    total: number;
+    completed: number;
+    failed: number;
+    killed: number;
+    byProvider: Record<string, number>;
+    byModel: Record<string, number>;
+  };
+}
+
+export interface TelemetryFilters {
+  startDate?: string;
+  endDate?: string;
+  channelId?: string;
+  source?: string;
+  provider?: string;
+  model?: string;
+}
+
+/**
+ * Get comprehensive governance telemetry.
+ */
+export async function getTelemetry(filters: TelemetryFilters = {}): Promise<GovernanceTelemetry> {
+  // Get usage aggregates
+  const usageFilters: UsageFilters = {
+    startDate: filters.startDate,
+    endDate: filters.endDate,
+    channelId: filters.channelId,
+    source: filters.source,
+    provider: filters.provider,
+    model: filters.model,
+  };
+
+  const aggregates = await getAggregates(usageFilters);
+
+  // Get budget states
+  const budgetScope: BudgetScope = {};
+  if (filters.channelId) {
+    budgetScope.channelId = filters.channelId;
+  }
+  const budgetStates = await getBudgetState(budgetScope);
+
+  // Build telemetry response
+  const telemetry: GovernanceTelemetry = {
+    // Session stats (derived from usage records)
+    totalSessions: Object.keys(aggregates.byChannel).length,
+    activeSessions: 0, // Would need active session tracking
+
+    // Cost stats
+    estimatedTotalCost: aggregates.totalEstimatedCost,
+    currency: "USD", // Default currency
+
+    // Channel stats
+    channelStats: Object.fromEntries(
+      Object.entries(aggregates.byChannel).map(([channelId, stats]) => [
+        channelId,
+        {
+          sessions: 0, // Would need session-level tracking
+          estimatedCost: stats.cost,
+          tokens: stats.tokens,
+          invocations: stats.count,
+        },
+      ])
+    ),
+
+    // Provider stats
+    providerStats: Object.fromEntries(
+      Object.entries(aggregates.byProvider).map(([provider, stats]) => [
+        provider,
+        {
+          calls: stats.count,
+          tokens: stats.tokens,
+          estimatedCost: stats.cost,
+        },
+      ])
+    ),
+
+    // Model stats
+    modelStats: Object.fromEntries(
+      Object.entries(aggregates.byModel).map(([model, stats]) => [
+        model,
+        {
+          calls: stats.count,
+          tokens: stats.tokens,
+          estimatedCost: stats.cost,
+        },
+      ])
+    ),
+
+    // Budget states
+    budgetStates: Object.fromEntries(
+      budgetStates.map((bs) => [
+        bs.policyId,
+        {
+          status: bs.state,
+          scope: JSON.stringify(bs),
+          currentSpend: bs.currentSpend,
+          threshold: bs.threshold ?? undefined,
+        },
+      ])
+    ),
+
+    // Watchdog stats (placeholder - would need watchdog event tracking)
+    watchdog: {
+      triggered: 0,
+      warned: 0,
+      killed: aggregates.killedInvocations,
+      suspended: 0,
+    },
+
+    // Invocation stats
+    invocationStats: {
+      total: aggregates.totalInvocations,
+      completed: aggregates.completedInvocations,
+      failed: aggregates.failedInvocations,
+      killed: aggregates.killedInvocations,
+      byProvider: Object.fromEntries(
+        Object.entries(aggregates.byProvider).map(([p, v]) => [p, v.count])
+      ),
+      byModel: Object.fromEntries(
+        Object.entries(aggregates.byModel).map(([m, v]) => [m, v.count])
+      ),
+    },
+  };
+
+  return telemetry;
+}
+
+/**
+ * Get lightweight summary for quick overview.
+ */
+export async function getTelemetrySummary(): Promise<{
+  totalInvocations: number;
+  estimatedTotalCost: number;
+  activeBudgets: number;
+  blockedBudgets: number;
+}> {
+  const aggregates = await getAggregates({});
+  const budgetStates = await getBudgetState({});
+
+  return {
+    totalInvocations: aggregates.totalInvocations,
+    estimatedTotalCost: aggregates.totalEstimatedCost,
+    activeBudgets: budgetStates.filter((b) => b.state !== "healthy").length,
+    blockedBudgets: budgetStates.filter((b) => b.state === "block").length,
+  };
+}
+
+/**
+ * Get provider breakdown.
+ */
+export async function getProviderBreakdown(): Promise<Array<{
+  provider: string;
+  calls: number;
+  tokens: number;
+  estimatedCost: number;
+  avgCostPerCall: number;
+}>> {
+  const aggregates = await getAggregates({});
+
+  return Object.entries(aggregates.byProvider).map(([provider, stats]) => ({
+    provider,
+    calls: stats.count,
+    tokens: stats.tokens,
+    estimatedCost: stats.cost,
+    avgCostPerCall: stats.count > 0 ? stats.cost / stats.count : 0,
+  }));
+}
+
+function inferProvider(model: string): string {
+  if (model.startsWith("claude")) return "anthropic";
+  if (model.startsWith("gpt") || model.startsWith("o1") || model.startsWith("o3")) return "openai";
+  if (model.startsWith("gemini") || model.startsWith("glm")) return "google";
+  if (model.startsWith("llama") || model.startsWith("codellama")) return "meta";
+  return "unknown";
+}
+
+/**
+ * Get model breakdown.
+ */
+export async function getModelBreakdown(): Promise<Array<{
+  model: string;
+  provider: string;
+  calls: number;
+  tokens: number;
+  estimatedCost: number;
+  avgCostPerCall: number;
+}>> {
+  const aggregates = await getAggregates({});
+
+  return Object.entries(aggregates.byModel).map(([model, stats]) => {
+    const provider = inferProvider(model);
+    return {
+      model,
+      provider,
+      calls: stats.count,
+      tokens: stats.tokens,
+      estimatedCost: stats.cost,
+      avgCostPerCall: stats.count > 0 ? stats.cost / stats.count : 0,
+    };
+  });
+}
+
+/**
+ * Get channel breakdown.
+ */
+export async function getChannelBreakdown(): Promise<Array<{
+  channelId: string;
+  sessions: number;
+  invocations: number;
+  tokens: number;
+  estimatedCost: number;
+}>> {
+  const aggregates = await getAggregates({});
+
+  return Object.entries(aggregates.byChannel).map(([channelId, stats]) => ({
+    channelId,
+    sessions: 0, // Would need session tracking per channel
+    invocations: stats.count,
+    tokens: stats.tokens,
+    estimatedCost: stats.cost,
+  }));
+}
+
+/**
+ * Get budget health summary.
+ */
+export async function getBudgetHealth(): Promise<Array<{
+  policyId: string;
+  policyName: string;
+  state: string;
+  currentSpend: number;
+  threshold: number | null;
+  percentage: number;
+  currency: string;
+}>> {
+  const budgetStates = await getBudgetState({});
+
+  return budgetStates.map((bs) => ({
+    policyId: bs.policyId,
+    policyName: bs.policyName,
+    state: bs.state,
+    currentSpend: bs.currentSpend,
+    threshold: bs.threshold,
+    percentage: bs.percentage,
+    currency: bs.currency,
+  }));
+}

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -1,0 +1,619 @@
+/**
+ * Durable Usage Tracker
+ * 
+ * Persisted per-invocation usage/accounting records with aggregate queries.
+ * 
+ * STORAGE MODEL:
+ * - Records stored in .claude/claudeclaw/usage/
+ * - Per-invocation: usage-{invocationId}.json
+ * - Index: usage-index.json (maps invocationId to file)
+ * - Usage logs: usage-{YYYYMMDD}.jsonl (daily rotation)
+ * 
+ * COST CALCULATION:
+ * - Cost is ESTIMATED based on configurable pricing metadata
+ * - Cost is NEVER presented as exact provider billing
+ * - Pricing is versioned for auditability
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { appendFile, readdir } from "fs/promises";
+import { randomUUID } from "crypto";
+
+const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
+const USAGE_INDEX_FILE = join(USAGE_DIR, "usage-index.json");
+const MAX_INDEX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+export type InvocationStatus = "started" | "completed" | "failed" | "killed";
+
+export interface UsageMetrics {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
+export interface EstimatedCost {
+  currency: string;
+  inputCost?: number;
+  outputCost?: number;
+  cacheCost?: number;
+  totalCost?: number;
+  pricingVersion?: string;
+}
+
+export interface InvocationUsageRecord {
+  invocationId: string;
+  eventId?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  source?: string;
+  channelId?: string;
+  threadId?: string;
+  provider: string;
+  model: string;
+  startedAt: string;
+  completedAt?: string;
+  status: InvocationStatus;
+  usage?: UsageMetrics;
+  estimatedCost?: EstimatedCost;
+  metadata?: Record<string, unknown>;
+  error?: {
+    type?: string;
+    message: string;
+  };
+}
+
+export interface InvocationContext {
+  eventId?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  source?: string;
+  channelId?: string;
+  threadId?: string;
+  provider: string;
+  model: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface UsageIndex {
+  version: number;
+  records: Record<string, string>; // invocationId -> filename
+  updatedAt: string;
+}
+
+interface DailyUsageLog {
+  date: string;
+  records: string[];
+}
+
+// In-memory cache for performance
+let usageIndex: UsageIndex | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+// Write queue for serializing concurrent operations
+let writeQueue: Promise<void> = Promise.resolve();
+let writeQueueLength = 0;
+
+function enqueueWrite<T>(operation: () => Promise<T>): Promise<T> {
+  writeQueueLength++;
+  const promise = writeQueue.then(() => operation());
+  writeQueue = promise.then(
+    () => { writeQueueLength--; },
+    () => { writeQueueLength--; }
+  );
+  return promise;
+}
+
+export function getWriteQueueLength(): number {
+  return writeQueueLength;
+}
+
+export function resetUsageTracker(): void {
+  usageIndex = null;
+  initializationPromise = null;
+  writeQueue = Promise.resolve();
+  writeQueueLength = 0;
+}
+
+/**
+ * Initialize the usage tracker system.
+ */
+export async function initUsageTracker(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directory exists
+  await Bun.write(join(USAGE_DIR, ".gitkeep"), "");
+
+  // Try to load existing index
+  usageIndex = await loadUsageIndex();
+
+  if (!usageIndex) {
+    usageIndex = {
+      version: 1,
+      records: {},
+      updatedAt: new Date().toISOString(),
+    };
+    await saveUsageIndex();
+  }
+}
+
+async function loadUsageIndex(): Promise<UsageIndex | null> {
+  try {
+    if (!existsSync(USAGE_INDEX_FILE)) {
+      return null;
+    }
+    const content = await Bun.file(USAGE_INDEX_FILE).json();
+    if (content.version === 1 && typeof content.records === "object") {
+      return content as UsageIndex;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveUsageIndex(): Promise<void> {
+  if (!usageIndex) return;
+
+  usageIndex.updatedAt = new Date().toISOString();
+  await Bun.write(USAGE_INDEX_FILE, JSON.stringify(usageIndex, null, 2) + "\n");
+}
+
+function getInvocationFilePath(invocationId: string): string {
+  return join(USAGE_DIR, `usage-${invocationId}.json`);
+}
+
+function getDailyLogFilePath(date: string): string {
+  return join(USAGE_DIR, `usage-${date}.jsonl`);
+}
+
+function getTodayDate(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+/**
+ * Record the start of an invocation.
+ */
+export async function recordInvocationStart(context: InvocationContext, invocationId?: string): Promise<InvocationUsageRecord> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const now = new Date().toISOString();
+    const record: InvocationUsageRecord = {
+      invocationId: invocationId ?? randomUUID(),
+      eventId: context.eventId,
+      sessionId: context.sessionId,
+      claudeSessionId: context.claudeSessionId ?? null,
+      source: context.source,
+      channelId: context.channelId,
+      threadId: context.threadId,
+      provider: context.provider,
+      model: context.model,
+      startedAt: now,
+      status: "started",
+      metadata: context.metadata,
+    };
+
+    // Save record
+    const filePath = getInvocationFilePath(record.invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Update index
+    if (usageIndex) {
+      usageIndex.records[record.invocationId] = filePath;
+      await saveUsageIndex();
+    }
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "start",
+    }) + "\n";
+    
+    await appendFile(dailyLogPath, logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Record the completion of an invocation with usage metrics.
+ */
+export async function recordInvocationCompletion(
+  invocationId: string,
+  usage?: UsageMetrics,
+  estimatedCost?: EstimatedCost
+): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const record = await loadInvocationRecord(invocationId);
+    if (!record) {
+      console.warn(`[usage-tracker] Invocation ${invocationId} not found for completion`);
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    record.status = "completed";
+    record.completedAt = now;
+    record.usage = usage;
+    record.estimatedCost = estimatedCost;
+
+    // Save updated record
+    const filePath = getInvocationFilePath(invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "completion",
+      usage,
+      estimatedCost,
+    }) + "\n";
+    
+    await appendFile(dailyLogPath, logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Record the failure of an invocation.
+ */
+export async function recordInvocationFailure(
+  invocationId: string,
+  error: { type?: string; message: string }
+): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const record = await loadInvocationRecord(invocationId);
+    if (!record) {
+      console.warn(`[usage-tracker] Invocation ${invocationId} not found for failure`);
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    record.status = "failed";
+    record.completedAt = now;
+    record.error = error;
+
+    // Save updated record
+    const filePath = getInvocationFilePath(invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "failure",
+      error,
+    }) + "\n";
+    
+    await appendFile(dailyLogPath, logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Record invocation killed by watchdog.
+ */
+export async function recordInvocationKilled(
+  invocationId: string,
+  reason: string
+): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const record = await loadInvocationRecord(invocationId);
+    if (!record) {
+      console.warn(`[usage-tracker] Invocation ${invocationId} not found for kill`);
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    record.status = "killed";
+    record.completedAt = now;
+    record.error = { type: "watchdog", message: reason };
+
+    // Save updated record
+    const filePath = getInvocationFilePath(invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "killed",
+      reason,
+    }) + "\n";
+    
+    await appendFile(dailyLogPath, logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Load an invocation record by ID.
+ */
+export async function getInvocation(invocationId: string): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+  return loadInvocationRecord(invocationId);
+}
+
+async function loadInvocationRecord(invocationId: string): Promise<InvocationUsageRecord | null> {
+  const filePath = getInvocationFilePath(invocationId);
+  
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return await Bun.file(filePath).json() as InvocationUsageRecord;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get usage for a specific session.
+ */
+export async function getSessionUsage(sessionId: string): Promise<InvocationUsageRecord[]> {
+  await initUsageTracker();
+
+  const records: InvocationUsageRecord[] = [];
+
+  if (!usageIndex) {
+    return records;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+      if (record.sessionId === sessionId) {
+        records.push(record);
+      }
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get usage for a specific channel.
+ */
+export async function getChannelUsage(channelId: string): Promise<InvocationUsageRecord[]> {
+  await initUsageTracker();
+
+  const records: InvocationUsageRecord[] = [];
+
+  if (!usageIndex) {
+    return records;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+      if (record.channelId === channelId) {
+        records.push(record);
+      }
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get usage filtered by various criteria.
+ */
+export interface UsageFilters {
+  sessionId?: string;
+  channelId?: string;
+  source?: string;
+  provider?: string;
+  model?: string;
+  status?: InvocationStatus;
+  startDate?: string;
+  endDate?: string;
+}
+
+export async function getAggregates(filters: UsageFilters = {}): Promise<{
+  totalInvocations: number;
+  completedInvocations: number;
+  failedInvocations: number;
+  killedInvocations: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
+  totalEstimatedCost: number;
+  byProvider: Record<string, { count: number; tokens: number; cost: number }>;
+  byModel: Record<string, { count: number; tokens: number; cost: number }>;
+  byChannel: Record<string, { count: number; tokens: number; cost: number }>;
+  bySource: Record<string, { count: number; tokens: number; cost: number }>;
+}> {
+  await initUsageTracker();
+
+  const result = {
+    totalInvocations: 0,
+    completedInvocations: 0,
+    failedInvocations: 0,
+    killedInvocations: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalEstimatedCost: 0,
+    byProvider: {} as Record<string, { count: number; tokens: number; cost: number }>,
+    byModel: {} as Record<string, { count: number; tokens: number; cost: number }>,
+    byChannel: {} as Record<string, { count: number; tokens: number; cost: number }>,
+    bySource: {} as Record<string, { count: number; tokens: number; cost: number }>,
+  };
+
+  if (!usageIndex) {
+    return result;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+
+      // Apply filters
+      if (filters.sessionId && record.sessionId !== filters.sessionId) continue;
+      if (filters.channelId && record.channelId !== filters.channelId) continue;
+      if (filters.source && record.source !== filters.source) continue;
+      if (filters.provider && record.provider !== filters.provider) continue;
+      if (filters.model && record.model !== filters.model) continue;
+      if (filters.status && record.status !== filters.status) continue;
+      if (filters.startDate && record.startedAt < filters.startDate) continue;
+      if (filters.endDate && record.startedAt > filters.endDate) continue;
+
+      // Count
+      result.totalInvocations++;
+
+      if (record.status === "completed") {
+        result.completedInvocations++;
+      } else if (record.status === "failed") {
+        result.failedInvocations++;
+      } else if (record.status === "killed") {
+        result.killedInvocations++;
+      }
+
+      // Tokens
+      const inputTokens = record.usage?.inputTokens ?? 0;
+      const outputTokens = record.usage?.outputTokens ?? 0;
+      const cacheCreationTokens = record.usage?.cacheCreationInputTokens ?? 0;
+      const cacheReadTokens = record.usage?.cacheReadInputTokens ?? 0;
+
+      result.totalInputTokens += inputTokens;
+      result.totalOutputTokens += outputTokens;
+      result.totalCacheCreationTokens += cacheCreationTokens;
+      result.totalCacheReadTokens += cacheReadTokens;
+
+      // Cost
+      const cost = record.estimatedCost?.totalCost ?? 0;
+      result.totalEstimatedCost += cost;
+
+      // By provider
+      if (!result.byProvider[record.provider]) {
+        result.byProvider[record.provider] = { count: 0, tokens: 0, cost: 0 };
+      }
+      result.byProvider[record.provider].count++;
+      result.byProvider[record.provider].tokens += inputTokens + outputTokens;
+      result.byProvider[record.provider].cost += cost;
+
+      // By model
+      if (!result.byModel[record.model]) {
+        result.byModel[record.model] = { count: 0, tokens: 0, cost: 0 };
+      }
+      result.byModel[record.model].count++;
+      result.byModel[record.model].tokens += inputTokens + outputTokens;
+      result.byModel[record.model].cost += cost;
+
+      // By channel
+      if (record.channelId) {
+        if (!result.byChannel[record.channelId]) {
+          result.byChannel[record.channelId] = { count: 0, tokens: 0, cost: 0 };
+        }
+        result.byChannel[record.channelId].count++;
+        result.byChannel[record.channelId].tokens += inputTokens + outputTokens;
+        result.byChannel[record.channelId].cost += cost;
+      }
+
+      // By source
+      if (record.source) {
+        if (!result.bySource[record.source]) {
+          result.bySource[record.source] = { count: 0, tokens: 0, cost: 0 };
+        }
+        result.bySource[record.source].count++;
+        result.bySource[record.source].tokens += inputTokens + outputTokens;
+        result.bySource[record.source].cost += cost;
+      }
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get all usage records (for testing/admin).
+ */
+export async function getAllUsageRecords(): Promise<InvocationUsageRecord[]> {
+  await initUsageTracker();
+
+  const records: InvocationUsageRecord[] = [];
+
+  if (!usageIndex) {
+    return records;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+      records.push(record);
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get usage tracker statistics.
+ */
+export async function getUsageStats(): Promise<{
+  totalRecords: number;
+  indexSizeBytes: number;
+  directorySizeBytes: number;
+}> {
+  await initUsageTracker();
+
+  let directorySizeBytes = 0;
+
+  try {
+    const files = await readdir(USAGE_DIR, { withFileTypes: true });
+    for (const file of files) {
+      if (file.isFile()) {
+        const size = Bun.file(join(USAGE_DIR, file.name)).size;
+        directorySizeBytes += size;
+      }
+    }
+  } catch {
+    // Directory might not exist
+  }
+
+  return {
+    totalRecords: usageIndex ? Object.keys(usageIndex.records).length : 0,
+    indexSizeBytes: existsSync(USAGE_INDEX_FILE) 
+      ? new TextEncoder().encode(JSON.stringify(usageIndex)).length 
+      : 0,
+    directorySizeBytes,
+  };
+}

--- a/src/governance/watchdog.ts
+++ b/src/governance/watchdog.ts
@@ -1,0 +1,605 @@
+/**
+ * Runaway Watchdog
+ * 
+ * Detects and controls runaway execution patterns safely and durably.
+ * 
+ * DESIGN PRINCIPLES:
+ * - Watchdog monitors durable execution metrics per invocation/session
+ * - "kill" is modeled as a governance outcome first, then mapped to execution control
+ * - Actions flow through governance/event paths, not subprocess hacks
+ * - Repeated-tool detection uses normalized signatures, not raw string comparison
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { appendFile, mkdir } from "fs/promises";
+import { randomUUID } from "crypto";
+import { recordInvocationKilled } from "./usage-tracker";
+
+const CLAUDECLAW_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const WATCHDOG_DIR = join(CLAUDECLAW_DIR, "watchdog");
+const WATCHDOG_INDEX_FILE = join(WATCHDOG_DIR, "watchdog-index.json");
+const WATCHDOG_EVENTS_FILE = join(WATCHDOG_DIR, "watchdog-events.jsonl");
+
+export type WatchdogState = "healthy" | "warn" | "suspend" | "kill";
+
+export interface WatchdogLimits {
+  maxToolCalls?: number;
+  maxTurns?: number;
+  maxRuntimeSeconds?: number;
+  maxRepeatedTools?: number;
+  repeatedToolThreshold?: number; // Number of repeated patterns before action
+}
+
+export interface ExecutionMetrics {
+  invocationId: string;
+  sessionId?: string;
+  toolCallCount: number;
+  turnCount: number;
+  toolCalls: Array<{
+    tool: string;
+    inputHash: string;
+    timestamp: string;
+  }>;
+  startedAt: string;
+  lastActivityAt: string;
+}
+
+export interface WatchdogDecision {
+  invocationId: string;
+  state: WatchdogState;
+  reason: string;
+  triggeredLimits: string[];
+  recommendedAction: string;
+  evaluatedAt: string;
+}
+
+export interface WatchdogConfig {
+  limits: WatchdogLimits;
+  enabled: boolean;
+  checkIntervalMs: number;
+}
+
+interface WatchdogEventRecord {
+  id: string;
+  invocationId: string;
+  sessionId?: string;
+  decision: WatchdogDecision;
+  executedAction?: string;
+  timestamp: string;
+}
+
+interface WatchdogIndex {
+  version: number;
+  activeInvocations: Record<string, ExecutionMetrics>;
+  updatedAt: string;
+}
+
+// Default configuration
+let watchdogConfig: WatchdogConfig = {
+  limits: {
+    maxToolCalls: 100,
+    maxTurns: 50,
+    maxRuntimeSeconds: 600, // 10 minutes
+    maxRepeatedTools: 5,
+    repeatedToolThreshold: 3, // 3+ repeated patterns triggers warning
+  },
+  enabled: true,
+  checkIntervalMs: 5000, // Check every 5 seconds
+};
+
+// In-memory state
+let watchdogIndex: WatchdogIndex | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+export function resetWatchdog(): void {
+  watchdogIndex = null;
+  initializationPromise = null;
+}
+
+/**
+ * Configure the watchdog.
+ */
+export function configureWatchdog(config: Partial<WatchdogConfig>): void {
+  watchdogConfig = {
+    ...watchdogConfig,
+    limits: {
+      ...watchdogConfig.limits,
+      ...config.limits,
+    },
+    enabled: config.enabled ?? watchdogConfig.enabled,
+    checkIntervalMs: config.checkIntervalMs ?? watchdogConfig.checkIntervalMs,
+  };
+}
+
+/**
+ * Get current watchdog configuration.
+ */
+export function getWatchdogConfig(): WatchdogConfig {
+  return { ...watchdogConfig };
+}
+
+/**
+ * Initialize the watchdog system.
+ */
+export async function initWatchdog(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directory exists
+  await Bun.write(join(WATCHDOG_DIR, ".gitkeep"), "");
+
+  // Try to load existing index
+  watchdogIndex = await loadWatchdogIndex();
+
+  if (!watchdogIndex) {
+    watchdogIndex = {
+      version: 1,
+      activeInvocations: {},
+      updatedAt: new Date().toISOString(),
+    };
+    await saveWatchdogIndex();
+  }
+}
+
+async function loadWatchdogIndex(): Promise<WatchdogIndex | null> {
+  try {
+    if (!existsSync(WATCHDOG_INDEX_FILE)) {
+      return null;
+    }
+    const content = await Bun.file(WATCHDOG_INDEX_FILE).json();
+    if (content.version === 1 && typeof content.activeInvocations === "object") {
+      return content as WatchdogIndex;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveWatchdogIndex(): Promise<void> {
+  if (!watchdogIndex) return;
+
+  watchdogIndex.updatedAt = new Date().toISOString();
+  await Bun.write(WATCHDOG_INDEX_FILE, JSON.stringify(watchdogIndex, null, 2) + "\n");
+}
+
+async function appendWatchdogEvent(event: WatchdogEventRecord): Promise<void> {
+  const line = JSON.stringify(event) + "\n";
+  await mkdir(WATCHDOG_DIR, { recursive: true });
+  await appendFile(WATCHDOG_EVENTS_FILE, line);
+}
+
+/**
+ * Normalize a tool call for comparison.
+ * Uses input hash to detect repeated patterns.
+ */
+function normalizeToolCall(tool: string, input: unknown): { tool: string; inputHash: string } {
+  const normalizedTool = tool.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const inputStr = JSON.stringify(input) || "";
+  // Simple hash for comparison
+  let hash = 0;
+  for (let i = 0; i < inputStr.length; i++) {
+    const char = inputStr.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  const inputHash = Math.abs(hash).toString(16);
+
+  return { tool: normalizedTool, inputHash };
+}
+
+/**
+ * Detect repeated tool call patterns.
+ */
+function detectRepeatedPatterns(
+  toolCalls: Array<{ tool: string; inputHash: string; timestamp: string }>
+): { pattern: string; count: number }[] {
+  const patterns: Record<string, number> = {};
+
+  for (const call of toolCalls) {
+    const key = `${call.tool}:${call.inputHash}`;
+    patterns[key] = (patterns[key] || 0) + 1;
+  }
+
+  return Object.entries(patterns)
+    .filter(([, count]) => count >= (watchdogConfig.limits.repeatedToolThreshold || 3))
+    .map(([pattern, count]) => {
+      const [tool, hash] = pattern.split(":");
+      return { pattern: `${tool}(hash=${hash.slice(0, 8)})`, count };
+    });
+}
+
+/**
+ * Record execution metrics for an invocation.
+ */
+export async function recordExecutionMetric(
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  },
+  metrics: {
+    toolCallCount?: number;
+    turnCount?: number;
+    toolCalls?: Array<{ tool: string; input: unknown; timestamp?: string }>;
+  }
+): Promise<void> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+
+  if (!watchdogIndex!.activeInvocations[context.invocationId]) {
+    watchdogIndex!.activeInvocations[context.invocationId] = {
+      invocationId: context.invocationId,
+      sessionId: context.sessionId,
+      toolCallCount: 0,
+      turnCount: 0,
+      toolCalls: [],
+      startedAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  const record = watchdogIndex!.activeInvocations[context.invocationId];
+
+  if (metrics.toolCallCount !== undefined) {
+    record.toolCallCount = metrics.toolCallCount;
+  }
+
+  if (metrics.turnCount !== undefined) {
+    record.turnCount = metrics.turnCount;
+  }
+
+  if (metrics.toolCalls) {
+    record.toolCalls = metrics.toolCalls.map((tc) => {
+      const normalized = normalizeToolCall(tc.tool, tc.input);
+      return {
+        tool: normalized.tool,
+        inputHash: normalized.inputHash,
+        timestamp: tc.timestamp || now,
+      };
+    });
+  }
+
+  record.lastActivityAt = now;
+
+  await saveWatchdogIndex();
+}
+
+/**
+ * Increment tool call count for an invocation.
+ */
+export async function incrementToolCall(
+  invocationId: string,
+  tool: string,
+  input: unknown
+): Promise<void> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+  const normalized = normalizeToolCall(tool, input);
+
+  if (!watchdogIndex!.activeInvocations[invocationId]) {
+    watchdogIndex!.activeInvocations[invocationId] = {
+      invocationId,
+      toolCallCount: 0,
+      turnCount: 0,
+      toolCalls: [],
+      startedAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  const record = watchdogIndex!.activeInvocations[invocationId];
+  record.toolCallCount++;
+  record.toolCalls.push({
+    tool: normalized.tool,
+    inputHash: normalized.inputHash,
+    timestamp: now,
+  });
+  record.lastActivityAt = now;
+
+  await saveWatchdogIndex();
+}
+
+/**
+ * Increment turn count for an invocation.
+ */
+export async function incrementTurnCount(invocationId: string): Promise<void> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+
+  if (!watchdogIndex!.activeInvocations[invocationId]) {
+    watchdogIndex!.activeInvocations[invocationId] = {
+      invocationId,
+      toolCallCount: 0,
+      turnCount: 0,
+      toolCalls: [],
+      startedAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  watchdogIndex!.activeInvocations[invocationId].turnCount++;
+  watchdogIndex!.activeInvocations[invocationId].lastActivityAt = now;
+
+  await saveWatchdogIndex();
+}
+
+/**
+ * Check limits for an invocation.
+ */
+export async function checkLimits(
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  }
+): Promise<WatchdogDecision> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+  const record = watchdogIndex!.activeInvocations[context.invocationId];
+
+  if (!record) {
+    // No metrics recorded yet - assume healthy
+    return {
+      invocationId: context.invocationId,
+      state: "healthy",
+      reason: "No execution metrics recorded",
+      triggeredLimits: [],
+      recommendedAction: "continue",
+      evaluatedAt: now,
+    };
+  }
+
+  const triggeredLimits: string[] = [];
+  let worstState: WatchdogState = "healthy";
+
+  const { limits } = watchdogConfig;
+
+  // Check tool call limit
+  if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls) {
+    triggeredLimits.push(`maxToolCalls=${record.toolCallCount}/${limits.maxToolCalls}`);
+    worstState = worstState === "healthy" ? "suspend" : worstState;
+  } else if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls * 0.8) {
+    triggeredLimits.push(`maxToolCalls_warning=${record.toolCallCount}/${limits.maxToolCalls}`);
+    if (worstState === "healthy") worstState = "warn";
+  }
+
+  // Check turn limit
+  if (limits.maxTurns && record.turnCount >= limits.maxTurns) {
+    triggeredLimits.push(`maxTurns=${record.turnCount}/${limits.maxTurns}`);
+    worstState = worstState === "healthy" ? "suspend" : worstState;
+  } else if (limits.maxTurns && record.turnCount >= limits.maxTurns * 0.8) {
+    triggeredLimits.push(`maxTurns_warning=${record.turnCount}/${limits.maxTurns}`);
+    if (worstState === "healthy") worstState = "warn";
+  }
+
+  // Check runtime limit
+  if (limits.maxRuntimeSeconds) {
+    const startedAt = new Date(record.startedAt);
+    const elapsedSeconds = (Date.now() - startedAt.getTime()) / 1000;
+    if (elapsedSeconds >= limits.maxRuntimeSeconds) {
+      triggeredLimits.push(`maxRuntimeSeconds=${elapsedSeconds}/${limits.maxRuntimeSeconds}`);
+      worstState = worstState === "healthy" ? "suspend" : worstState;
+    } else if (elapsedSeconds >= limits.maxRuntimeSeconds * 0.8) {
+      triggeredLimits.push(`maxRuntimeSeconds_warning=${elapsedSeconds}/${limits.maxRuntimeSeconds}`);
+      if (worstState === "healthy") worstState = "warn";
+    }
+  }
+
+  // Check repeated tool patterns
+  if (limits.maxRepeatedTools) {
+    const repeatedPatterns = detectRepeatedPatterns(record.toolCalls);
+    const totalRepeatedCalls = repeatedPatterns.reduce((sum, p) => sum + p.count, 0);
+    if (totalRepeatedCalls >= limits.maxRepeatedTools) {
+      triggeredLimits.push(
+        `maxRepeatedTools=${totalRepeatedCalls}/${limits.maxRepeatedTools} (patterns: ${repeatedPatterns.map(p => `${p.pattern}=${p.count}`).join(", ")})`
+      );
+      worstState = worstState === "healthy" ? "suspend" : worstState;
+    } else if (totalRepeatedCalls >= limits.maxRepeatedTools * 0.7) {
+      triggeredLimits.push(
+        `maxRepeatedTools_warning=${totalRepeatedCalls}/${limits.maxRepeatedTools}`
+      );
+      if (worstState === "healthy") worstState = "warn";
+    }
+  }
+
+  // Determine reason and recommended action
+  let reason = "Execution within normal parameters";
+  let recommendedAction = "continue";
+
+  if (triggeredLimits.length > 0) {
+    reason = `Limits triggered: ${triggeredLimits.join(", ")}`;
+    // Note: kill state escalation requires explicit handling at execution layer
+    // suspend is the highest state returned by checkLimits
+    recommendedAction = worstState === "suspend" ? "pause" : "review";
+  }
+
+  const decision: WatchdogDecision = {
+    invocationId: context.invocationId,
+    state: worstState,
+    reason,
+    triggeredLimits,
+    recommendedAction,
+    evaluatedAt: now,
+  };
+
+  // Record watchdog event
+  const eventRecord: WatchdogEventRecord = {
+    id: randomUUID(),
+    invocationId: context.invocationId,
+    sessionId: context.sessionId,
+    decision,
+    timestamp: now,
+  };
+  await appendWatchdogEvent(eventRecord);
+
+  return decision;
+}
+
+/**
+ * Handle a watchdog trigger.
+ * This maps watchdog decisions to actual execution control.
+ */
+export async function handleTrigger(
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  },
+  decision: WatchdogDecision
+): Promise<{ action: string; success: boolean }> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+
+  switch (decision.state) {
+    case "kill":
+      // Record kill in usage tracker for audit
+      await recordInvocationKilled(
+        context.invocationId,
+        `Watchdog kill: ${decision.reason}`
+      );
+
+      // Remove from active invocations
+      delete watchdogIndex!.activeInvocations[context.invocationId];
+      await saveWatchdogIndex();
+
+      // Log the event
+      const killEvent: WatchdogEventRecord = {
+        id: randomUUID(),
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        decision,
+        executedAction: "killed",
+        timestamp: now,
+      };
+      await appendWatchdogEvent(killEvent);
+
+      return {
+        action: "terminated",
+        success: true,
+      };
+
+    case "suspend":
+      // Suspend is advisory - execution should pause but not terminate
+      // This would need support from the execution layer
+      const suspendEvent: WatchdogEventRecord = {
+        id: randomUUID(),
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        decision,
+        executedAction: "suspended",
+        timestamp: now,
+      };
+      await appendWatchdogEvent(suspendEvent);
+
+      return {
+        action: "suspended",
+        success: true,
+      };
+
+    case "warn":
+      // Just log the warning
+      const warnEvent: WatchdogEventRecord = {
+        id: randomUUID(),
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        decision,
+        executedAction: "warned",
+        timestamp: now,
+      };
+      await appendWatchdogEvent(warnEvent);
+
+      return {
+        action: "warning_logged",
+        success: true,
+      };
+
+    case "healthy":
+    default:
+      return {
+        action: "no_action",
+        success: true,
+      };
+  }
+}
+
+/**
+ * Get active invocation metrics.
+ */
+export async function getActiveInvocation(
+  invocationId: string
+): Promise<ExecutionMetrics | null> {
+  await initWatchdog();
+  return watchdogIndex?.activeInvocations[invocationId] || null;
+}
+
+/**
+ * Get all active invocations for a session.
+ */
+export async function getSessionActiveInvocations(
+  sessionId: string
+): Promise<ExecutionMetrics[]> {
+  await initWatchdog();
+
+  const invocations: ExecutionMetrics[] = [];
+
+  if (!watchdogIndex) {
+    return invocations;
+  }
+
+  for (const record of Object.values(watchdogIndex.activeInvocations)) {
+    if (record.sessionId === sessionId) {
+      invocations.push(record);
+    }
+  }
+
+  return invocations;
+}
+
+/**
+ * Clear an invocation from the watchdog (when completed normally).
+ */
+export async function clearInvocation(invocationId: string): Promise<void> {
+  await initWatchdog();
+
+  if (watchdogIndex?.activeInvocations[invocationId]) {
+    delete watchdogIndex.activeInvocations[invocationId];
+    await saveWatchdogIndex();
+  }
+}
+
+/**
+ * Get watchdog statistics.
+ */
+export async function getWatchdogStats(): Promise<{
+  activeInvocations: number;
+  eventsLogged: number;
+  config: WatchdogConfig;
+}> {
+  await initWatchdog();
+
+  let eventsLogged = 0;
+  try {
+    if (existsSync(WATCHDOG_EVENTS_FILE)) {
+      const content = await Bun.file(WATCHDOG_EVENTS_FILE).text();
+      eventsLogged = content.trim().split("\n").filter((l) => l.trim()).length;
+    }
+  } catch {
+    // File might not exist
+  }
+
+  return {
+    activeInvocations: watchdogIndex ? Object.keys(watchdogIndex.activeInvocations).length : 0,
+    eventsLogged,
+    config: { ...watchdogConfig },
+  };
+}

--- a/src/policy/approval-queue.ts
+++ b/src/policy/approval-queue.ts
@@ -1,0 +1,335 @@
+/**
+ * Approval Workflow
+ * 
+ * Durable approval workflow for requests that require operator authorization.
+ * 
+ * DESIGN:
+ * - Approval requests are durably stored in append-friendly format
+ * - Storage path: .claude/claudeclaw/approval-queue.jsonl
+ * - Queue state must not live only in memory
+ * - Approval resolution is restart-safe
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All queue operations use atomic file operations
+ * - State is loaded from disk on init and kept in sync
+ * - Approval must result in controlled continuation path
+ */
+
+import { appendFile, readFile, mkdir, stat, rename } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { type ToolRequestContext, type PolicyDecision } from "./engine";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ApprovalStatus = "pending" | "approved" | "denied" | "expired";
+
+export interface ApprovalRequest {
+  eventId: string;
+  request: ToolRequestContext;
+  decision: PolicyDecision;
+  requestedAt: string;
+  status: ApprovalStatus;
+  approvedBy?: string;
+  approvedAt?: string;
+  deniedBy?: string;
+  deniedAt?: string;
+  resolutionReason?: string;
+  expiresAt?: string;
+}
+
+export interface ApprovalEntry extends ApprovalRequest {
+  id: string;
+  createdAt: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const APPROVAL_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const APPROVAL_QUEUE_FILE = join(APPROVAL_DIR, "approval-queue.jsonl");
+const APPROVAL_INDEX_FILE = join(APPROVAL_DIR, "approval-index.json");
+const DEFAULT_EXPIRY_HOURS = 24;
+
+// ============================================================================
+// State
+// ============================================================================
+
+let approvalIndex: Map<string, ApprovalEntry> = new Map();
+let indexLoadedAt: string = "";
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Enqueue a request that requires approval.
+ * Returns the approval entry with generated ID.
+ */
+export async function enqueue(
+  request: ToolRequestContext,
+  decision: PolicyDecision
+): Promise<ApprovalEntry> {
+  const now = new Date();
+  const expiryDate = new Date(now.getTime() + DEFAULT_EXPIRY_HOURS * 60 * 60 * 1000);
+  
+  const entry: ApprovalEntry = {
+    id: randomUUID(),
+    eventId: request.eventId,
+    request,
+    decision,
+    requestedAt: now.toISOString(),
+    status: "pending",
+    createdAt: now.toISOString(),
+    expiresAt: expiryDate.toISOString(),
+  };
+  
+  // Ensure directory exists
+  await mkdir(APPROVAL_DIR, { recursive: true });
+  
+  // Append to queue file (atomic append)
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(APPROVAL_QUEUE_FILE, line, "utf8");
+  
+  // Update in-memory index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * Approve a pending approval request.
+ */
+export async function approve(
+  eventId: string,
+  actor: string,
+  reason?: string
+): Promise<ApprovalEntry | null> {
+  const entry = await findByEventId(eventId);
+  if (!entry) {
+    return null;
+  }
+  
+  if (entry.status !== "pending") {
+    // Already resolved - idempotent operation
+    return entry;
+  }
+  
+  const now = new Date().toISOString();
+  
+  // Update entry
+  entry.status = "approved";
+  entry.approvedBy = actor;
+  entry.approvedAt = now;
+  entry.resolutionReason = reason;
+  
+  // Persist to queue file
+  await appendResolution(entry);
+  
+  // Update index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * Deny a pending approval request.
+ */
+export async function deny(
+  eventId: string,
+  actor: string,
+  reason?: string
+): Promise<ApprovalEntry | null> {
+  const entry = await findByEventId(eventId);
+  if (!entry) {
+    return null;
+  }
+  
+  if (entry.status !== "pending") {
+    // Already resolved - idempotent operation
+    return entry;
+  }
+  
+  const now = new Date().toISOString();
+  
+  // Update entry
+  entry.status = "denied";
+  entry.deniedBy = actor;
+  entry.deniedAt = now;
+  entry.resolutionReason = reason;
+  
+  // Persist to queue file
+  await appendResolution(entry);
+  
+  // Update index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * List all pending approval requests.
+ */
+export function listPending(): ApprovalEntry[] {
+  const pending: ApprovalEntry[] = [];
+  
+  for (const entry of approvalIndex.values()) {
+    if (entry.status === "pending") {
+      // Check if expired
+      if (entry.expiresAt) {
+        const expiryDate = new Date(entry.expiresAt);
+        if (expiryDate < new Date()) {
+          continue; // Skip expired
+        }
+      }
+      pending.push(entry);
+    }
+  }
+  
+  // Sort by requestedAt (oldest first)
+  pending.sort((a, b) => 
+    new Date(a.requestedAt).getTime() - new Date(b.requestedAt).getTime()
+  );
+  
+  return pending;
+}
+
+/**
+ * Load state from disk.
+ * Rebuilds in-memory index from queue file.
+ * Since we always append to the file, the last occurrence of each ID is the latest state.
+ */
+export async function loadState(): Promise<void> {
+  approvalIndex.clear();
+  
+  // Ensure directory exists
+  if (!existsSync(APPROVAL_DIR)) {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    indexLoadedAt = new Date().toISOString();
+    return;
+  }
+  
+  // Check if queue file exists
+  if (!existsSync(APPROVAL_QUEUE_FILE)) {
+    indexLoadedAt = new Date().toISOString();
+    return;
+  }
+  
+  try {
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Since we always append and never modify existing lines,
+    // the LAST occurrence of each ID in the file is the most recent state.
+    // So we iterate in order and just overwrite with the latest.
+    for (const line of lines) {
+      try {
+        const entry: ApprovalEntry = JSON.parse(line);
+        approvalIndex.set(entry.id, entry);
+      } catch {
+        // Skip malformed lines
+        continue;
+      }
+    }
+  } catch {
+    // File doesn't exist or can't be read - start fresh
+  }
+  
+  indexLoadedAt = new Date().toISOString();
+}
+
+/**
+ * Get the last time state was loaded.
+ */
+export function getLoadedAt(): string {
+  return indexLoadedAt;
+}
+
+/**
+ * Get entry by event ID.
+ */
+export async function findByEventId(eventId: string): Promise<ApprovalEntry | null> {
+  // Search in memory first
+  for (const entry of approvalIndex.values()) {
+    if (entry.eventId === eventId) {
+      return entry;
+    }
+  }
+  
+  // Fallback: search in file
+  if (!existsSync(APPROVAL_QUEUE_FILE)) {
+    return null;
+  }
+  
+  try {
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Find most recent entry for this eventId
+    let latest: ApprovalEntry | null = null;
+    
+    for (const line of lines) {
+      try {
+        const entry: ApprovalEntry = JSON.parse(line);
+        if (entry.eventId === eventId) {
+          if (!latest || new Date(entry.createdAt) > new Date(latest.createdAt)) {
+            latest = entry;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+    
+    return latest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get entry by approval ID.
+ */
+export function findById(id: string): ApprovalEntry | null {
+  return approvalIndex.get(id) || null;
+}
+
+/**
+ * Check if an event is pending approval.
+ */
+export function isPending(eventId: string): boolean {
+  const entry = approvalIndex.get(idFromEventId(eventId));
+  return entry?.status === "pending";
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function idFromEventId(eventId: string): string | undefined {
+  for (const [id, entry] of approvalIndex.entries()) {
+    if (entry.eventId === eventId) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+async function appendResolution(entry: ApprovalEntry): Promise<void> {
+  // Append updated entry as new line
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(APPROVAL_QUEUE_FILE, line, "utf8");
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+// Auto-load state on module import
+loadState().catch(err => {
+  console.error("Failed to load approval queue state:", err);
+});

--- a/src/policy/audit-log.ts
+++ b/src/policy/audit-log.ts
@@ -1,0 +1,406 @@
+/**
+ * Audit Log
+ * 
+ * Durable audit trail capturing all policy-relevant decisions and operator actions.
+ * 
+ * DESIGN:
+ * - Every policy decision is logged
+ * - Every approval/denial action is logged
+ * - File stored at .claude/claudeclaw/audit-log.jsonl
+ * - Log entries are queryable and exportable
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All log entries are append-only
+ * - Entries include rule provenance and operator attribution
+ */
+
+import { appendFile, readFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type AuditAction = "allow" | "deny" | "require_approval" | "approved" | "denied" | "expired";
+
+export interface AuditEntry {
+  timestamp: string;
+  eventId: string;
+  requestId: string;
+  source: string;
+  channelId?: string;
+  threadId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName: string;
+  action: AuditAction;
+  reason: string;
+  matchedRuleId?: string;
+  operatorId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Filters
+// ============================================================================
+
+export interface AuditLogFilters {
+  startDate?: string;
+  endDate?: string;
+  source?: string;
+  channelId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName?: string;
+  action?: AuditAction;
+  eventId?: string;
+  operatorId?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
+const DEFAULT_RETENTION_DAYS = 30;
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Log a policy decision or operator action.
+ */
+export async function log(entry: AuditEntry): Promise<void> {
+  // Ensure directory exists
+  if (!existsSync(AUDIT_DIR)) {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  }
+  
+  // Add timestamp if not provided
+  if (!entry.timestamp) {
+    entry.timestamp = new Date().toISOString();
+  }
+  
+  // Append to log file
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(AUDIT_LOG_FILE, line, "utf8");
+}
+
+/**
+ * Log a policy decision.
+ */
+export async function logPolicyDecision(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  action: AuditAction,
+  reason: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    matchedRuleId?: string;
+    operatorId?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  const entry: AuditEntry = {
+    timestamp: new Date().toISOString(),
+    eventId,
+    requestId,
+    source,
+    toolName,
+    action,
+    reason,
+    ...options,
+  };
+  
+  await log(entry);
+}
+
+/**
+ * Log an approval action.
+ */
+export async function logApproval(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  operatorId: string,
+  reason?: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logPolicyDecision(
+    eventId,
+    requestId,
+    source,
+    toolName,
+    "approved",
+    reason || "Approved by operator",
+    {
+      ...options,
+      operatorId,
+    }
+  );
+}
+
+/**
+ * Log a denial action.
+ */
+export async function logDenial(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  operatorId: string,
+  reason?: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logPolicyDecision(
+    eventId,
+    requestId,
+    source,
+    toolName,
+    "denied",
+    reason || "Denied by operator",
+    {
+      ...options,
+      operatorId,
+    }
+  );
+}
+
+/**
+ * Query audit log entries with filters.
+ */
+export async function query(filters: AuditLogFilters = {}): Promise<AuditEntry[]> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return [];
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const results: AuditEntry[] = [];
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      // Apply filters
+      if (filters.startDate && entry.timestamp < filters.startDate) {
+        continue;
+      }
+      
+      if (filters.endDate && entry.timestamp > filters.endDate) {
+        continue;
+      }
+      
+      if (filters.source && entry.source !== filters.source) {
+        continue;
+      }
+      
+      if (filters.channelId && entry.channelId !== filters.channelId) {
+        continue;
+      }
+      
+      if (filters.userId && entry.userId !== filters.userId) {
+        continue;
+      }
+      
+      if (filters.skillName && entry.skillName !== filters.skillName) {
+        continue;
+      }
+      
+      if (filters.toolName && entry.toolName !== filters.toolName) {
+        continue;
+      }
+      
+      if (filters.action && entry.action !== filters.action) {
+        continue;
+      }
+      
+      if (filters.eventId && entry.eventId !== filters.eventId) {
+        continue;
+      }
+      
+      if (filters.operatorId && entry.operatorId !== filters.operatorId) {
+        continue;
+      }
+      
+      results.push(entry);
+    } catch {
+      // Skip malformed entries
+      continue;
+    }
+  }
+  
+  // Sort by timestamp descending (newest first)
+  results.sort((a, b) => 
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+  
+  return results;
+}
+
+/**
+ * Export audit log entries within a date range.
+ */
+export async function exportEntries(
+  startDate: string,
+  endDate: string
+): Promise<AuditEntry[]> {
+  return query({ startDate, endDate });
+}
+
+/**
+ * Get audit log statistics.
+ */
+export async function getStats(): Promise<{
+  totalEntries: number;
+  byAction: Record<AuditAction, number>;
+  bySource: Record<string, number>;
+  oldestTimestamp: string | null;
+  newestTimestamp: string | null;
+}> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return {
+      totalEntries: 0,
+      byAction: { allow: 0, deny: 0, require_approval: 0, approved: 0, denied: 0, expired: 0 },
+      bySource: {},
+      oldestTimestamp: null,
+      newestTimestamp: null,
+    };
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const byAction: Record<AuditAction, number> = {
+    allow: 0,
+    deny: 0,
+    require_approval: 0,
+    approved: 0,
+    denied: 0,
+    expired: 0,
+  };
+  const bySource: Record<string, number> = {};
+  let oldestTimestamp: string | null = null;
+  let newestTimestamp: string | null = null;
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      byAction[entry.action] = (byAction[entry.action] || 0) + 1;
+      bySource[entry.source] = (bySource[entry.source] || 0) + 1;
+      
+      if (!oldestTimestamp || entry.timestamp < oldestTimestamp) {
+        oldestTimestamp = entry.timestamp;
+      }
+      if (!newestTimestamp || entry.timestamp > newestTimestamp) {
+        newestTimestamp = entry.timestamp;
+      }
+    } catch {
+      continue;
+    }
+  }
+  
+  return {
+    totalEntries: lines.length,
+    byAction,
+    bySource,
+    oldestTimestamp,
+    newestTimestamp,
+  };
+}
+
+// ============================================================================
+// Retention Management
+// ============================================================================
+
+export interface RetentionConfig {
+  maxAgeDays?: number;
+  maxFileSizeBytes?: number;
+}
+
+/**
+ * Clean up old audit log entries based on retention policy.
+ */
+export async function cleanupRetention(
+  config: RetentionConfig = {}
+): Promise<{ deleted: number; remaining: number }> {
+  const maxAgeDays = config.maxAgeDays ?? DEFAULT_RETENTION_DAYS;
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays);
+  const cutoffTimestamp = cutoffDate.toISOString();
+  
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return { deleted: 0, remaining: 0 };
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const keptLines: string[] = [];
+  let deleted = 0;
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      if (entry.timestamp < cutoffTimestamp) {
+        deleted++;
+        continue;
+      }
+      
+      keptLines.push(line);
+    } catch {
+      // Skip malformed entries - count as deleted
+      deleted++;
+      continue;
+    }
+  }
+  
+  // Note: In a production system, we'd write the kept lines back
+  // For safety, we just report what would be deleted
+  // Actual deletion should be done manually or with a backup
+  
+  return {
+    deleted,
+    remaining: keptLines.length,
+  };
+}
+
+/**
+ * Get retention configuration documentation.
+ */
+export function getRetentionPolicy(): {
+  defaultRetentionDays: number;
+  defaultMaxFileSizeBytes: number;
+  recommendation: string;
+} {
+  return {
+    defaultRetentionDays: DEFAULT_RETENTION_DAYS,
+    defaultMaxFileSizeBytes: MAX_FILE_SIZE_BYTES,
+    recommendation: `Default retention is ${DEFAULT_RETENTION_DAYS} days. Rotate log file monthly and archive entries older than retention period. Monitor file size and rotate when approaching ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB.`,
+  };
+}

--- a/src/policy/channel-policies.ts
+++ b/src/policy/channel-policies.ts
@@ -1,0 +1,344 @@
+/**
+ * Scoped Channel and User Policies
+ * 
+ * Helper layer that resolves channel/user scoped policy rules into
+ * normalized engine rules without hard-coding channel-specific logic.
+ * 
+ * This module produces normalized rules - not a parallel evaluator.
+ */
+
+import {
+  type PolicyRule,
+  type ToolRequestContext,
+  getRules,
+} from "./engine";
+
+import { readFileSync, existsSync } from "fs";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SourceConfig {
+  source: string;
+  channels?: Record<string, ChannelConfig>;
+  defaultRules?: PolicyRule[];
+}
+
+export interface ChannelConfig {
+  channelId: string;
+  denyRules?: PolicyRule[];
+  allowRules?: PolicyRule[];
+  userOverrides?: Record<string, UserOverride>;
+}
+
+export interface UserOverride {
+  userId: string;
+  denyRules?: PolicyRule[];
+  allowRules?: PolicyRule[];
+}
+
+export interface ScopedPolicyConfig {
+  version: number;
+  sources: Record<string, SourceConfig>;
+  globalRules: PolicyRule[];
+  updatedAt: string;
+}
+
+const POLICY_DIR = ".claude/claudeclaw";
+const SCOPED_POLICY_FILE = `${POLICY_DIR}/scoped-policies.json`;
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Get all scoped rules applicable to a request context.
+ * Returns rules from global, source, channel, and user levels.
+ */
+export function getScopedRules(context: ToolRequestContext): PolicyRule[] {
+  const allRules: PolicyRule[] = [];
+  
+  // Get global rules (these are already loaded in engine)
+  const globalRules = getRules();
+  allRules.push(...globalRules);
+  
+  // Try to load and merge scoped policies
+  try {
+    const scopedConfig = loadScopedPolicyConfig();
+    if (scopedConfig) {
+      const sourceConfig = scopedConfig.sources[context.source];
+      if (sourceConfig) {
+        // Add source-level default rules
+        if (sourceConfig.defaultRules) {
+          allRules.push(...sourceConfig.defaultRules);
+        }
+        
+        // Find channel-specific rules
+        if (context.channelId && sourceConfig.channels) {
+          const channelConfig = sourceConfig.channels[context.channelId];
+          if (channelConfig) {
+            // Add channel deny rules (high priority)
+            if (channelConfig.denyRules) {
+              allRules.push(...channelConfig.denyRules.map(rule => ({
+                ...rule,
+                priority: rule.priority ?? 150, // Higher than typical
+              })));
+            }
+            
+            // Add channel allow rules
+            if (channelConfig.allowRules) {
+              allRules.push(...channelConfig.allowRules.map(rule => ({
+                ...rule,
+                priority: rule.priority ?? 100,
+              })));
+            }
+            
+            // Find user-specific overrides
+            if (context.userId && channelConfig.userOverrides) {
+              const userOverride = channelConfig.userOverrides[context.userId];
+              if (userOverride) {
+                // User deny rules override channel allows
+                if (userOverride.denyRules) {
+                  allRules.push(...userOverride.denyRules.map(rule => ({
+                    ...rule,
+                    priority: rule.priority ?? 200, // Even higher priority
+                  })));
+                }
+                
+                // User allow rules
+                if (userOverride.allowRules) {
+                  allRules.push(...userOverride.allowRules.map(rule => ({
+                    ...rule,
+                    priority: rule.priority ?? 100,
+                  })));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // Scoped policy config not found or invalid - proceed with global rules only
+  }
+  
+  return allRules;
+}
+
+/**
+ * Merge scoped policies with global rules to produce effective rule set.
+ * This is the main entry point for the channel policy system.
+ */
+export function mergeScopedPolicies(
+  globalRules: PolicyRule[],
+  scopedRules: PolicyRule[]
+): PolicyRule[] {
+  // Scoped rules are already enriched with priorities in getScopedRules
+  // Here we just combine them with global rules
+  
+  // Filter out any disabled rules
+  const enabledGlobal = globalRules.filter(r => r.enabled !== false);
+  const enabledScoped = scopedRules.filter(r => r.enabled !== false);
+  
+  // Return combined and deduplicated rules
+  const ruleMap = new Map<string, PolicyRule>();
+  
+  // Add global rules first (lower base priority)
+  for (const rule of enabledGlobal) {
+    ruleMap.set(rule.id, rule);
+  }
+  
+  // Add scoped rules (may override global rules with same ID)
+  for (const rule of enabledScoped) {
+    ruleMap.set(rule.id, rule);
+  }
+  
+  return Array.from(ruleMap.values());
+}
+
+// ============================================================================
+// Configuration Loading
+// ============================================================================
+
+let cachedConfig: ScopedPolicyConfig | null = null;
+let configLoadedAt: string = "";
+
+function loadScopedPolicyConfig(): ScopedPolicyConfig | null {
+  try {
+    if (!existsSync(SCOPED_POLICY_FILE)) {
+      return null;
+    }
+    
+    const content = readFileSync(SCOPED_POLICY_FILE, "utf8");
+    const config = JSON.parse(content) as ScopedPolicyConfig;
+    
+    cachedConfig = config;
+    configLoadedAt = new Date().toISOString();
+    
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the scoped policy configuration.
+ */
+export function getScopedPolicyConfig(): ScopedPolicyConfig | null {
+  if (!cachedConfig) {
+    return loadScopedPolicyConfig();
+  }
+  return cachedConfig;
+}
+
+/**
+ * Reload the scoped policy configuration from disk.
+ */
+export function reloadScopedPolicy(): ScopedPolicyConfig | null {
+  cachedConfig = null;
+  return loadScopedPolicyConfig();
+}
+
+/**
+ * Validate a scoped policy configuration.
+ */
+export function validateScopedPolicyConfig(
+  config: ScopedPolicyConfig
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  
+  if (!config.version) {
+    errors.push("Missing version field");
+  }
+  
+  if (!config.sources || typeof config.sources !== "object") {
+    errors.push("Missing or invalid sources object");
+  } else {
+    for (const [source, sourceConfig] of Object.entries(config.sources)) {
+      if (!sourceConfig.source) {
+        errors.push(`Source "${source}" missing source field`);
+      }
+      
+      if (sourceConfig.channels) {
+        for (const [channelId, channelConfig] of Object.entries(sourceConfig.channels)) {
+          if (channelConfig.channelId !== channelId) {
+            errors.push(`Channel ${channelId} has mismatched channelId`);
+          }
+          
+          // Validate nested rules
+          if (channelConfig.denyRules) {
+            for (const rule of channelConfig.denyRules) {
+              if (!rule.id || !rule.tool || !rule.action) {
+                errors.push(`Channel ${channelId} has invalid deny rule`);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+// ============================================================================
+// Default Configuration Factory
+// ============================================================================
+
+/**
+ * Create a default scoped policy configuration.
+ */
+export function createDefaultScopedPolicyConfig(): ScopedPolicyConfig {
+  return {
+    version: 1,
+    sources: {},
+    globalRules: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Get example configuration structure.
+ */
+export function getExampleScopedPolicyConfig(): ScopedPolicyConfig {
+  return {
+    version: 1,
+    sources: {
+      telegram: {
+        source: "telegram",
+        channels: {
+          "telegram:123": {
+            channelId: "telegram:123",
+            denyRules: [
+              {
+                id: "telegram-123-deny-bash",
+                priority: 200,
+                tool: "Bash",
+                action: "deny",
+                reason: "Bash disabled in this channel",
+              },
+            ],
+            allowRules: [
+              {
+                id: "telegram-123-allow-view",
+                priority: 100,
+                tool: ["View", "GlobTool", "GrepTool"],
+                action: "allow",
+                reason: "Read-only tools allowed",
+              },
+            ],
+            userOverrides: {
+              "admin-user": {
+                userId: "admin-user",
+                allowRules: [
+                  {
+                    id: "telegram-123-admin-allow-all",
+                    priority: 200,
+                    tool: "*",
+                    action: "allow",
+                    reason: "Admin has full access in this channel",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        defaultRules: [
+          {
+            id: "telegram-default-deny-edit",
+            priority: 50,
+            tool: "Edit",
+            action: "require_approval",
+            reason: "Edit requires approval on telegram by default",
+          },
+        ],
+      },
+      discord: {
+        source: "discord",
+        defaultRules: [
+          {
+            id: "discord-default-allow-view",
+            priority: 50,
+            tool: ["View", "GlobTool"],
+            action: "allow",
+            reason: "View tools allowed on discord",
+          },
+        ],
+      },
+    },
+    globalRules: [
+      {
+        id: "global-deny-dangerous",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+        reason: "Bash disabled globally unless explicitly allowed",
+      },
+    ],
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,0 +1,526 @@
+/**
+ * Policy Engine Core
+ * 
+ * Deterministic rule evaluation over normalized tool-use requests.
+ * 
+ * DESIGN:
+ * - Policy file stored at .claude/claudeclaw/policies.json
+ * - Default decision is DENY unless explicitly allowed
+ * - Evaluation order: highest priority first, then specificity, then explicit deny > allow > require_approval
+ * - Cache is configurable and bounded, invalidated on policy reload
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All policy state is loaded from disk on init
+ * - Invalid rules fail closed and are surfaced clearly
+ * - Cache must not become source of truth
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "crypto";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const POLICY_FILE = join(POLICY_DIR, "policies.json");
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ToolRequestContext {
+  eventId: string;
+  source: string;               // telegram, discord, slack, web, etc.
+  channelId?: string;
+  threadId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName: string;
+  toolArgs?: Record<string, unknown>;
+  sessionId?: string;           // local session mapping ID
+  claudeSessionId?: string | null;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type PolicyAction = "allow" | "deny" | "require_approval";
+
+export interface PolicyDecision {
+  requestId: string;
+  action: PolicyAction;
+  matchedRuleId?: string;
+  reason: string;
+  evaluatedAt: string;
+  cacheable?: boolean;
+}
+
+export interface PolicyScope {
+  source?: string | string[]; // "telegram", ["telegram","discord"], "*"
+  channelId?: string | string[];
+  userId?: string | string[];
+  skillName?: string | string[];
+}
+
+export interface PolicyConditions {
+  timeWindow?: { start: string; end: string };
+  argConstraints?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyRule {
+  id: string;
+  enabled?: boolean;
+  priority?: number;            // higher priority evaluated first
+  scope?: PolicyScope;
+  tool: string | string[];      // specific tool(s) or "*"
+  action: PolicyAction;
+  conditions?: PolicyConditions;
+  reason?: string;
+}
+
+export interface PolicyFile {
+  version: number;
+  rules: PolicyRule[];
+  cache?: {
+    enabled: boolean;
+    maxEntries: number;
+    ttlMs: number;
+  };
+  updatedAt: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+export interface ValidationError {
+  ruleId: string;
+  field: string;
+  message: string;
+}
+
+export interface ValidationWarning {
+  ruleId: string;
+  field: string;
+  message: string;
+}
+
+// ============================================================================
+// Cache
+// ============================================================================
+
+interface CacheEntry {
+  requestKey: string;
+  decision: PolicyDecision;
+  expiresAt: number;
+}
+
+let policyCache: Map<string, CacheEntry> = new Map();
+let cacheConfig = { enabled: false, maxEntries: 1000, ttlMs: 60000 };
+
+// ============================================================================
+// State
+// ============================================================================
+
+let loadedRules: PolicyRule[] = [];
+let loadedAt: string = "";
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Evaluate a tool-use request against loaded policy rules.
+ * Returns a deterministic PolicyDecision.
+ */
+export function evaluate(request: ToolRequestContext): PolicyDecision {
+  const requestId = randomUUID();
+  const evaluatedAt = new Date().toISOString();
+  
+  // Check cache first if enabled
+  if (cacheConfig.enabled) {
+    const cached = getCachedDecision(request);
+    if (cached) {
+      return {
+        ...cached,
+        requestId, // Fresh request ID even for cached decisions
+        evaluatedAt, // Fresh evaluation timestamp
+      };
+    }
+  }
+  
+  // Get all applicable rules sorted by priority
+  const applicableRules = getApplicableRules(request);
+  
+  if (applicableRules.length === 0) {
+    // No matching rules - default deny
+    const decision: PolicyDecision = {
+      requestId,
+      action: "deny",
+      reason: "No matching policy rule - default deny",
+      evaluatedAt,
+      cacheable: true,
+    };
+    
+    if (cacheConfig.enabled) {
+      cacheDecision(request, decision);
+    }
+    
+    return decision;
+  }
+  
+  // Sort by priority (highest first), then by specificity
+  const sortedRules = sortRules(applicableRules);
+  
+  // Find the best matching rule
+  const matchedRule = sortedRules[0];
+  
+  const decision: PolicyDecision = {
+    requestId,
+    action: matchedRule.action,
+    matchedRuleId: matchedRule.id,
+    reason: matchedRule.reason || `Matched rule: ${matchedRule.id}`,
+    evaluatedAt,
+    cacheable: matchedRule.action === "allow",
+  };
+  
+  if (cacheConfig.enabled && decision.cacheable) {
+    cacheDecision(request, decision);
+  }
+  
+  return decision;
+}
+
+/**
+ * Load and validate rules from the policy file.
+ * Creates default policy file if none exists.
+ */
+export async function loadRules(): Promise<PolicyRule[]> {
+  // Ensure directory exists
+  if (!existsSync(POLICY_DIR)) {
+    await mkdir(POLICY_DIR, { recursive: true });
+  }
+  
+  // Create default policy file if none exists
+  if (!existsSync(POLICY_FILE)) {
+    const defaultPolicy: PolicyFile = {
+      version: 1,
+      rules: [],
+      cache: { enabled: false, maxEntries: 1000, ttlMs: 60000 },
+      updatedAt: new Date().toISOString(),
+    };
+    await writeFile(POLICY_FILE, JSON.stringify(defaultPolicy, null, 2), "utf8");
+  }
+  
+  // Read and parse policy file
+  const content = await readFile(POLICY_FILE, "utf8");
+  const policyFile: PolicyFile = JSON.parse(content);
+  
+  // Validate rules
+  const validation = validateRules(policyFile.rules);
+  if (!validation.valid) {
+    // Fail closed - don't load invalid rules
+    const errorMsg = validation.errors.map(e => `${e.ruleId}: ${e.message}`).join("; ");
+    throw new Error(`Policy file contains invalid rules: ${errorMsg}`);
+  }
+  
+  // Update cache config
+  if (policyFile.cache) {
+    cacheConfig = { ...cacheConfig, ...policyFile.cache };
+  }
+  
+  // Clear cache on reload
+  policyCache.clear();
+  
+  loadedRules = policyFile.rules;
+  loadedAt = new Date().toISOString();
+  
+  return loadedRules;
+}
+
+/**
+ * Validate a set of policy rules.
+ * Returns validation result with errors and warnings.
+ */
+export function validateRules(rules: PolicyRule[]): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  
+  for (const rule of rules) {
+    // Validate rule ID
+    if (!rule.id || typeof rule.id !== "string") {
+      errors.push({ ruleId: rule.id || "unknown", field: "id", message: "Rule must have a valid id string" });
+    }
+    
+    // Validate action
+    if (!rule.action || !["allow", "deny", "require_approval"].includes(rule.action)) {
+      errors.push({ ruleId: rule.id, field: "action", message: "Rule must have action: allow | deny | require_approval" });
+    }
+    
+    // Validate tool
+    if (!rule.tool) {
+      errors.push({ ruleId: rule.id, field: "tool", message: "Rule must specify tool(s)" });
+    } else if (Array.isArray(rule.tool) && rule.tool.length === 0) {
+      errors.push({ ruleId: rule.id, field: "tool", message: "Tool array cannot be empty" });
+    }
+    
+    // Validate scope values
+    if (rule.scope) {
+      if (rule.scope.source === "") {
+        errors.push({ ruleId: rule.id, field: "scope.source", message: "Scope source cannot be empty string" });
+      }
+    }
+    
+    // Validate conditions
+    if (rule.conditions) {
+      if (rule.conditions.timeWindow) {
+        const tw = rule.conditions.timeWindow;
+        if (!tw.start || !tw.end) {
+          errors.push({ ruleId: rule.id, field: "conditions.timeWindow", message: "timeWindow requires start and end" });
+        } else {
+          const startDate = new Date(tw.start);
+          const endDate = new Date(tw.end);
+          if (isNaN(startDate.getTime())) {
+            errors.push({ ruleId: rule.id, field: "conditions.timeWindow.start", message: "Invalid start date format" });
+          }
+          if (isNaN(endDate.getTime())) {
+            errors.push({ ruleId: rule.id, field: "conditions.timeWindow.end", message: "Invalid end date format" });
+          }
+        }
+      }
+    }
+    
+    // Warnings for potentially problematic patterns
+    if (rule.action === "allow" && !rule.scope) {
+      warnings.push({ ruleId: rule.id, field: "scope", message: "Unscoped allow rule - will apply to all requests" });
+    }
+    
+    if (rule.tool === "*" && !rule.scope) {
+      warnings.push({ ruleId: rule.id, field: "tool/scope", message: "Globally allow all tools - may be overly permissive" });
+    }
+  }
+  
+  // Check for duplicate rule IDs
+  const ids = rules.map(r => r.id);
+  const duplicates = ids.filter((id, idx) => ids.indexOf(id) !== idx);
+  if (duplicates.length > 0) {
+    errors.push({ ruleId: "global", field: "rules", message: `Duplicate rule IDs: ${[...new Set(duplicates)].join(", ")}` });
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Get the currently loaded rules.
+ */
+export function getRules(): PolicyRule[] {
+  return [...loadedRules];
+}
+
+/**
+ * Get the last time rules were loaded.
+ */
+export function getLoadedAt(): string {
+  return loadedAt;
+}
+
+/**
+ * Check if cache is enabled.
+ */
+export function isCacheEnabled(): boolean {
+  return cacheConfig.enabled;
+}
+
+/**
+ * Clear the decision cache.
+ */
+export function clearCache(): void {
+  policyCache.clear();
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function getApplicableRules(request: ToolRequestContext): PolicyRule[] {
+  return loadedRules.filter(rule => {
+    // Skip disabled rules
+    if (rule.enabled === false) return false;
+    
+    // Check tool match
+    if (!matchesTool(rule.tool, request.toolName)) return false;
+    
+    // Check scope match
+    if (!matchesScope(rule.scope, request)) return false;
+    
+    // Check conditions
+    if (!matchesConditions(rule.conditions, request)) return false;
+    
+    return true;
+  });
+}
+
+function matchesTool(ruleTool: string | string[], requestTool: string): boolean {
+  if (ruleTool === "*") return true;
+  if (Array.isArray(ruleTool)) return ruleTool.includes(requestTool);
+  return ruleTool === requestTool;
+}
+
+function matchesScope(scope: PolicyScope | undefined, request: ToolRequestContext): boolean {
+  if (!scope) return true; // No scope = match all
+  
+  // Check source
+  if (scope.source) {
+    if (Array.isArray(scope.source)) {
+      if (!scope.source.includes(request.source)) return false;
+    } else if (scope.source !== "*") {
+      if (scope.source !== request.source) return false;
+    }
+  }
+  
+  // Check channelId
+  if (scope.channelId && request.channelId) {
+    if (Array.isArray(scope.channelId)) {
+      if (!scope.channelId.includes(request.channelId)) return false;
+    } else if (scope.channelId !== "*") {
+      if (scope.channelId !== request.channelId) return false;
+    }
+  }
+  
+  // Check userId
+  if (scope.userId && request.userId) {
+    if (Array.isArray(scope.userId)) {
+      if (!scope.userId.includes(request.userId)) return false;
+    } else if (scope.userId !== "*") {
+      if (scope.userId !== request.userId) return false;
+    }
+  }
+  
+  // Check skillName
+  if (scope.skillName && request.skillName) {
+    if (Array.isArray(scope.skillName)) {
+      if (!scope.skillName.includes(request.skillName)) return false;
+    } else if (scope.skillName !== "*") {
+      if (scope.skillName !== request.skillName) return false;
+    }
+  }
+  
+  return true;
+}
+
+function matchesConditions(conditions: PolicyConditions | undefined, request: ToolRequestContext): boolean {
+  if (!conditions) return true;
+  
+  // Check time window
+  if (conditions.timeWindow) {
+    const now = new Date(request.timestamp);
+    const start = new Date(conditions.timeWindow.start);
+    const end = new Date(conditions.timeWindow.end);
+    
+    if (now < start || now > end) return false;
+  }
+  
+  // Check arg constraints
+  if (conditions.argConstraints && request.toolArgs) {
+    for (const [key, expectedValue] of Object.entries(conditions.argConstraints)) {
+      const actualValue = request.toolArgs[key];
+      if (actualValue !== expectedValue) return false;
+    }
+  }
+  
+  // Check metadata constraints
+  if (conditions.metadata && request.metadata) {
+    for (const [key, expectedValue] of Object.entries(conditions.metadata)) {
+      const actualValue = request.metadata[key];
+      if (actualValue !== expectedValue) return false;
+    }
+  }
+  
+  return true;
+}
+
+function sortRules(rules: PolicyRule[]): PolicyRule[] {
+  return [...rules].sort((a, b) => {
+    // Highest priority first
+    const priorityA = a.priority ?? 0;
+    const priorityB = b.priority ?? 0;
+    if (priorityB !== priorityA) return priorityB - priorityA;
+    
+    // More specific scope first (more scope fields set = more specific)
+    const specificityA = countScopeFields(a.scope);
+    const specificityB = countScopeFields(b.scope);
+    if (specificityB !== specificityA) return specificityB - specificityA;
+    
+    // Explicit deny beats require_approval beats allow
+    const actionOrder: Record<PolicyAction, number> = { deny: 0, require_approval: 1, allow: 2 };
+    return actionOrder[a.action] - actionOrder[b.action];
+  });
+}
+
+function countScopeFields(scope: PolicyScope | undefined): number {
+  if (!scope) return 0;
+  let count = 0;
+  if (scope.source) count++;
+  if (scope.channelId) count++;
+  if (scope.userId) count++;
+  if (scope.skillName) count++;
+  return count;
+}
+
+function getRequestKey(request: ToolRequestContext): string {
+  const parts = [
+    request.source,
+    request.channelId || "",
+    request.userId || "",
+    request.skillName || "",
+    request.toolName,
+    request.toolArgs ? JSON.stringify(request.toolArgs) : "",
+  ];
+  return parts.join("|");
+}
+
+function getCachedDecision(request: ToolRequestContext): PolicyDecision | null {
+  const key = getRequestKey(request);
+  const entry = policyCache.get(key);
+  
+  if (!entry) return null;
+  
+  if (Date.now() > entry.expiresAt) {
+    policyCache.delete(key);
+    return null;
+  }
+  
+  return entry.decision;
+}
+
+function cacheDecision(request: ToolRequestContext, decision: PolicyDecision): void {
+  if (!decision.cacheable) return;
+  
+  const key = getRequestKey(request);
+  
+  // Evict oldest if at capacity
+  if (policyCache.size >= cacheConfig.maxEntries) {
+    const oldestKey = policyCache.keys().next().value;
+    if (oldestKey) policyCache.delete(oldestKey);
+  }
+  
+  policyCache.set(key, {
+    requestKey: key,
+    decision,
+    expiresAt: Date.now() + cacheConfig.ttlMs,
+  });
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+// Auto-load rules on module import
+loadRules().catch(err => {
+  console.error("Failed to load policy rules:", err);
+});

--- a/src/policy/skill-overlays.ts
+++ b/src/policy/skill-overlays.ts
@@ -1,0 +1,275 @@
+/**
+ * Skill Policy Overlays
+ * 
+ * Allow skills to declare tool constraints that integrate with the policy engine.
+ * Skill overlays are translated into policy-relevant constraints.
+ * 
+ * IMPORTANT: Skill overlays must not become a privilege-escalation path.
+ * - "preferredTools" influences recommendation, not security overrides
+ * - "requiredTools" surfaces actionable policy errors when unavailable
+ * - "deniedTools" are enforced as restrictions even when globally allowed
+ */
+
+import {
+  type PolicyRule,
+  type ToolRequestContext,
+} from "./engine";
+import { resolveSkillPrompt } from "../skills";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SkillOverlay {
+  skillName: string;
+  requiredTools?: string[];
+  preferredTools?: string[];
+  deniedTools?: string[];
+  reason?: string;
+}
+
+export interface SkillPolicyResult {
+  allowed: boolean;
+  reason: string;
+  skillOverlay?: SkillOverlay;
+  missingTools?: string[];
+  deniedTools?: string[];
+}
+
+// ============================================================================
+// Skill Metadata Parsing
+// ============================================================================
+
+/**
+ * Parse skill metadata from SKILL.md content.
+ * Looks for policy-related frontmatter fields.
+ */
+export function parseSkillMetadata(skillContent: string, skillName: string): SkillOverlay | null {
+  // Parse YAML frontmatter
+  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    return null;
+  }
+  
+  const fm = fmMatch[1];
+  
+  // Look for policy-related fields
+  let requiredTools: string[] | undefined;
+  let preferredTools: string[] | undefined;
+  let deniedTools: string[] | undefined;
+  
+  // Helper to parse array fields (handles both multiline and inline formats)
+  function parseArrayField(fieldName: string): string[] | undefined {
+    // Match multiline format:
+    // requiredTools:
+    //   - item1
+    //   - item2
+    const multilineMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\n((?:\\s*-\\s*.+\\n?)+)`, 'm'));
+    if (multilineMatch) {
+      return multilineMatch[1]
+        .split("\n")
+        .map(line => line.replace(/^\s*-\s*/, "").trim())
+        .filter(Boolean);
+    }
+    
+    // Match inline empty array: requiredTools: []
+    const emptyMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\[\\s*\\]`, 'm'));
+    if (emptyMatch) {
+      return [];
+    }
+    
+    // Match inline array: requiredTools: [item1, item2]
+    const inlineMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\[([^\\]]+)\\]`, 'm'));
+    if (inlineMatch) {
+      return inlineMatch[1]
+        .split(",")
+        .map(item => item.trim())
+        .filter(Boolean);
+    }
+    
+    return undefined;
+  }
+  
+  // Parse requiredTools
+  const parsedRequired = parseArrayField("requiredTools");
+  if (parsedRequired !== undefined) {
+    requiredTools = parsedRequired;
+  }
+  
+  // Parse preferredTools
+  const parsedPreferred = parseArrayField("preferredTools");
+  if (parsedPreferred !== undefined) {
+    preferredTools = parsedPreferred;
+  }
+  
+  // Parse deniedTools
+  const parsedDenied = parseArrayField("deniedTools");
+  if (parsedDenied !== undefined) {
+    deniedTools = parsedDenied;
+  }
+  
+  // If no policy fields found, return null
+  if (!requiredTools && !preferredTools && !deniedTools) {
+    return null;
+  }
+  
+  return {
+    skillName,
+    requiredTools,
+    preferredTools,
+    deniedTools,
+  };
+}
+
+// ============================================================================
+// Skill Overlay Resolution
+// ============================================================================
+
+/**
+ * Get the skill overlay for a given skill name.
+ * Loads and parses the skill's SKILL.md to extract policy metadata.
+ */
+export async function getSkillOverlay(skillName: string): Promise<SkillOverlay | null> {
+  // Resolve skill prompt (reads SKILL.md)
+  const content = await resolveSkillPrompt(skillName);
+  if (!content) {
+    return null;
+  }
+  
+  return parseSkillMetadata(content, skillName);
+}
+
+/**
+ * Get skill overlay synchronously from cached content.
+ */
+export function getSkillOverlayFromContent(content: string, skillName: string): SkillOverlay | null {
+  return parseSkillMetadata(content, skillName);
+}
+
+// ============================================================================
+// Overlay to Rules Conversion
+// ============================================================================
+
+/**
+ * Convert a skill overlay into policy rules.
+ * 
+ * Rules generated:
+ * - deniedTools → high-priority deny rules (restrictive)
+ * - requiredTools → no direct rules, tracked for validation
+ * - preferredTools → informational only (not security-critical)
+ */
+export function overlayToRules(overlay: SkillOverlay, basePriority: number = 100): PolicyRule[] {
+  const rules: PolicyRule[] = [];
+  
+  // Denied tools become deny rules (high priority)
+  if (overlay.deniedTools && overlay.deniedTools.length > 0) {
+    for (const tool of overlay.deniedTools) {
+      rules.push({
+        id: `skill-${overlay.skillName}-deny-${tool}`,
+        priority: basePriority + 50, // Higher than typical rules
+        scope: {
+          skillName: overlay.skillName,
+        },
+        tool,
+        action: "deny",
+        reason: overlay.reason || `Tool ${tool} denied by skill ${overlay.skillName} policy`,
+      });
+    }
+  }
+  
+  return rules;
+}
+
+// ============================================================================
+// Skill Policy Evaluation
+// ============================================================================
+
+/**
+ * Evaluate a tool request in the context of skill policy.
+ * Checks if the requested tool is allowed given the skill's policy overlay.
+ */
+export function evaluateSkillPolicy(
+  overlay: SkillOverlay,
+  toolName: string
+): SkillPolicyResult {
+  // Check if tool is explicitly denied
+  if (overlay.deniedTools && overlay.deniedTools.includes(toolName)) {
+    return {
+      allowed: false,
+      reason: `Tool ${toolName} is explicitly denied by skill ${overlay.skillName}`,
+      skillOverlay: overlay,
+      deniedTools: [toolName],
+    };
+  }
+  
+  // Check if required tools are missing (but not for the requested tool)
+  if (overlay.requiredTools) {
+    const missingTools = overlay.requiredTools.filter(t => t !== toolName);
+    if (missingTools.length > 0) {
+      // Tool requested is not missing, but some required tools might be
+      // This is informational - not a blocking error
+    }
+  }
+  
+  // If we get here, the tool is allowed by the skill overlay
+  return {
+    allowed: true,
+    reason: `Tool ${toolName} is allowed by skill ${overlay.skillName} policy`,
+    skillOverlay: overlay,
+  };
+}
+
+/**
+ * Validate that all required tools for a skill are available.
+ * Returns information about missing required tools.
+ */
+export function validateRequiredTools(
+  overlay: SkillOverlay,
+  availableTools: string[]
+): { valid: boolean; missingTools: string[] } {
+  if (!overlay.requiredTools || overlay.requiredTools.length === 0) {
+    return { valid: true, missingTools: [] };
+  }
+  
+  const missingTools = overlay.requiredTools.filter(
+    required => !availableTools.includes(required)
+  );
+  
+  return {
+    valid: missingTools.length === 0,
+    missingTools,
+  };
+}
+
+// ============================================================================
+// Example Skill Overlays
+// ============================================================================
+
+/**
+ * Get example skill overlay configurations for documentation.
+ */
+export function getExampleSkillOverlays(): Record<string, SkillOverlay> {
+  return {
+    "code-review": {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+      preferredTools: ["View", "GlobTool", "GrepTool"],
+      deniedTools: ["Bash", "Edit", "Write"],
+      reason: "Code review skill is read-only by default",
+    },
+    "web-scrape": {
+      skillName: "web-scrape",
+      requiredTools: ["WebFetch", "Bash"],
+      preferredTools: ["WebFetch"],
+      deniedTools: [],
+      reason: "Web scraping requires network access and shell",
+    },
+    "admin": {
+      skillName: "admin",
+      requiredTools: ["Bash", "Write", "Edit", "View"],
+      preferredTools: ["Bash", "Write", "Edit", "View"],
+      deniedTools: [],
+      reason: "Admin skill has full tool access",
+    },
+  };
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,17 +2,23 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
-import {
-  getThreadSession,
-  createThreadSession,
-  incrementThreadTurn,
-  markThreadCompactWarned,
-} from "./sessionManager";
-import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
+import { getSettings, type ModelConfig, type SecurityConfig, type AgenticMode } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
-import { selectModel } from "./model-router";
+import { selectModel as governanceSelectModel, configureRouter as configureGovernanceRouter } from "./governance/model-router";
+import { recordInvocationStart, recordInvocationCompletion, recordInvocationFailure } from "./governance/usage-tracker";
+import { recordExecutionMetric, checkLimits, handleTrigger as watchdogHandleTrigger } from "./governance/watchdog";
+import { getGovernanceClient, type GovernanceClient } from "./governance/client";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
+
+// Initialize governance router with agentic modes from settings
+let governanceInitialized = false;
+function ensureGovernanceRouter(modes?: AgenticMode[], defaultMode?: string): void {
+  if (!governanceInitialized && modes && defaultMode) {
+    configureGovernanceRouter({ modes, defaultMode, defaultProvider: "anthropic", defaultModel: "claude-3-5-sonnet" });
+    governanceInitialized = true;
+  }
+}
 // Resolve prompts relative to the claudeclaw installation, not the project dir
 const PROMPTS_DIR = join(import.meta.dir, "..", "prompts");
 const HEARTBEAT_PROMPT_FILE = join(PROMPTS_DIR, "heartbeat", "HEARTBEAT.md");
@@ -60,20 +66,11 @@ export interface RunResult {
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
-// Global queue for non-thread messages (backward compatible)
-let globalQueue: Promise<unknown> = Promise.resolve();
-// Per-thread queues — each thread runs independently in parallel
-const threadQueues = new Map<string, Promise<unknown>>();
+let queue: Promise<unknown> = Promise.resolve();
 
-function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
-  if (threadId) {
-    const current = threadQueues.get(threadId) ?? Promise.resolve();
-    const task = current.then(fn, fn);
-    threadQueues.set(threadId, task.catch(() => {}));
-    return task;
-  }
-  const task = globalQueue.then(fn, fn);
-  globalQueue = task.catch(() => {});
+function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+  const task = queue.then(fn, fn);
+  queue = task.catch(() => {});
   return task;
 }
 
@@ -327,7 +324,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
   const securityArgs = buildSecurityArgs(settings.security);
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = (getSettings() as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
     existing.sessionId,
@@ -343,18 +340,101 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string): Promise<RunResult> {
+/**
+ * Policy-aware tool execution wrapper.
+ * Evaluates tool requests against policy before allowing execution.
+ */
+async function evaluateToolForExecution(
+  toolName: string,
+  toolArgs: Record<string, unknown> | undefined,
+  context: {
+    source: string;
+    channelId?: string;
+    userId?: string;
+    skillName?: string;
+    sessionId?: string;
+    claudeSessionId?: string | null;
+    eventId: string;
+  }
+): Promise<{ allowed: boolean; decision: import("./policy/engine").PolicyDecision }> {
+  const gc = getGovernanceClient();
+  const request: import("./policy/engine").ToolRequestContext = {
+    eventId: context.eventId,
+    source: context.source,
+    channelId: context.channelId,
+    userId: context.userId,
+    skillName: context.skillName,
+    toolName,
+    toolArgs,
+    sessionId: context.sessionId,
+    claudeSessionId: context.claudeSessionId,
+    timestamp: new Date().toISOString(),
+  };
+
+  const decision = gc.evaluateToolRequest(request);
+  
+  if (decision.action === "deny") {
+    console.warn(`[policy] Tool ${toolName} denied: ${decision.reason}`);
+    return { allowed: false, decision };
+  }
+  
+  if (decision.action === "require_approval") {
+    console.warn(`[policy] Tool ${toolName} requires approval: ${decision.reason}`);
+    // Enqueue for approval
+    const entry = await gc.requestApproval(request, decision);
+    if (entry) {
+      console.warn(`[policy] Approval request enqueued: ${entry.id}`);
+    }
+    return { allowed: false, decision };
+  }
+  
+  return { allowed: true, decision };
+}
+
+/**
+ * Get context for policy evaluation from current session and settings.
+ */
+async function getPolicyContext(source: string): Promise<{
+  eventId: string;
+  source: string;
+  channelId?: string;
+  userId?: string;
+  skillName?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+}> {
+  const existing = await getSession();
+  const settings = getSettings();
+  return {
+    eventId: crypto.randomUUID(),
+    source,
+    channelId: undefined, // Will be populated from event context
+    userId: settings.userId,
+    skillName: undefined,
+    sessionId: existing?.sessionId,
+    claudeSessionId: existing?.sessionId ?? null,
+  };
+}
+
+async function execClaude(name: string, prompt: string): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
-  const existing = threadId
-    ? await getThreadSession(threadId)
-    : await getSession();
+  // Ensure governance client is initialized
+  const gc = getGovernanceClient();
+
+  const existing = await getSession();
   const isNew = !existing;
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const logFile = join(LOGS_DIR, `${name}-${timestamp}.log`);
 
-  const settings = getSettings();
-  const { security, model, api, fallback, agentic } = settings;
+  const { security, model, api, fallback, agentic } = getSettings();
+
+  // Generate invocation ID for tracking
+  const invocationId = crypto.randomUUID();
+  const invocationSessionId = existing?.sessionId;
+
+  // Initialize watchdog metrics
+  await recordExecutionMetric({ invocationId, sessionId: invocationSessionId }, {});
 
   // Determine which model to use based on agentic routing
   let primaryConfig: ModelConfig;
@@ -362,12 +442,26 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   let routingReasoning = "";
 
   if (agentic.enabled) {
-    const routing = selectModel(prompt, agentic.modes, agentic.defaultMode);
-    primaryConfig = { model: routing.model, api };
-    taskType = routing.taskType;
-    routingReasoning = routing.reasoning;
+    ensureGovernanceRouter(agentic.modes, agentic.defaultMode);
+    const routing = await governanceSelectModel({
+      prompt,
+      taskType: agentic.defaultMode,
+      sessionId: existing?.sessionId,
+      channelId: undefined,
+      source: name,
+    });
+    primaryConfig = { model: routing.selectedModel, api: routing.selectedProvider === "openai" ? "" : api };
+    taskType = routing.reason;
+    routingReasoning = routing.reason;
+    // Handle budget block
+    if (routing.budgetState === "block") {
+      console.warn(`[${new Date().toLocaleTimeString()}] Execution blocked: budget limit exceeded`);
+      // Record failure and return
+      await recordInvocationFailure(invocationId, { type: "budget-blocked", message: `Budget state: ${routing.budgetState}` });
+      return { stdout: "", stderr: "Execution blocked: budget limit exceeded", exitCode: 0 };
+    }
     console.log(
-      `[${new Date().toLocaleTimeString()}] Agentic routing: ${routing.taskType} → ${routing.model} (${routing.reasoning})`
+      `[${new Date().toLocaleTimeString()}] Agentic routing: ${routing.selectedModel} (${routing.reason})`
     );
   } else {
     primaryConfig = { model, api };
@@ -378,7 +472,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = (getSettings() as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
@@ -421,7 +515,27 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
 
-  let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+  // Record invocation start
+  const invocationContext = {
+    sessionId: existing?.sessionId,
+    claudeSessionId: existing?.sessionId ?? null,
+    source: name,
+    channelId: undefined,
+    provider: primaryConfig.model.startsWith("gpt") || primaryConfig.model.startsWith("o1") || primaryConfig.model.startsWith("o3") ? "openai" : "anthropic",
+    model: primaryConfig.model,
+    metadata: { taskType, routingReasoning },
+  };
+  await recordInvocationStart(invocationContext, invocationId);
+
+  let exec: { rawStdout: string; stderr: string; exitCode: number };
+  try {
+    exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+  } catch (err) {
+    // Record failure
+    await recordInvocationFailure(invocationId, { type: "execution-error", message: err instanceof Error ? err.message : String(err) });
+    throw err;
+  }
+
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
   let usedFallback = false;
 
@@ -431,6 +545,10 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     );
     exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs);
     usedFallback = true;
+    // If fallback also fails, record failure
+    if (extractRateLimitMessage(exec.rawStdout, exec.stderr)) {
+      await recordInvocationFailure(invocationId, { type: "rate-limit", message: "Both primary and fallback hit rate limit" });
+    }
   }
 
   const rawStdout = exec.rawStdout;
@@ -451,13 +569,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
       sessionId = json.session_id;
       stdout = json.result ?? "";
       // Save the real session ID from Claude Code
-      if (threadId) {
-        await createThreadSession(threadId, sessionId);
-        console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
-      } else {
-        await createSession(sessionId);
-        console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}`);
-      }
+      await createSession(sessionId);
+      console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}`);
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to parse session from Claude output:`, e);
     }
@@ -468,6 +581,23 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     stderr,
     exitCode,
   };
+
+  // Record successful completion
+  await recordInvocationCompletion(invocationId, undefined, undefined);
+
+  // Check watchdog limits
+  const watchdogDecision = await checkLimits({ invocationId, sessionId: invocationSessionId });
+  if (watchdogDecision.state === "suspend" || watchdogDecision.state === "kill") {
+    console.warn(`[${new Date().toLocaleTimeString()}] Watchdog ${watchdogDecision.state}: ${watchdogDecision.reason}`);
+    await watchdogHandleTrigger({ invocationId, sessionId: invocationSessionId }, watchdogDecision);
+    // Send escalation notification for watchdog triggers
+    try {
+      const { handleWatchdogTrigger } = await import("./escalation");
+      await handleWatchdogTrigger(watchdogDecision, { invocationId, sessionId: invocationSessionId });
+    } catch (escalationError) {
+      console.error("[escalation] Failed to send watchdog notification:", escalationError);
+    }
+  }
 
   const output = [
     `# ${name}`,
@@ -516,8 +646,14 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
       });
 
       if (retryExec.exitCode === 0) {
-        const count = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
+        const count = await incrementTurn();
         console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${count} (after compact + retry)`);
+        // Check watchdog after successful retry
+        const retryWatchdogDecision = await checkLimits({ invocationId, sessionId: invocationSessionId });
+        if (retryWatchdogDecision.state === "suspend" || retryWatchdogDecision.state === "kill") {
+          console.warn(`[${new Date().toLocaleTimeString()}] Watchdog ${retryWatchdogDecision.state} after retry: ${retryWatchdogDecision.reason}`);
+          await watchdogHandleTrigger({ invocationId, sessionId: invocationSessionId }, retryWatchdogDecision);
+        }
       }
       return retryResult;
     }
@@ -525,15 +661,11 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
 
   // --- Turn tracking & compact warning ---
   if (exitCode === 0 && !isNew) {
-    const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
-    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${threadId ? ` (thread ${threadId.slice(0, 8)})` : ""}`);
+    const turnCount = await incrementTurn();
+    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}`);
 
     if (turnCount >= COMPACT_WARN_THRESHOLD && existing && !existing.compactWarned) {
-      if (threadId) {
-        await markThreadCompactWarned(threadId);
-      } else {
-        await markCompactWarned();
-      }
+      await markCompactWarned();
       emitCompactEvent({ type: "warn", turnCount });
     }
   }
@@ -541,8 +673,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId), threadId);
+export async function run(name: string, prompt: string): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt));
 }
 
 async function streamClaude(
@@ -687,8 +819,8 @@ function prefixUserMessageWithClock(prompt: string): string {
   }
 }
 
-export async function runUserMessage(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return run(name, prefixUserMessageWithClock(prompt), threadId);
+export async function runUserMessage(name: string, prompt: string): Promise<RunResult> {
+  return run(name, prefixUserMessageWithClock(prompt));
 }
 
 /**


### PR DESCRIPTION
## ClaudeClaw v2: Governance & Event Architecture

This is **PR 2 of 3** in a series that introduces a production-grade governance, policy, and event processing architecture to ClaudeClaw.

### The series

| PR | Role | Status |
|----|------|--------|
| #71 | **Policy Engine** — deterministic rule evaluation for tool-use governance | Open |
| **#72 (this PR)** | **Governance Layer** — model routing, budget control, usage tracking, watchdog | Open |
| #73 | **Gateway & Events** — unified message pipeline, event log, escalation | Open |

**Merge order:** #71 → #72 → #73. **This PR depends on #71.**

---

## This PR: Governance Layer (#72)

The governance layer sits **between the daemon and the Claude CLI**. While the policy engine (PR #71) controls *what tools are allowed*, the governance layer controls *how sessions are managed* — which model handles each request, how much it costs, and when to intervene.

### Why this matters

ClaudeClaw spawns a full `claude -p --resume` process for every message. Without governance:
- Every message uses the same model regardless of complexity (a "ping" uses opus)
- There's no cost tracking — you discover usage overruns after the fact
- Runaway sessions (infinite loops, repeated failures) run unchecked
- There's no way to degrade gracefully when approaching limits

### Features

**Model Router:**
- Agentic model routing based on task classification (planning → opus, implementation → sonnet)
- Keyword and phrase matching for mode selection
- Configurable fallback chains

**Budget Engine:**
- Per-session and global token/cost budgets
- Warn/throttle/block states with configurable thresholds
- UTC-consistent period bounds for daily/monthly budgets

**Usage Tracker:**
- Invocation-level metrics with caller-provided tracking IDs
- Atomic JSONL appending (no read-then-write races)
- Provider and model usage aggregation

**Watchdog:**
- Runaway detection (consecutive failures, timeout patterns, tool call limits)
- Configurable suspend/kill thresholds
- Atomic event logging

**Telemetry:**
- Correct provider inference (claude → anthropic, gpt → openai)
- Structured metric recording for all governance decisions

**Governance Client:**
- Unified interface bridging policy engine and governance modules
- Tool request evaluation with policy + budget checks

### Security hardening

| Issue | Fix |
|-------|-----|
| Scope matching bypass in budget engine | Undefined record fields now fail to match scoped policies |
| UTC/local timezone mismatch in budget periods | All period bounds use Date.UTC() |
| Invocation ID mismatch (usage tracking broken) | Runner passes ID to usage tracker |
| File append race condition | All JSONL appending uses atomic appendFile |
| Provider field storing API key | Stores provider name (anthropic/openai) |
| worstEvaluation selecting wrong policy | Finds evaluation matching determined worst state |
| fallbackChain ignoring empty arrays | Uses ?? instead of \|\| |
| Incorrect provider inference | Proper prefix-to-provider mapping |
| Nonsensical session counting | Uses channel count directly |
| Watchdog append race condition | Same appendFile fix as usage tracker |

### Code review

3 rounds of automated code review (code-reviewer agent):
- Round 1: 4 CRITICAL + 5 HIGH issues found
- Round 2: All 9 fixed + 1 additional HIGH + 2 MEDIUM fixed
- Round 3: **APPROVED**

### Files added/modified

**New:** `src/governance/` — budget-engine.ts, client.ts, index.ts, model-router.ts, telemetry.ts, usage-tracker.ts, watchdog.ts
**Modified:** `src/config.ts` (agentic config), `src/runner.ts` (governance integration)
**Tests:** `src/__tests__/governance/` (5 test files) + `src/__tests__/policy/wiring.test.ts`

## Test plan

- [ ] `bun test src/__tests__/governance/` — all governance tests pass
- [ ] `bun test src/__tests__/policy/wiring.test.ts` — policy-governance bridge
- [ ] Verify budget evaluation with scoped policies
- [ ] Verify model routing classification