### PR TITLE
feat: add unified gateway, event system, and escalation framework

### DIFF
--- a/src/__tests__/escalation/handoff.test.ts
+++ b/src/__tests__/escalation/handoff.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Tests for escalation/handoff.ts
+ * 
+ * Run with: bun test src/__tests__/escalation/handoff.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  initHandoffManager,
+  createHandoff,
+  getHandoff,
+  listHandoffs,
+  acceptHandoff,
+  closeHandoff,
+  getHandoffStats,
+  resetHandoffManager,
+  clearHandoffCache,
+  type HandoffContext,
+  type HandoffSeverity,
+} from "../../escalation/handoff";
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const HANDOFFS_DIR = join(ESCALATION_DIR, "handoffs");
+
+describe("Handoff Manager - Initialization", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should initialize with empty handoff index", async () => {
+    await initHandoffManager();
+    
+    const handoffs = await listHandoffs();
+    expect(handoffs).toHaveLength(0);
+  });
+
+  it("should create handoffs directory", async () => {
+    await initHandoffManager();
+    
+    expect(existsSync(HANDOFFS_DIR)).toBe(true);
+  });
+});
+
+describe("Handoff Manager - Create Handoff", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should create a basic handoff", async () => {
+    const handoff = await createHandoff("Test handoff reason");
+    
+    expect(handoff.handoffId).toBeDefined();
+    expect(handoff.reason).toBe("Test handoff reason");
+    expect(handoff.severity).toBe("info");
+    expect(handoff.status).toBe("open");
+    expect(handoff.createdAt).toBeDefined();
+  });
+
+  it("should create handoff with context", async () => {
+    const context: HandoffContext = {
+      workflowIds: ["wf-1", "wf-2"],
+      sessionId: "session-123",
+      claudeSessionId: "claude-456",
+      source: "telegram",
+      channelId: "telegram:789",
+      threadId: "thread-abc",
+      relatedEventIds: ["evt-1", "evt-2"],
+      pendingTasks: ["task-1", "task-2"],
+      pendingApprovals: ["appr-1"],
+      pendingEvents: [
+        { eventId: "evt-1", type: "message", status: "pending" },
+      ],
+    };
+    
+    const handoff = await createHandoff("Handoff with context", context, {
+      severity: "warning",
+      summary: "Summary of the handoff",
+    });
+    
+    expect(handoff.workflowIds).toEqual(["wf-1", "wf-2"]);
+    expect(handoff.sessionId).toBe("session-123");
+    expect(handoff.claudeSessionId).toBe("claude-456");
+    expect(handoff.source).toBe("telegram");
+    expect(handoff.channelId).toBe("telegram:789");
+    expect(handoff.threadId).toBe("thread-abc");
+    expect(handoff.relatedEventIds).toEqual(["evt-1", "evt-2"]);
+    expect(handoff.pendingTasks).toEqual(["task-1", "task-2"]);
+    expect(handoff.pendingApprovals).toEqual(["appr-1"]);
+    expect(handoff.pendingEvents).toHaveLength(1);
+    expect(handoff.severity).toBe("warning");
+    expect(handoff.summary).toBe("Summary of the handoff");
+  });
+
+  it("should persist handoff to file", async () => {
+    const handoff = await createHandoff("Persisted handoff");
+    
+    const filePath = join(HANDOFFS_DIR, `${handoff.handoffId}.json`);
+    expect(existsSync(filePath)).toBe(true);
+    
+    const content = await readFile(filePath, "utf8");
+    const parsed = JSON.parse(content);
+    
+    expect(parsed.reason).toBe("Persisted handoff");
+    expect(parsed.status).toBe("open");
+  });
+
+  it("should add handoff to index", async () => {
+    const handoff = await createHandoff("Indexed handoff");
+    
+    const handoffs = await listHandoffs();
+    expect(handoffs).toHaveLength(1);
+    expect(handoffs[0].handoffId).toBe(handoff.handoffId);
+    expect(handoffs[0].reason).toBe("Indexed handoff");
+  });
+});
+
+describe("Handoff Manager - Get Handoff", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should get handoff by ID", async () => {
+    const created = await createHandoff("Get me");
+    
+    const retrieved = await getHandoff(created.handoffId);
+    
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.handoffId).toBe(created.handoffId);
+    expect(retrieved!.reason).toBe("Get me");
+  });
+
+  it("should return null for non-existent handoff", async () => {
+    const retrieved = await getHandoff("non-existent-id");
+    expect(retrieved).toBeNull();
+  });
+
+  it("should get full handoff details including context", async () => {
+    const context: HandoffContext = {
+      sessionId: "test-session",
+      pendingTasks: ["task-a", "task-b"],
+    };
+    
+    const created = await createHandoff("Full details", context);
+    const retrieved = await getHandoff(created.handoffId);
+    
+    expect(retrieved!.sessionId).toBe("test-session");
+    expect(retrieved!.pendingTasks).toEqual(["task-a", "task-b"]);
+  });
+});
+
+describe("Handoff Manager - List Handoffs", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should list all handoffs sorted by createdAt descending", async () => {
+    await createHandoff("First", { source: "telegram" });
+    await new Promise(r => setTimeout(r, 10)); // Ensure different timestamps
+    await createHandoff("Second", { source: "discord" });
+    
+    const handoffs = await listHandoffs();
+    
+    expect(handoffs).toHaveLength(2);
+    expect(handoffs[0].reason).toBe("Second"); // Newest first
+    expect(handoffs[1].reason).toBe("First");
+  });
+
+  it("should filter by status", async () => {
+    const h1 = await createHandoff("Open handoff");
+    const h2 = await createHandoff("Another open");
+    await acceptHandoff(h2.handoffId, { acceptedBy: "operator" });
+    
+    const openHandoffs = await listHandoffs({ status: "open" });
+    const acceptedHandoffs = await listHandoffs({ status: "accepted" });
+    
+    expect(openHandoffs).toHaveLength(1);
+    expect(openHandoffs[0].handoffId).toBe(h1.handoffId);
+    expect(acceptedHandoffs).toHaveLength(1);
+    expect(acceptedHandoffs[0].handoffId).toBe(h2.handoffId);
+  });
+
+  it("should filter by severity", async () => {
+    await createHandoff("Info", {}, { severity: "info" });
+    await createHandoff("Warning", {}, { severity: "warning" });
+    await createHandoff("Critical", {}, { severity: "critical" });
+    
+    const criticalHandoffs = await listHandoffs({ severity: "critical" });
+    
+    expect(criticalHandoffs).toHaveLength(1);
+    expect(criticalHandoffs[0].reason).toBe("Critical");
+  });
+
+  it("should filter by source", async () => {
+    await createHandoff("Telegram", { source: "telegram" });
+    await createHandoff("Discord", { source: "discord" });
+    
+    const telegramHandoffs = await listHandoffs({ source: "telegram" });
+    
+    expect(telegramHandoffs).toHaveLength(1);
+    expect(telegramHandoffs[0].reason).toBe("Telegram");
+  });
+
+  it("should filter by sessionId", async () => {
+    await createHandoff("Session A", { sessionId: "session-a" });
+    await createHandoff("Session B", { sessionId: "session-b" });
+    
+    const sessionAHandoffs = await listHandoffs({ sessionId: "session-a" });
+    
+    expect(sessionAHandoffs).toHaveLength(1);
+    expect(sessionAHandoffs[0].reason).toBe("Session A");
+  });
+
+  it("should filter by date range", async () => {
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 86400000).toISOString();
+    const tomorrow = new Date(now.getTime() + 86400000).toISOString();
+    
+    await createHandoff("Recent");
+    
+    const recentHandoffs = await listHandoffs({
+      createdAfter: yesterday,
+      createdBefore: tomorrow,
+    });
+    
+    expect(recentHandoffs.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("Handoff Manager - Accept Handoff", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should accept an open handoff", async () => {
+    const handoff = await createHandoff("Accept me");
+    
+    const accepted = await acceptHandoff(handoff.handoffId, {
+      acceptedBy: "operator-1",
+    });
+    
+    expect(accepted).not.toBeNull();
+    expect(accepted!.status).toBe("accepted");
+    expect(accepted!.acceptedBy).toBe("operator-1");
+    expect(accepted!.acceptedAt).toBeDefined();
+  });
+
+  it("should return null for non-existent handoff", async () => {
+    const result = await acceptHandoff("non-existent", { acceptedBy: "op" });
+    expect(result).toBeNull();
+  });
+
+  it("should not accept already accepted handoff", async () => {
+    const handoff = await createHandoff("Already accepted");
+    await acceptHandoff(handoff.handoffId, { acceptedBy: "operator-1" });
+    
+    // Try to accept again
+    const secondAccept = await acceptHandoff(handoff.handoffId, {
+      acceptedBy: "operator-2",
+    });
+    
+    expect(secondAccept!.status).toBe("accepted");
+    expect(secondAccept!.acceptedBy).toBe("operator-1"); // First acceptor wins
+  });
+
+  it("should update index when accepting", async () => {
+    const handoff = await createHandoff("Update index");
+    await acceptHandoff(handoff.handoffId, { acceptedBy: "op" });
+    
+    const handoffs = await listHandoffs({ status: "accepted" });
+    expect(handoffs).toHaveLength(1);
+    expect(handoffs[0].handoffId).toBe(handoff.handoffId);
+  });
+});
+
+describe("Handoff Manager - Close Handoff", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should close an open handoff", async () => {
+    const handoff = await createHandoff("Close me");
+    
+    const closed = await closeHandoff(handoff.handoffId, {
+      closedBy: "operator-1",
+      resolution: "Issue resolved",
+    });
+    
+    expect(closed).not.toBeNull();
+    expect(closed!.status).toBe("closed");
+    expect(closed!.closedBy).toBe("operator-1");
+    expect(closed!.resolution).toBe("Issue resolved");
+    expect(closed!.closedAt).toBeDefined();
+  });
+
+  it("should close an accepted handoff", async () => {
+    const handoff = await createHandoff("Close accepted");
+    await acceptHandoff(handoff.handoffId, { acceptedBy: "op" });
+    
+    const closed = await closeHandoff(handoff.handoffId, {
+      closedBy: "operator-2",
+      resolution: "Done",
+    });
+    
+    expect(closed!.status).toBe("closed");
+  });
+
+  it("should return null for non-existent handoff", async () => {
+    const result = await closeHandoff("non-existent", { closedBy: "op" });
+    expect(result).toBeNull();
+  });
+
+  it("should update index when closing", async () => {
+    const handoff = await createHandoff("Update on close");
+    await closeHandoff(handoff.handoffId, { closedBy: "op" });
+    
+    const handoffs = await listHandoffs({ status: "closed" });
+    expect(handoffs).toHaveLength(1);
+    expect(handoffs[0].closedAt).toBeDefined();
+  });
+});
+
+describe("Handoff Manager - Statistics", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return correct statistics", async () => {
+    // Create handoffs with different severities
+    const h1 = await createHandoff("Info open", {}, { severity: "info" });
+    await createHandoff("Warning open", {}, { severity: "warning" });
+    const h3 = await createHandoff("Critical open", {}, { severity: "critical" });
+    
+    // Close one
+    await closeHandoff(h1.handoffId, {});
+    
+    // Accept one
+    await acceptHandoff(h3.handoffId, {});
+    
+    const stats = await getHandoffStats();
+    
+    expect(stats.total).toBe(3);
+    expect(stats.byStatus.open).toBe(1);
+    expect(stats.byStatus.accepted).toBe(1);
+    expect(stats.byStatus.closed).toBe(1);
+    expect(stats.bySeverity.info).toBe(1);
+    expect(stats.bySeverity.warning).toBe(1);
+    expect(stats.bySeverity.critical).toBe(1);
+    expect(stats.openCritical).toBe(0); // The critical one was accepted
+  });
+
+  it("should count open critical handoffs", async () => {
+    await createHandoff("Critical 1", {}, { severity: "critical" });
+    await createHandoff("Critical 2", {}, { severity: "critical" });
+    await createHandoff("Info", {}, { severity: "info" });
+    
+    const stats = await getHandoffStats();
+    
+    expect(stats.openCritical).toBe(2);
+  });
+});
+
+describe("Handoff Manager - Persistence Across Restart", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should persist handoffs across cache clear (simulated restart)", async () => {
+    const handoff = await createHandoff("Persist me", {
+      sessionId: "test-session",
+      source: "telegram",
+    });
+    
+    // Simulate restart by clearing cache
+    clearHandoffCache();
+    
+    // Should still be able to retrieve
+    const retrieved = await getHandoff(handoff.handoffId);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.reason).toBe("Persist me");
+    expect(retrieved!.sessionId).toBe("test-session");
+  });
+
+  it("should persist handoff status changes", async () => {
+    const handoff = await createHandoff("Status change");
+    await acceptHandoff(handoff.handoffId, { acceptedBy: "op" });
+    
+    clearHandoffCache();
+    
+    const retrieved = await getHandoff(handoff.handoffId);
+    expect(retrieved!.status).toBe("accepted");
+    expect(retrieved!.acceptedBy).toBe("op");
+  });
+});
+
+describe("Handoff Manager - Metadata Support", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetHandoffManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(HANDOFFS_DIR, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should store metadata on create", async () => {
+    const handoff = await createHandoff("With metadata", {}, {
+      metadata: { ticketId: "T-123", priority: "high" },
+    });
+    
+    expect(handoff.metadata).toEqual({
+      ticketId: "T-123",
+      priority: "high",
+    });
+    
+    const retrieved = await getHandoff(handoff.handoffId);
+    expect(retrieved!.metadata).toEqual({
+      ticketId: "T-123",
+      priority: "high",
+    });
+  });
+
+  it("should merge metadata on accept", async () => {
+    const handoff = await createHandoff("Merge on accept", {}, {
+      metadata: { original: "value" },
+    });
+    
+    await acceptHandoff(handoff.handoffId, {
+      acceptedBy: "op",
+      metadata: { acceptedBy: "op", notes: "Working on it" },
+    });
+    
+    const retrieved = await getHandoff(handoff.handoffId);
+    expect(retrieved!.metadata).toEqual({
+      original: "value",
+      acceptedBy: "op",
+      notes: "Working on it",
+    });
+  });
+
+  it("should merge metadata on close", async () => {
+    const handoff = await createHandoff("Merge on close", {}, {
+      metadata: { original: "value" },
+    });
+    
+    await closeHandoff(handoff.handoffId, {
+      closedBy: "op",
+      resolution: "Fixed",
+      metadata: { closedAt: new Date().toISOString() },
+    });
+    
+    const retrieved = await getHandoff(handoff.handoffId);
+    expect(retrieved!.metadata).toEqual({
+      original: "value",
+      closedAt: expect.any(String),
+    });
+  });
+});

--- a/src/__tests__/escalation/notifications.test.ts
+++ b/src/__tests__/escalation/notifications.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for escalation/notifications.ts
+ * 
+ * Run with: bun test src/__tests__/escalation/notifications.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, readdir, unlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  initNotificationManager,
+  notify,
+  listNotifications,
+  getNotification,
+  configure,
+  getConfig,
+  retryDelivery,
+  getNotificationStats,
+  resetNotificationManager,
+  clearNotificationCache,
+  type NotificationType,
+  type NotificationSeverity,
+} from "../../escalation/notifications";
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const NOTIFICATIONS_DIR = join(ESCALATION_DIR, "notifications");
+const RATE_LIMIT_FILE = join(ESCALATION_DIR, "notification-rate-limits.json");
+const CONFIG_FILE = join(ESCALATION_DIR, "notification-config.json");
+
+describe("Notification Manager - Initialization", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should initialize with default config", async () => {
+    await initNotificationManager();
+    
+    const config = getConfig();
+    expect(config.enabledTypes).toContain("dlq_overflow");
+    expect(config.enabledTypes).toContain("watchdog");
+    expect(config.enabledTypes).toContain("policy_denial");
+    expect(config.minSeverity).toBe("info");
+  });
+
+  it("should create notifications directory", async () => {
+    await initNotificationManager();
+    
+    expect(existsSync(NOTIFICATIONS_DIR)).toBe(true);
+  });
+});
+
+describe("Notification Manager - Create Notification", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should create a basic notification", async () => {
+    const notification = await notify("dlq_overflow", "warning", "DLQ has 100 items");
+    
+    expect(notification).not.toBeNull();
+    expect(notification!.notificationId).toBeDefined();
+    expect(notification!.type).toBe("dlq_overflow");
+    expect(notification!.severity).toBe("warning");
+    expect(notification!.message).toBe("DLQ has 100 items");
+    expect(notification!.createdAt).toBeDefined();
+    expect(notification!.delivery).toBeDefined();
+  });
+
+  it("should create notification with context", async () => {
+    const notification = await notify(
+      "policy_denial",
+      "critical",
+      "Tool execution denied",
+      {
+        eventId: "evt-123",
+        workflowId: "wf-456",
+        sessionId: "session-789",
+        details: { toolName: "Bash", reason: "Security policy" },
+      }
+    );
+    
+    expect(notification!.eventId).toBe("evt-123");
+    expect(notification!.workflowId).toBe("wf-456");
+    expect(notification!.sessionId).toBe("session-789");
+    expect(notification!.details).toEqual({
+      toolName: "Bash",
+      reason: "Security policy",
+    });
+  });
+
+  it("should persist notification to file", async () => {
+    const notification = await notify("error", "critical", "System error");
+    
+    const filePath = join(NOTIFICATIONS_DIR, `${notification!.notificationId}.json`);
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it("should skip disabled notification types", async () => {
+    await configure({ enabledTypes: ["dlq_overflow"] });
+    
+    const notification = await notify("watchdog", "warning", "Should be skipped");
+    
+    expect(notification).toBeNull();
+  });
+
+  it("should skip notifications below minimum severity", async () => {
+    await configure({ minSeverity: "warning" });
+    
+    const infoNotification = await notify("dlq_overflow", "info", "Info message");
+    const warningNotification = await notify("dlq_overflow", "warning", "Warning message");
+    
+    expect(infoNotification).toBeNull();
+    expect(warningNotification).not.toBeNull();
+  });
+});
+
+describe("Notification Manager - Deduplication", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should deduplicate identical notifications", async () => {
+    const n1 = await notify("dlq_overflow", "warning", "Same message");
+    const n2 = await notify("dlq_overflow", "warning", "Same message");
+    
+    expect(n1).not.toBeNull();
+    expect(n2).toBeNull(); // Duplicate suppressed
+  });
+
+  it("should allow different types with same message", async () => {
+    const n1 = await notify("dlq_overflow", "warning", "Same message");
+    const n2 = await notify("watchdog", "warning", "Same message");
+    
+    expect(n1).not.toBeNull();
+    expect(n2).not.toBeNull();
+  });
+
+  it("should allow same type with different severity", async () => {
+    const n1 = await notify("dlq_overflow", "warning", "Same message");
+    const n2 = await notify("dlq_overflow", "critical", "Same message");
+    
+    expect(n1).not.toBeNull();
+    expect(n2).not.toBeNull();
+  });
+
+  it("should allow notifications for different events", async () => {
+    const n1 = await notify("dlq_overflow", "warning", "Same message", { eventId: "evt-1" });
+    const n2 = await notify("dlq_overflow", "warning", "Same message", { eventId: "evt-2" });
+    
+    expect(n1).not.toBeNull();
+    expect(n2).not.toBeNull();
+  });
+});
+
+describe("Notification Manager - Rate Limiting", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+    // Set very low rate limits for testing
+    await configure({ rateLimits: { perTypePerMinute: 2, perSeverityPerMinute: 3 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should rate limit by type", async () => {
+    const n1 = await notify("dlq_overflow", "info", "Message 1");
+    const n2 = await notify("dlq_overflow", "info", "Message 2");
+    const n3 = await notify("dlq_overflow", "info", "Message 3"); // Should be rate limited
+    
+    expect(n1).not.toBeNull();
+    expect(n2).not.toBeNull();
+    expect(n3).toBeNull(); // Rate limited
+  });
+
+  it("should rate limit by severity", async () => {
+    const n1 = await notify("dlq_overflow", "warning", "Warning 1");
+    const n2 = await notify("watchdog", "warning", "Warning 2");
+    const n3 = await notify("policy_denial", "warning", "Warning 3");
+    const n4 = await notify("error", "warning", "Warning 4"); // Should be rate limited
+    
+    expect(n1).not.toBeNull();
+    expect(n2).not.toBeNull();
+    expect(n3).not.toBeNull(); // Still within limit of 3
+    expect(n4).toBeNull(); // Rate limited
+  });
+
+  it("should allow different types under severity limit", async () => {
+    // With perSeverityPerMinute: 3, we should be able to send 3 warnings
+    const n1 = await notify("dlq_overflow", "info", "Info 1");
+    const n2 = await notify("dlq_overflow", "info", "Info 2");
+    
+    expect(n1).not.toBeNull();
+    expect(n2).not.toBeNull();
+  });
+});
+
+describe("Notification Manager - List and Get", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should list all notifications sorted by date", async () => {
+    await notify("dlq_overflow", "warning", "First");
+    await new Promise(r => setTimeout(r, 10));
+    await notify("watchdog", "info", "Second");
+    
+    const notifications = await listNotifications();
+    
+    expect(notifications).toHaveLength(2);
+    expect(notifications[0].message).toBe("Second");
+    expect(notifications[1].message).toBe("First");
+  });
+
+  it("should filter by type", async () => {
+    await notify("dlq_overflow", "warning", "DLQ message");
+    await notify("watchdog", "info", "Watchdog message");
+    
+    const dlqNotifications = await listNotifications({ type: "dlq_overflow" });
+    
+    expect(dlqNotifications).toHaveLength(1);
+    expect(dlqNotifications[0].type).toBe("dlq_overflow");
+  });
+
+  it("should filter by severity", async () => {
+    await notify("dlq_overflow", "info", "Info");
+    await notify("dlq_overflow", "warning", "Warning");
+    await notify("dlq_overflow", "critical", "Critical");
+    
+    const criticalNotifications = await listNotifications({ severity: "critical" });
+    
+    expect(criticalNotifications).toHaveLength(1);
+    expect(criticalNotifications[0].severity).toBe("critical");
+  });
+
+  it("should filter by eventId", async () => {
+    await notify("dlq_overflow", "warning", "Event 1", { eventId: "evt-1" });
+    await notify("dlq_overflow", "warning", "Event 2", { eventId: "evt-2" });
+    
+    const event1Notifications = await listNotifications({ eventId: "evt-1" });
+    
+    expect(event1Notifications).toHaveLength(1);
+    expect(event1Notifications[0].eventId).toBe("evt-1");
+  });
+
+  it("should filter by undelivered status", async () => {
+    // Create a notification (not delivered by default without config)
+    const n = await notify("dlq_overflow", "warning", "Undelivered");
+    
+    // Mark one as delivered manually
+    const undelivered = await listNotifications({ undeliveredOnly: true });
+    
+    expect(undelivered.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should respect limit parameter", async () => {
+    // Reset rate limits
+    await configure({ rateLimits: { perTypePerMinute: 100 } });
+    
+    for (let i = 0; i < 5; i++) {
+      await notify("dlq_overflow", "info", `Message ${i}`);
+    }
+    
+    const notifications = await listNotifications({}, 3);
+    
+    expect(notifications.length).toBeLessThanOrEqual(3);
+  });
+
+  it("should get notification by ID", async () => {
+    const created = await notify("dlq_overflow", "warning", "Get me");
+    
+    const retrieved = await getNotification(created!.notificationId);
+    
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.notificationId).toBe(created!.notificationId);
+    expect(retrieved!.message).toBe("Get me");
+  });
+
+  it("should return null for non-existent notification", async () => {
+    const retrieved = await getNotification("non-existent-id");
+    expect(retrieved).toBeNull();
+  });
+});
+
+describe("Notification Manager - Configuration", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should update configuration", async () => {
+    await configure({
+      webhookUrl: "https://example.com/webhook",
+      emailTarget: "alerts@example.com",
+      minSeverity: "warning",
+    });
+    
+    const config = getConfig();
+    expect(config.webhookUrl).toBe("https://example.com/webhook");
+    expect(config.emailTarget).toBe("alerts@example.com");
+    expect(config.minSeverity).toBe("warning");
+  });
+
+  it("should merge rate limits on update", async () => {
+    await configure({ rateLimits: { perTypePerMinute: 50 } });
+    
+    const config = getConfig();
+    expect(config.rateLimits?.perTypePerMinute).toBe(50);
+    expect(config.rateLimits?.perSeverityPerMinute).toBe(20); // Default preserved
+  });
+
+  it("should persist configuration", async () => {
+    await configure({ webhookUrl: "https://test.com" });
+    
+    // Clear cache and reload
+    clearNotificationCache();
+    await initNotificationManager();
+    
+    const config = getConfig();
+    expect(config.webhookUrl).toBe("https://test.com");
+  });
+});
+
+describe("Notification Manager - Statistics", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return correct statistics", async () => {
+    await notify("dlq_overflow", "warning", "DLQ warning");
+    await notify("dlq_overflow", "critical", "DLQ critical");
+    await notify("watchdog", "info", "Watchdog info");
+    await notify("policy_denial", "warning", "Policy warning");
+    
+    const stats = await getNotificationStats();
+    
+    expect(stats.total).toBe(4);
+    expect(stats.byType.dlq_overflow).toBe(2);
+    expect(stats.byType.watchdog).toBe(1);
+    expect(stats.byType.policy_denial).toBe(1);
+    expect(stats.bySeverity.warning).toBe(2);
+    expect(stats.bySeverity.critical).toBe(1);
+    expect(stats.bySeverity.info).toBe(1);
+  });
+
+  it("should track delivery status", async () => {
+    // Without delivery config, all are undelivered
+    await notify("dlq_overflow", "warning", "Undelivered");
+    
+    const stats = await getNotificationStats();
+    
+    expect(stats.undelivered).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("Notification Manager - All Notification Types", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetNotificationManager();
+    // Disable rate limits for these tests
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(NOTIFICATIONS_DIR, { recursive: true, force: true });
+      if (existsSync(RATE_LIMIT_FILE)) await unlink(RATE_LIMIT_FILE);
+      if (existsSync(CONFIG_FILE)) await unlink(CONFIG_FILE);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should support all notification types", async () => {
+    const types: NotificationType[] = [
+      "dlq_overflow",
+      "watchdog",
+      "policy_denial",
+      "error",
+      "manual_escalation",
+      "pause",
+      "resume",
+    ];
+    
+    for (const type of types) {
+      const notification = await notify(type, "info", `Test ${type}`);
+      expect(notification).not.toBeNull();
+      expect(notification!.type).toBe(type);
+    }
+    
+    const allNotifications = await listNotifications();
+    expect(allNotifications).toHaveLength(types.length);
+  });
+
+  it("should support all severity levels", async () => {
+    const severities: NotificationSeverity[] = ["info", "warning", "critical"];
+    
+    for (const severity of severities) {
+      // Add delay to avoid deduplication
+      await new Promise(r => setTimeout(r, 10));
+      const notification = await notify("dlq_overflow", severity, `Test ${severity}`);
+      expect(notification).not.toBeNull();
+      expect(notification!.severity).toBe(severity);
+    }
+  });
+});

--- a/src/__tests__/escalation/pause.test.ts
+++ b/src/__tests__/escalation/pause.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for escalation/pause.ts
+ * 
+ * Run with: bun test src/__tests__/escalation/pause.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  initPauseController,
+  pause,
+  resume,
+  getPauseState,
+  isPaused,
+  shouldBlockAdmission,
+  shouldBlockScheduling,
+  getPauseHistory,
+  resetPauseController,
+  clearPauseCache,
+  type PauseMode,
+  type PauseState,
+} from "../../escalation/pause";
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const PAUSE_STATE_FILE = join(ESCALATION_DIR, "paused.json");
+const PAUSE_ACTIONS_FILE = join(ESCALATION_DIR, "pause-actions.jsonl");
+
+describe("Pause Controller - Initialization", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(PAUSE_STATE_FILE, { force: true });
+      await rm(PAUSE_ACTIONS_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should initialize with default unpaused state", async () => {
+    await initPauseController();
+    
+    const state = await getPauseState();
+    expect(state.paused).toBe(false);
+    expect(state.mode).toBe("admission_only");
+  });
+
+  it("should persist state to file", async () => {
+    await initPauseController();
+    
+    expect(existsSync(PAUSE_STATE_FILE)).toBe(true);
+    
+    const content = await readFile(PAUSE_STATE_FILE, "utf8");
+    const parsed = JSON.parse(content);
+    
+    expect(parsed.paused).toBe(false);
+  });
+});
+
+describe("Pause Controller - Pause/Resume Operations", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(PAUSE_STATE_FILE, { force: true });
+      await rm(PAUSE_ACTIONS_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should pause with admission_only mode", async () => {
+    const action = await pause("admission_only", {
+      reason: "Maintenance window",
+      pausedBy: "operator-1",
+    });
+    
+    expect(action.action).toBe("pause");
+    expect(action.mode).toBe("admission_only");
+    expect(action.reason).toBe("Maintenance window");
+    expect(action.actor).toBe("operator-1");
+    
+    const state = await getPauseState();
+    expect(state.paused).toBe(true);
+    expect(state.mode).toBe("admission_only");
+    expect(state.pausedBy).toBe("operator-1");
+    expect(state.reason).toBe("Maintenance window");
+  });
+
+  it("should pause with admission_and_scheduling mode", async () => {
+    const action = await pause("admission_and_scheduling", {
+      reason: "Critical issue",
+      pausedBy: "operator-2",
+    });
+    
+    expect(action.mode).toBe("admission_and_scheduling");
+    
+    const state = await getPauseState();
+    expect(state.paused).toBe(true);
+    expect(state.mode).toBe("admission_and_scheduling");
+  });
+
+  it("should resume from paused state", async () => {
+    await pause("admission_only", {
+      reason: "Testing",
+      pausedBy: "operator-1",
+    });
+    
+    const action = await resume({
+      reason: "Issue resolved",
+      resumedBy: "operator-2",
+    });
+    
+    expect(action.action).toBe("resume");
+    expect(action.reason).toBe("Issue resolved");
+    expect(action.actor).toBe("operator-2");
+    
+    const state = await getPauseState();
+    expect(state.paused).toBe(false);
+    expect(state.resumedAt).toBeDefined();
+    expect(state.resumedBy).toBe("operator-2");
+  });
+
+  it("should handle resume when not paused", async () => {
+    const action = await resume({
+      reason: "Attempting resume",
+      resumedBy: "operator-1",
+    });
+    
+    expect(action.action).toBe("resume");
+    
+    const state = await getPauseState();
+    expect(state.paused).toBe(false);
+  });
+
+  it("should track isPaused correctly", async () => {
+    expect(await isPaused()).toBe(false);
+    
+    await pause("admission_only", { reason: "Test" });
+    expect(await isPaused()).toBe(true);
+    
+    await resume({});
+    expect(await isPaused()).toBe(false);
+  });
+});
+
+describe("Pause Controller - Pause Mode Semantics", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(PAUSE_STATE_FILE, { force: true });
+      await rm(PAUSE_ACTIONS_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("shouldBlockAdmission returns true when paused (any mode)", async () => {
+    expect(await shouldBlockAdmission()).toBe(false);
+    
+    await pause("admission_only", { reason: "Test" });
+    expect(await shouldBlockAdmission()).toBe(true);
+    
+    await resume({});
+    await pause("admission_and_scheduling", { reason: "Test 2" });
+    expect(await shouldBlockAdmission()).toBe(true);
+  });
+
+  it("shouldBlockScheduling returns true only in admission_and_scheduling mode", async () => {
+    expect(await shouldBlockScheduling()).toBe(false);
+    
+    await pause("admission_only", { reason: "Test" });
+    expect(await shouldBlockScheduling()).toBe(false);
+    
+    await resume({});
+    await pause("admission_and_scheduling", { reason: "Test 2" });
+    expect(await shouldBlockScheduling()).toBe(true);
+  });
+});
+
+describe("Pause Controller - Persistence Across Restart", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(PAUSE_STATE_FILE, { force: true });
+      await rm(PAUSE_ACTIONS_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should persist pause state across cache clear (simulated restart)", async () => {
+    await pause("admission_and_scheduling", {
+      reason: "Critical maintenance",
+      pausedBy: "admin",
+    });
+    
+    // Simulate restart by clearing cache
+    clearPauseCache();
+    
+    // State should still be paused after re-initialization
+    const state = await getPauseState();
+    expect(state.paused).toBe(true);
+    expect(state.mode).toBe("admission_and_scheduling");
+    expect(state.reason).toBe("Critical maintenance");
+    expect(state.pausedBy).toBe("admin");
+  });
+
+  it("should maintain pause history across restarts", async () => {
+    await pause("admission_only", { reason: "First pause" });
+    await resume({ reason: "First resume" });
+    await pause("admission_only", { reason: "Second pause" });
+    
+    clearPauseCache();
+    
+    const history = await getPauseHistory();
+    expect(history.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("Pause Controller - Action History", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(PAUSE_STATE_FILE, { force: true });
+      await rm(PAUSE_ACTIONS_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should record pause actions", async () => {
+    await pause("admission_only", {
+      reason: "Test pause",
+      pausedBy: "test-operator",
+    });
+    
+    const history = await getPauseHistory();
+    const pauseActions = history.filter(h => h.action === "pause");
+    
+    expect(pauseActions.length).toBeGreaterThanOrEqual(1);
+    expect(pauseActions[0].reason).toBe("Test pause");
+    expect(pauseActions[0].actor).toBe("test-operator");
+    expect(pauseActions[0].actionId).toBeDefined();
+  });
+
+  it("should record resume actions", async () => {
+    await pause("admission_only", { reason: "Test" });
+    await resume({ reason: "Test resume", resumedBy: "operator-2" });
+    
+    const history = await getPauseHistory();
+    const resumeActions = history.filter(h => h.action === "resume");
+    
+    expect(resumeActions.length).toBeGreaterThanOrEqual(1);
+    expect(resumeActions[0].reason).toBe("Test resume");
+    expect(resumeActions[0].actor).toBe("operator-2");
+  });
+
+  it("should track previous and new state in actions", async () => {
+    await pause("admission_only", { reason: "First" });
+    const action = await resume({ reason: "Second" });
+    
+    expect(action.previousState).toBeDefined();
+    expect(action.previousState!.paused).toBe(true);
+    expect(action.newState).toBeDefined();
+    expect(action.newState.paused).toBe(false);
+  });
+
+  it("should respect limit parameter", async () => {
+    // Create multiple actions
+    for (let i = 0; i < 5; i++) {
+      await pause("admission_only", { reason: `Pause ${i}` });
+      await resume({ reason: `Resume ${i}` });
+    }
+    
+    const history = await getPauseHistory(3);
+    expect(history.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("Pause Controller - Metadata Support", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(PAUSE_STATE_FILE, { force: true });
+      await rm(PAUSE_ACTIONS_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should store metadata in pause state", async () => {
+    await pause("admission_only", {
+      reason: "Test",
+      metadata: { ticketId: "TICKET-123", priority: "high" },
+    });
+    
+    const state = await getPauseState();
+    expect(state.metadata).toEqual({
+      ticketId: "TICKET-123",
+      priority: "high",
+    });
+  });
+
+  it("should merge metadata on resume", async () => {
+    await pause("admission_only", {
+      reason: "Test",
+      metadata: { original: "value" },
+    });
+    
+    await resume({
+      reason: "Resume test",
+      metadata: { additional: "info" },
+    });
+    
+    const state = await getPauseState();
+    expect(state.metadata).toEqual({
+      original: "value",
+      additional: "info",
+    });
+  });
+});

--- a/src/__tests__/escalation/status.test.ts
+++ b/src/__tests__/escalation/status.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Tests for escalation/status.ts
+ * 
+ * Run with: bun test src/__tests__/escalation/status.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  getEscalationStatus,
+  getEscalationSummary,
+  requiresAttention,
+  formatStatus,
+  exportStatusAsJson,
+} from "../../escalation/status";
+import { pause, resume, resetPauseController } from "../../escalation/pause";
+import { createHandoff, acceptHandoff, closeHandoff, resetHandoffManager } from "../../escalation/handoff";
+import { notify, resetNotificationManager } from "../../escalation/notifications";
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+
+describe("Escalation Status - Basic Operations", () => {
+  beforeEach(async () => {
+    // Clean directories before test to ensure isolation
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "pause-actions.jsonl"), { force: true });
+      await rm(join(ESCALATION_DIR, "paused.json"), { force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+    
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+    
+    // Disable rate limits for testing
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should get escalation status when empty", async () => {
+    const status = await getEscalationStatus();
+    
+    expect(status.timestamp).toBeDefined();
+    expect(status.pause.paused).toBe(false);
+    expect(status.handoffs).toHaveLength(0);
+    expect(status.notifications).toHaveLength(0);
+    expect(status.summary.totalHandoffs).toBe(0);
+    expect(status.summary.isPaused).toBe(false);
+  });
+
+  it("should include pause status when paused", async () => {
+    await pause("admission_only", { reason: "Test pause", pausedBy: "operator" });
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.pause.paused).toBe(true);
+    expect(status.pause.mode).toBe("admission_only");
+    expect(status.pause.reason).toBe("Test pause");
+    expect(status.pause.pausedBy).toBe("operator");
+    expect(status.summary.isPaused).toBe(true);
+  });
+
+  it("should include handoffs in status", async () => {
+    await createHandoff("Test handoff", { source: "telegram" }, { severity: "warning" });
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.handoffs).toHaveLength(1);
+    expect(status.handoffs[0].reason).toBe("Test handoff");
+    expect(status.handoffs[0].status).toBe("open");
+    expect(status.handoffs[0].severity).toBe("warning");
+    expect(status.summary.totalHandoffs).toBe(1);
+    expect(status.summary.openHandoffs).toBe(1);
+  });
+
+  it("should include notifications in status", async () => {
+    await notify("dlq_overflow", "warning", "DLQ is filling up");
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.notifications).toHaveLength(1);
+    expect(status.notifications[0].type).toBe("dlq_overflow");
+    expect(status.notifications[0].severity).toBe("warning");
+  });
+
+  it("should count critical handoffs correctly", async () => {
+    await createHandoff("Critical handoff", {}, { severity: "critical" });
+    await createHandoff("Warning handoff", {}, { severity: "warning" });
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.summary.criticalHandoffs).toBe(1);
+  });
+
+  it("should not count closed handoffs as critical", async () => {
+    const handoff = await createHandoff("Critical handoff", {}, { severity: "critical" });
+    await closeHandoff(handoff.handoffId, { closedBy: "operator" });
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.summary.criticalHandoffs).toBe(0);
+    expect(status.summary.openHandoffs).toBe(0);
+  });
+});
+
+describe("Escalation Status - Filtering", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+    
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should respect handoff limit", async () => {
+    for (let i = 0; i < 5; i++) {
+      await createHandoff(`Handoff ${i}`);
+    }
+    
+    const status = await getEscalationStatus({ handoffLimit: 3 });
+    
+    expect(status.handoffs).toHaveLength(3);
+  });
+
+  it("should respect notification limit", async () => {
+    for (let i = 0; i < 5; i++) {
+      await notify("dlq_overflow", "info", `Message ${i}`);
+    }
+    
+    const status = await getEscalationStatus({ notificationLimit: 3 });
+    
+    expect(status.notifications).toHaveLength(3);
+  });
+
+  it("should include closed handoffs when requested", async () => {
+    const h1 = await createHandoff("Open handoff");
+    const h2 = await createHandoff("Closed handoff");
+    await closeHandoff(h2.handoffId, {});
+    
+    const statusWithClosed = await getEscalationStatus({ includeClosedHandoffs: true });
+    const statusWithoutClosed = await getEscalationStatus({ includeClosedHandoffs: false });
+    
+    expect(statusWithClosed.handoffs).toHaveLength(2);
+    expect(statusWithoutClosed.handoffs).toHaveLength(1);
+  });
+
+  it("should filter by since date", async () => {
+    // Create an old handoff
+    const oldHandoff = await createHandoff("Old handoff");
+    
+    // Wait a bit and create a new one
+    await new Promise(r => setTimeout(r, 50));
+    const since = new Date().toISOString();
+    await new Promise(r => setTimeout(r, 50));
+    
+    await createHandoff("New handoff");
+    
+    const status = await getEscalationStatus({ since });
+    
+    expect(status.handoffs).toHaveLength(1);
+    expect(status.handoffs[0].reason).toBe("New handoff");
+  });
+});
+
+describe("Escalation Status - Summary", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+    
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should get escalation summary", async () => {
+    await pause("admission_only", { reason: "Test" });
+    await createHandoff("Test handoff", {}, { severity: "critical" });
+    await notify("dlq_overflow", "warning", "Test notification");
+    
+    const summary = await getEscalationSummary();
+    
+    expect(summary.isPaused).toBe(true);
+    expect(summary.totalHandoffs).toBe(1);
+    expect(summary.criticalHandoffs).toBe(1);
+    expect(summary.openHandoffs).toBe(1);
+  });
+
+  it("should count notifications from last 24 hours", async () => {
+    await notify("dlq_overflow", "info", "Recent notification");
+    
+    const summary = await getEscalationSummary();
+    
+    expect(summary.totalNotifications24h).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("Escalation Status - Requires Attention", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+    
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should not require attention when system is healthy", async () => {
+    const result = await requiresAttention();
+    
+    expect(result.requiresAttention).toBe(false);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it("should require attention when paused", async () => {
+    await pause("admission_only", { reason: "Maintenance" });
+    
+    const result = await requiresAttention();
+    
+    expect(result.requiresAttention).toBe(true);
+    expect(result.reasons.some(r => r.includes("paused"))).toBe(true);
+  });
+
+  it("should require attention with critical handoffs", async () => {
+    await createHandoff("Critical issue", {}, { severity: "critical" });
+    
+    const result = await requiresAttention();
+    
+    expect(result.requiresAttention).toBe(true);
+    expect(result.reasons.some(r => r.includes("critical"))).toBe(true);
+  });
+});
+
+describe("Escalation Status - Formatting", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+    
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should format status as human-readable string", async () => {
+    await pause("admission_only", { reason: "Test" });
+    await createHandoff("Test handoff");
+    
+    const status = await getEscalationStatus();
+    const formatted = formatStatus(status);
+    
+    expect(formatted).toContain("ESCALATION STATUS");
+    expect(formatted).toContain("PAUSE STATUS");
+    expect(formatted).toContain("SYSTEM IS PAUSED");
+    expect(formatted).toContain("HANDOFFS");
+    expect(formatted).toContain("Test handoff");
+    expect(formatted).toContain("SUMMARY");
+  });
+
+  it("should format running status correctly", async () => {
+    const status = await getEscalationStatus();
+    const formatted = formatStatus(status);
+    
+    expect(formatted).toContain("System is running normally");
+  });
+
+  it("should export status as JSON", async () => {
+    await createHandoff("Test");
+    
+    const status = await getEscalationStatus();
+    const json = exportStatusAsJson(status);
+    
+    const parsed = JSON.parse(json);
+    expect(parsed.timestamp).toBeDefined();
+    expect(parsed.pause).toBeDefined();
+    expect(parsed.handoffs).toBeDefined();
+    expect(parsed.summary).toBeDefined();
+  });
+});
+
+describe("Escalation Status - Recent Actions", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+    
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "pause-actions.jsonl"), { force: true });
+      await rm(join(ESCALATION_DIR, "handoff-actions.jsonl"), { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should include pause actions in recent actions", async () => {
+    await pause("admission_only", { reason: "Test" });
+    await resume({ reason: "Done" });
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.recentActions.length).toBeGreaterThanOrEqual(2);
+    expect(status.recentActions.some(a => a.action === "pause")).toBe(true);
+    expect(status.recentActions.some(a => a.action === "resume")).toBe(true);
+  });
+
+  it("should include handoff actions in recent actions", async () => {
+    const handoff = await createHandoff("Test handoff");
+    await acceptHandoff(handoff.handoffId, { acceptedBy: "operator" });
+    
+    const status = await getEscalationStatus();
+    
+    expect(status.recentActions.some(a => a.action === "handoff_created")).toBe(true);
+    expect(status.recentActions.some(a => a.action === "handoff_accepted")).toBe(true);
+  });
+
+  it("should respect action limit", async () => {
+    await pause("admission_only", { reason: "Test 1" });
+    await resume({ reason: "Done 1" });
+    await pause("admission_only", { reason: "Test 2" });
+    await resume({ reason: "Done 2" });
+    
+    const status = await getEscalationStatus({ actionLimit: 2 });
+    
+    expect(status.recentActions).toHaveLength(2);
+  });
+});

--- a/src/__tests__/escalation/triggers.test.ts
+++ b/src/__tests__/escalation/triggers.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Tests for escalation/triggers.ts
+ * 
+ * Run with: bun test src/__tests__/escalation/triggers.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  handleEscalationTrigger,
+  shouldPause,
+  shouldCreateHandoff,
+  shouldNotify,
+  configureEscalationPolicy,
+  getEscalationPolicy,
+  resetEscalationPolicy,
+  handlePolicyDenial,
+  handleWatchdogTrigger,
+  handleDlqOverflow,
+  handleOrchestrationFailure,
+  handleManualEscalation,
+  resetTriggerIntegration,
+  getFailureCounts,
+  clearFailureCount,
+  type TriggerContext,
+  type EscalationPolicy,
+} from "../../escalation/triggers";
+import { getPauseState, resetPauseController } from "../../escalation/pause";
+import { listHandoffs, resetHandoffManager } from "../../escalation/handoff";
+import { listNotifications, resetNotificationManager } from "../../escalation/notifications";
+import type { WatchdogDecision } from "../../governance/watchdog";
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+
+describe("Escalation Triggers - Policy Management", () => {
+  beforeEach(() => {
+    resetEscalationPolicy();
+  });
+
+  it("should have default policy", () => {
+    const policy = getEscalationPolicy();
+    
+    expect(policy.pauseOnCriticalPolicyDenial).toBe(true);
+    expect(policy.pauseOnWatchdogSuspend).toBe(true);
+    expect(policy.createHandoffOnPolicyDenial).toBe(true);
+    expect(policy.notifyOnPolicyDenial).toBe(true);
+    expect(policy.minHandoffSeverity).toBe("warning");
+    expect(policy.repeatedFailureThreshold).toBe(3);
+  });
+
+  it("should update policy", () => {
+    configureEscalationPolicy({
+      pauseOnCriticalPolicyDenial: false,
+      minHandoffSeverity: "critical",
+    });
+    
+    const policy = getEscalationPolicy();
+    expect(policy.pauseOnCriticalPolicyDenial).toBe(false);
+    expect(policy.minHandoffSeverity).toBe("critical");
+    // Other values should remain
+    expect(policy.pauseOnWatchdogSuspend).toBe(true);
+  });
+
+  it("should reset policy to defaults", () => {
+    configureEscalationPolicy({ pauseOnCriticalPolicyDenial: false });
+    resetEscalationPolicy();
+    
+    const policy = getEscalationPolicy();
+    expect(policy.pauseOnCriticalPolicyDenial).toBe(true);
+  });
+});
+
+describe("Escalation Triggers - shouldPause", () => {
+  beforeEach(() => {
+    resetEscalationPolicy();
+  });
+
+  it("should pause on critical policy denial", () => {
+    const context: TriggerContext = {
+      source: "policy_denial",
+      severity: "critical",
+    };
+    
+    expect(shouldPause(context)).toBe(true);
+  });
+
+  it("should not pause on non-critical policy denial", () => {
+    const context: TriggerContext = {
+      source: "policy_denial",
+      severity: "warning",
+    };
+    
+    expect(shouldPause(context)).toBe(false);
+  });
+
+  it("should pause on watchdog suspend", () => {
+    const decision: WatchdogDecision = {
+      invocationId: "test",
+      state: "suspend",
+      reason: "Too many tool calls",
+      triggeredLimits: ["maxToolCalls"],
+      recommendedAction: "pause",
+      evaluatedAt: new Date().toISOString(),
+    };
+    
+    const context: TriggerContext = {
+      source: "watchdog",
+      watchdogDecision: decision,
+    };
+    
+    expect(shouldPause(context)).toBe(true);
+  });
+
+  it("should pause on watchdog kill", () => {
+    const decision: WatchdogDecision = {
+      invocationId: "test",
+      state: "kill",
+      reason: "Runaway execution",
+      triggeredLimits: ["maxRuntimeSeconds"],
+      recommendedAction: "terminate",
+      evaluatedAt: new Date().toISOString(),
+    };
+    
+    const context: TriggerContext = {
+      source: "watchdog",
+      watchdogDecision: decision,
+    };
+    
+    expect(shouldPause(context)).toBe(true);
+  });
+
+  it("should not pause on watchdog warn", () => {
+    const decision: WatchdogDecision = {
+      invocationId: "test",
+      state: "warn",
+      reason: "Approaching limit",
+      triggeredLimits: [],
+      recommendedAction: "review",
+      evaluatedAt: new Date().toISOString(),
+    };
+    
+    const context: TriggerContext = {
+      source: "watchdog",
+      watchdogDecision: decision,
+    };
+    
+    expect(shouldPause(context)).toBe(false);
+  });
+
+  it("should not pause on manual escalation", () => {
+    const context: TriggerContext = {
+      source: "manual_escalation",
+      severity: "critical",
+    };
+    
+    expect(shouldPause(context)).toBe(false);
+  });
+
+  it("should respect policy disable", () => {
+    configureEscalationPolicy({ pauseOnCriticalPolicyDenial: false });
+    
+    const context: TriggerContext = {
+      source: "policy_denial",
+      severity: "critical",
+    };
+    
+    expect(shouldPause(context)).toBe(false);
+  });
+});
+
+describe("Escalation Triggers - shouldCreateHandoff", () => {
+  beforeEach(() => {
+    resetEscalationPolicy();
+  });
+
+  it("should create handoff on policy denial", () => {
+    const context: TriggerContext = {
+      source: "policy_denial",
+      severity: "warning",
+    };
+    
+    expect(shouldCreateHandoff(context)).toBe(true);
+  });
+
+  it("should not create handoff below minimum severity", () => {
+    configureEscalationPolicy({ minHandoffSeverity: "critical" });
+    
+    const context: TriggerContext = {
+      source: "policy_denial",
+      severity: "warning",
+    };
+    
+    expect(shouldCreateHandoff(context)).toBe(false);
+  });
+
+  it("should create handoff on watchdog trigger", () => {
+    const context: TriggerContext = {
+      source: "watchdog",
+      severity: "warning",
+    };
+    
+    expect(shouldCreateHandoff(context)).toBe(true);
+  });
+
+  it("should create handoff on manual escalation", () => {
+    const context: TriggerContext = {
+      source: "manual_escalation",
+      severity: "warning",
+    };
+    
+    expect(shouldCreateHandoff(context)).toBe(true);
+  });
+
+  it("should create handoff on critical DLQ overflow", () => {
+    const context: TriggerContext = {
+      source: "dlq_overflow",
+      severity: "critical",
+    };
+    
+    expect(shouldCreateHandoff(context)).toBe(true);
+  });
+
+  it("should not create handoff on non-critical DLQ overflow", () => {
+    const context: TriggerContext = {
+      source: "dlq_overflow",
+      severity: "warning",
+    };
+    
+    expect(shouldCreateHandoff(context)).toBe(false);
+  });
+});
+
+describe("Escalation Triggers - shouldNotify", () => {
+  it("should notify on all triggers by default", () => {
+    const sources: TriggerContext["source"][] = [
+      "policy_denial",
+      "watchdog",
+      "dlq_overflow",
+      "orchestration_failure",
+      "manual_escalation",
+      "policy_approval_timeout",
+    ];
+    
+    for (const source of sources) {
+      expect(shouldNotify({ source })).toBe(true);
+    }
+  });
+
+  it("should respect notification policy settings", () => {
+    configureEscalationPolicy({ notifyOnPolicyDenial: false });
+    
+    expect(shouldNotify({ source: "policy_denial" })).toBe(false);
+    expect(shouldNotify({ source: "watchdog" })).toBe(true); // Still enabled
+  });
+});
+
+describe("Escalation Triggers - Integration", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "handoffs"), { recursive: true });
+    await mkdir(join(ESCALATION_DIR, "notifications"), { recursive: true });
+    resetEscalationPolicy();
+    resetTriggerIntegration();
+    await resetPauseController();
+    await resetHandoffManager();
+    await resetNotificationManager();
+
+    // Disable rate limits for testing
+    const { configure } = await import("../../escalation/notifications");
+    await configure({ rateLimits: { perTypePerMinute: 100, perSeverityPerMinute: 100 } });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should handle policy denial trigger", async () => {
+    const action = await handlePolicyDenial(
+      "evt-123",
+      "Bash",
+      "Security policy violation",
+      { severity: "warning", channelId: "telegram:123" }
+    );
+    
+    expect(action.pause).toBe(false); // Not critical
+    expect(action.handoff).toBe(true);
+    expect(action.notification).toBe(true);
+    expect(action.notificationType).toBe("policy_denial");
+  });
+
+  it("should pause on critical policy denial", async () => {
+    const action = await handlePolicyDenial(
+      "evt-456",
+      "Edit",
+      "Critical security violation",
+      { severity: "critical" }
+    );
+    
+    expect(action.pause).toBe(true);
+    expect(action.pauseMode).toBe("admission_and_scheduling");
+    
+    // Verify pause state
+    const pauseState = await getPauseState();
+    expect(pauseState.paused).toBe(true);
+  });
+
+  it("should handle watchdog trigger", async () => {
+    const decision: WatchdogDecision = {
+      invocationId: "inv-123",
+      state: "suspend",
+      reason: "Too many tool calls",
+      triggeredLimits: ["maxToolCalls"],
+      recommendedAction: "pause",
+      evaluatedAt: new Date().toISOString(),
+    };
+    
+    const action = await handleWatchdogTrigger(decision, {
+      invocationId: "inv-123",
+      sessionId: "session-456",
+    });
+    
+    expect(action.pause).toBe(true);
+    expect(action.handoff).toBe(true);
+    expect(action.notification).toBe(true);
+  });
+
+  it("should handle DLQ overflow trigger", async () => {
+    const action = await handleDlqOverflow(150, 100, {
+      eventId: "evt-789",
+      workflowId: "wf-abc",
+    });
+    
+    expect(action.notification).toBe(true);
+    // Not critical, so no handoff
+    expect(action.handoff).toBe(false);
+  });
+
+  it("should handle critical DLQ overflow", async () => {
+    const action = await handleDlqOverflow(300, 100, {
+      eventId: "evt-critical",
+    });
+    
+    expect(action.notification).toBe(true);
+    expect(action.handoff).toBe(true); // Critical creates handoff
+  });
+
+  it("should track repeated orchestration failures", async () => {
+    const workflowId = "wf-repeated";
+    
+    // First two failures should not pause
+    await handleOrchestrationFailure(workflowId, "Error 1");
+    await handleOrchestrationFailure(workflowId, "Error 2");
+    
+    const counts = getFailureCounts();
+    expect(counts[workflowId].count).toBe(2);
+    
+    // Third failure should trigger pause
+    const action = await handleOrchestrationFailure(workflowId, "Error 3");
+    expect(action.pause).toBe(true);
+  });
+
+  it("should handle manual escalation", async () => {
+    const action = await handleManualEscalation(
+      "Operator needs assistance",
+      { severity: "warning", workflowId: "wf-help" }
+    );
+    
+    expect(action.pause).toBe(false); // Manual doesn't auto-pause
+    expect(action.handoff).toBe(true);
+    expect(action.notification).toBe(true);
+  });
+
+  it("should create handoffs with correct context", async () => {
+    await handleManualEscalation("Test", {
+      workflowId: "wf-test",
+      sessionId: "session-test",
+      channelId: "telegram:123",
+    });
+    
+    const handoffs = await listHandoffs();
+    expect(handoffs.length).toBeGreaterThanOrEqual(1);
+    
+    const handoff = handoffs.find(h => h.reason.includes("Test"));
+    expect(handoff).toBeDefined();
+  });
+
+  it("should generate audit log entries", async () => {
+    const action = await handleEscalationTrigger({
+      source: "manual_escalation",
+      severity: "warning",
+      message: "Audit test",
+    });
+    
+    expect(action.actionId).toBeDefined();
+    expect(action.timestamp).toBeDefined();
+  });
+});
+
+describe("Escalation Triggers - Failure Count Management", () => {
+  beforeEach(() => {
+    resetEscalationPolicy();
+    clearFailureCount("test-workflow");
+  });
+
+  it("should track failure counts per workflow", () => {
+    const workflowId = "test-workflow";
+    
+    clearFailureCount(workflowId);
+    
+    // Simulate failures
+    const context1: TriggerContext = { source: "orchestration_failure", workflowId };
+    const context2: TriggerContext = { source: "orchestration_failure", workflowId };
+    
+    shouldPause({ ...context1, severity: "warning" });
+    shouldPause({ ...context2, severity: "warning" });
+    
+    const counts = getFailureCounts();
+    expect(counts[workflowId].count).toBe(2);
+  });
+
+  it("should clear failure counts", () => {
+    const workflowId = "test-workflow";
+    
+    shouldPause({ source: "orchestration_failure", workflowId, severity: "warning" });
+    clearFailureCount(workflowId);
+    
+    const counts = getFailureCounts();
+    expect(counts[workflowId]).toBeUndefined();
+  });
+
+  it("should reset failure counts with policy", () => {
+    const workflowId = "test-workflow";
+    
+    shouldPause({ source: "orchestration_failure", workflowId, severity: "warning" });
+    resetEscalationPolicy();
+    
+    const counts = getFailureCounts();
+    expect(Object.keys(counts).length).toBe(0);
+  });
+});
+
+describe("Escalation Triggers - Pause Mode Determination", () => {
+  beforeEach(async () => {
+    await mkdir(ESCALATION_DIR, { recursive: true });
+    resetEscalationPolicy();
+    await resetPauseController();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(join(ESCALATION_DIR, "notifications"), { recursive: true, force: true });
+      await rm(join(ESCALATION_DIR, "handoffs"), { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should use admission_and_scheduling for critical severity", async () => {
+    await handlePolicyDenial("evt-1", "Bash", "Critical", { severity: "critical" });
+    
+    const state = await getPauseState();
+    expect(state.mode).toBe("admission_and_scheduling");
+  });
+
+  it("should use admission_only for warning severity", async () => {
+    // Disable auto-pause for critical to test warning
+    configureEscalationPolicy({ pauseOnCriticalPolicyDenial: false });
+    
+    // Create a watchdog suspend (which pauses)
+    const decision: WatchdogDecision = {
+      invocationId: "inv-1",
+      state: "suspend",
+      reason: "Test",
+      triggeredLimits: [],
+      recommendedAction: "pause",
+      evaluatedAt: new Date().toISOString(),
+    };
+    
+    await handleWatchdogTrigger(decision, { invocationId: "inv-1" });
+    
+    const state = await getPauseState();
+    expect(state.mode).toBe("admission_only");
+  });
+});

--- a/src/__tests__/event-log.test.ts
+++ b/src/__tests__/event-log.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for event-log.ts
+ * 
+ * Run with: bun test src/__tests__/event-log.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm, readdir } from "fs/promises";
+import { join } from "path";
+import {
+  initEventLog,
+  append,
+  readFrom,
+  readRange,
+  getLastSeq,
+  getStats,
+  appendStatusUpdate,
+  type EventEntryInput,
+} from "../event-log";
+
+const TEST_DIR = join(process.cwd(), ".claude", "claudeclaw", "event-log-test");
+
+// Override the event log directory for testing
+const originalCwd = process.cwd();
+
+// Test helper - available to all test suites
+const createTestEntry = (overrides: Partial<EventEntryInput> = {}): EventEntryInput => ({
+  type: "test",
+  source: "test-source",
+  channelId: "test-channel",
+  threadId: "test-thread",
+  payload: { message: "hello" },
+  dedupeKey: `test-${Date.now()}-${Math.random()}`,
+  ...overrides,
+});
+
+beforeEach(async () => {
+  // Create isolated test directory
+  await rm(TEST_DIR, { recursive: true, force: true });
+  await mkdir(TEST_DIR, { recursive: true });
+  
+  // Reset module state by re-importing
+  // Note: In real tests we'd need to clear the module cache
+});
+
+afterEach(async () => {
+  await rm(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("Event Log", () => {
+
+  it("should initialize event log", async () => {
+    await initEventLog();
+    const stats = await getStats();
+    expect(stats.totalSegments).toBeGreaterThanOrEqual(0);
+    expect(stats.lastSeq).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should append events with monotonic sequence numbers", async () => {
+    await initEventLog();
+    
+    const entry1 = createTestEntry();
+    const entry2 = createTestEntry();
+    const entry3 = createTestEntry();
+
+    const record1 = await append(entry1);
+    const record2 = await append(entry2);
+    const record3 = await append(entry3);
+
+    expect(record1.seq).toBeLessThan(record2.seq);
+    expect(record2.seq).toBeLessThan(record3.seq);
+    expect(record3.seq - record1.seq).toBe(2);
+  });
+
+  it("should read events from a sequence number", async () => {
+    await initEventLog();
+    
+    const entries = [
+      createTestEntry(),
+      createTestEntry(),
+      createTestEntry(),
+    ];
+
+    const records = await Promise.all(entries.map(e => append(e)));
+    const startSeq = records[1].seq;
+
+    const readEvents: typeof records = [];
+    for await (const event of readFrom(startSeq)) {
+      readEvents.push(event);
+    }
+
+    expect(readEvents.length).toBe(2);
+    expect(readEvents[0].seq).toBe(startSeq);
+    expect(readEvents[1].seq).toBe(startSeq + 1);
+  });
+
+  it("should read events in a range", async () => {
+    await initEventLog();
+    
+    const entries = [
+      createTestEntry(),
+      createTestEntry(),
+      createTestEntry(),
+      createTestEntry(),
+      createTestEntry(),
+    ];
+
+    const records = await Promise.all(entries.map(e => append(e)));
+    const startSeq = records[1].seq;
+    const endSeq = records[3].seq;
+
+    const readEvents: typeof records = [];
+    for await (const event of readRange(startSeq, endSeq)) {
+      readEvents.push(event);
+    }
+
+    expect(readEvents.length).toBe(3);
+    expect(readEvents[0].seq).toBe(startSeq);
+    expect(readEvents[2].seq).toBe(endSeq);
+  });
+
+  it("should maintain correct event status", async () => {
+    await initEventLog();
+    
+    const entry = createTestEntry();
+    const record = await append(entry);
+
+    expect(record.status).toBe("pending");
+    expect(record.retryCount).toBe(0);
+    expect(record.nextRetryAt).toBeNull();
+  });
+
+  it("should assign unique IDs to events", async () => {
+    await initEventLog();
+    
+    const entry1 = createTestEntry();
+    const entry2 = createTestEntry();
+
+    const record1 = await append(entry1);
+    const record2 = await append(entry2);
+
+    expect(record1.id).not.toBe(record2.id);
+    expect(record1.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  it("should preserve dedupe keys", async () => {
+    await initEventLog();
+    
+    const dedupeKey = "my-unique-dedupe-key";
+    const entry = createTestEntry({ dedupeKey });
+    const record = await append(entry);
+
+    expect(record.dedupeKey).toBe(dedupeKey);
+  });
+
+  it("should handle correlation and causation IDs", async () => {
+    await initEventLog();
+    
+    const correlationId = "corr-123";
+    const causationId = "cause-456";
+    const replayedFromEventId = "orig-789";
+    
+    const entry = createTestEntry({
+      correlationId,
+      causationId,
+      replayedFromEventId,
+    });
+    
+    const record = await append(entry);
+
+    expect(record.correlationId).toBe(correlationId);
+    expect(record.causationId).toBe(causationId);
+    expect(record.replayedFromEventId).toBe(replayedFromEventId);
+  });
+
+  it("should return correct statistics", async () => {
+    await initEventLog();
+    
+    const initialStats = await getStats();
+    const initialSeq = initialStats.lastSeq;
+
+    await append(createTestEntry());
+    await append(createTestEntry());
+    await append(createTestEntry());
+
+    const finalStats = await getStats();
+    expect(finalStats.lastSeq).toBe(initialSeq + 3);
+    expect(finalStats.totalEvents).toBe(initialSeq + 3);
+  });
+
+  it("should get last sequence number", async () => {
+    await initEventLog();
+    
+    const initialSeq = await getLastSeq();
+    
+    await append(createTestEntry());
+    const seq1 = await getLastSeq();
+    
+    await append(createTestEntry());
+    const seq2 = await getLastSeq();
+
+    expect(seq1).toBe(initialSeq + 1);
+    expect(seq2).toBe(initialSeq + 2);
+  });
+
+  it("should support status updates as new events", async () => {
+    await initEventLog();
+    
+    const entry = createTestEntry();
+    const record = await append(entry);
+
+    const update = await appendStatusUpdate(record.id, {
+      status: "done",
+      retryCount: 1,
+    });
+
+    expect(update.type).toBe("__status_update__");
+    expect(update.causationId).toBe(record.id);
+    expect(update.seq).toBeGreaterThan(record.seq);
+  });
+
+  it("should include timestamps", async () => {
+    await initEventLog();
+    
+    const before = Date.now();
+    const record = await append(createTestEntry());
+    const after = Date.now();
+    
+    const recordTime = new Date(record.timestamp).getTime();
+
+    expect(recordTime).toBeGreaterThanOrEqual(before);
+    expect(recordTime).toBeLessThanOrEqual(after);
+    expect(record.createdAt).toBe(record.timestamp);
+    expect(record.updatedAt).toBe(record.timestamp);
+  });
+
+  it("should preserve complex payloads", async () => {
+    await initEventLog();
+    
+    const complexPayload = {
+      nested: { deep: { value: 123 } },
+      array: [1, 2, 3],
+      string: "test",
+      number: 42,
+      boolean: true,
+      null: null,
+    };
+
+    const entry = createTestEntry({ payload: complexPayload });
+    const record = await append(entry);
+
+    expect(record.payload).toEqual(complexPayload);
+  });
+
+  it("should handle empty readFrom when seq is beyond last", async () => {
+    await initEventLog();
+    
+    await append(createTestEntry());
+    const lastSeq = await getLastSeq();
+
+    const events: unknown[] = [];
+    for await (const event of readFrom(lastSeq + 100)) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(0);
+  });
+
+  it("should handle concurrent appends safely", async () => {
+    await initEventLog();
+    
+    const entries = Array.from({ length: 10 }, () => createTestEntry());
+    
+    // Concurrent appends
+    const promises = entries.map(e => append(e));
+    const records = await Promise.all(promises);
+
+    // All sequences should be unique and monotonic
+    const seqs = records.map(r => r.seq).sort((a, b) => a - b);
+    const uniqueSeqs = new Set(seqs);
+    
+    expect(uniqueSeqs.size).toBe(seqs.length);
+    
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]).toBe(seqs[i - 1] + 1);
+    }
+  });
+});
+
+describe("Event Log - Recovery", () => {
+  it("should rebuild state from disk after simulated restart", async () => {
+    await initEventLog();
+    
+    // Add some events
+    const entry1 = createTestEntry();
+    const entry2 = createTestEntry();
+    
+    const record1 = await append(entry1);
+    const record2 = await append(entry2);
+    
+    const lastSeqBefore = await getLastSeq();
+
+    // Simulate restart by reinitializing
+    // In real scenario, we'd clear module state
+    await initEventLog();
+    
+    const lastSeqAfter = await getLastSeq();
+    expect(lastSeqAfter).toBe(lastSeqBefore);
+
+    // Should still be able to read events
+    const events: typeof record1[] = [];
+    for await (const event of readFrom(1)) {
+      events.push(event);
+    }
+    
+    expect(events.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("Event Log - Edge Cases", () => {
+  it("should handle special characters in payload", async () => {
+    await initEventLog();
+    
+    const entry = createTestEntry({
+      payload: {
+        text: "Hello\nWorld\t! \"quoted\" and 'single'",
+        unicode: "日本語 🎉 émojis",
+        html: "<script>alert('xss')</script>",
+      },
+    });
+
+    const record = await append(entry);
+    expect(record.payload).toEqual(entry.payload);
+  });
+
+  it("should handle very long dedupe keys", async () => {
+    await initEventLog();
+    
+    const longKey = "x".repeat(1000);
+    const entry = createTestEntry({ dedupeKey: longKey });
+    const record = await append(entry);
+
+    expect(record.dedupeKey).toBe(longKey);
+  });
+
+  it("should handle empty thread and channel IDs", async () => {
+    await initEventLog();
+    
+    const entry = createTestEntry({
+      channelId: "",
+      threadId: "",
+    });
+
+    const record = await append(entry);
+    expect(record.channelId).toBe("");
+    expect(record.threadId).toBe("");
+  });
+});

--- a/src/__tests__/event-processor.test.ts
+++ b/src/__tests__/event-processor.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for event-processor.ts
+ * 
+ * Run with: bun test src/__tests__/event-processor.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm } from "fs/promises";
+import { join } from "path";
+import {
+  initEventLog,
+  append,
+  resetEventLog,
+  type EventEntryInput,
+} from "../event-log";
+import {
+  initProcessor,
+  processNext,
+  processPending,
+  getPendingCount,
+  getLastProcessedSeq,
+  getDedupeStats,
+  hasDedupeKey,
+  resetProcessor,
+  type ProcessingResult,
+} from "../event-processor";
+
+const TEST_DIR = join(process.cwd(), ".claude", "claudeclaw");
+
+beforeEach(async () => {
+  // Reset module state
+  resetEventLog();
+  
+  // Clean up test directories
+  await rm(join(TEST_DIR, "event-log"), { recursive: true, force: true });
+  await rm(join(TEST_DIR, "dedupe"), { recursive: true, force: true });
+  await mkdir(join(TEST_DIR, "event-log"), { recursive: true });
+  await mkdir(join(TEST_DIR, "dedupe"), { recursive: true });
+  
+  await resetProcessor();
+});
+
+afterEach(async () => {
+  await rm(join(TEST_DIR, "event-log"), { recursive: true, force: true });
+  await rm(join(TEST_DIR, "dedupe"), { recursive: true, force: true });
+});
+
+const createTestEntry = (overrides: Partial<EventEntryInput> = {}): EventEntryInput => ({
+  type: "test",
+  source: "test-source",
+  channelId: "test-channel",
+  threadId: "test-thread",
+  payload: { message: "hello" },
+  dedupeKey: `test-${Date.now()}-${Math.random()}`,
+  ...overrides,
+});
+
+describe("Event Processor", () => {
+  it("should initialize processor", async () => {
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => ({ success: true }),
+    });
+
+    const stats = getDedupeStats();
+    expect(stats.totalEntries).toBe(0);
+    expect(stats.retentionDays).toBe(7);
+  });
+
+  it("should process a single event", async () => {
+    let processed = false;
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async (event) => {
+        processed = true;
+        expect(event.type).toBe("test");
+        return { success: true };
+      },
+    });
+
+    await append(createTestEntry());
+    const didProcess = await processNext();
+
+    expect(didProcess).toBe(true);
+    expect(processed).toBe(true);
+  });
+
+  it("should process multiple events in order", async () => {
+    const processedSeqs: number[] = [];
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async (event) => {
+        processedSeqs.push(event.seq);
+        return { success: true };
+      },
+    });
+
+    await append(createTestEntry());
+    await append(createTestEntry());
+    await append(createTestEntry());
+
+    const count = await processPending();
+
+    expect(count).toBe(3);
+    expect(processedSeqs).toEqual([1, 2, 3]);
+  });
+
+  it("should deduplicate events by dedupeKey", async () => {
+    let processCount = 0;
+    const dedupeKey = "unique-key-123";
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => {
+        processCount++;
+        return { success: true };
+      },
+    });
+
+    // Append two events with same dedupe key
+    await append(createTestEntry({ dedupeKey }));
+    await append(createTestEntry({ dedupeKey }));
+
+    await processPending();
+
+    expect(processCount).toBe(1);
+    expect(hasDedupeKey(dedupeKey)).toBe(true);
+  });
+
+  it("should handle event failure with retry", async () => {
+    let attempts = 0;
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => {
+        attempts++;
+        return { 
+          success: false, 
+          error: "Temporary error",
+          shouldRetry: true 
+        };
+      },
+    });
+
+    const entry = await append(createTestEntry());
+    await processNext();
+
+    expect(attempts).toBe(1);
+    // Event should be marked for retry
+    // (Full retry logic tested in retry-queue.test.ts)
+  });
+
+  it("should handle permanent failure", async () => {
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => ({
+        success: false,
+        error: "Permanent error",
+        shouldRetry: false,
+      }),
+    });
+
+    const entry = await append(createTestEntry());
+    await processNext();
+
+    // Event should be marked dead_lettered
+    // (DLQ logic tested in dead-letter-queue.test.ts)
+  });
+
+  it("should get pending count", async () => {
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => ({ success: true }),
+    });
+
+    await append(createTestEntry());
+    await append(createTestEntry());
+
+    const pendingBefore = await getPendingCount();
+    expect(pendingBefore).toBe(2);
+
+    await processNext();
+
+    const pendingAfter = await getPendingCount();
+    expect(pendingAfter).toBe(1);
+  });
+
+  it("should track last processed sequence", async () => {
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => ({ success: true }),
+    });
+
+    expect(getLastProcessedSeq()).toBe(0);
+
+    await append(createTestEntry());
+    await processNext();
+
+    expect(getLastProcessedSeq()).toBe(1);
+  });
+
+  it("should use canonical dedupe key when dedupeKey not provided", async () => {
+    let processCount = 0;
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => {
+        processCount++;
+        return { success: true };
+      },
+    });
+
+    // Same payload, no dedupeKey - should generate same canonical key
+    const payload = { action: "test", data: "same" };
+    await append(createTestEntry({ payload, dedupeKey: "" }));
+    await append(createTestEntry({ payload, dedupeKey: "" }));
+
+    await processPending();
+
+    expect(processCount).toBe(1);
+  });
+
+  it("should survive restart", async () => {
+    const dedupeKey = "restart-test-key";
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => ({ success: true }),
+    });
+
+    await append(createTestEntry({ dedupeKey }));
+    await processNext();
+
+    expect(hasDedupeKey(dedupeKey)).toBe(true);
+
+    // Simulate restart by reinitializing
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => ({ success: true }),
+    });
+
+    // Should still recognize the dedupe key
+    expect(hasDedupeKey(dedupeKey)).toBe(true);
+  });
+});
+
+describe("Event Processor - Edge Cases", () => {
+  it("should handle processor errors gracefully", async () => {
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => {
+        throw new Error("Processor crash");
+      },
+    });
+
+    await append(createTestEntry());
+    
+    // Should not throw
+    await processNext();
+  });
+
+  it("should not process when already processing", async () => {
+    let processing = false;
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async () => {
+        processing = true;
+        await new Promise(resolve => setTimeout(resolve, 100));
+        processing = false;
+        return { success: true };
+      },
+    });
+
+    await append(createTestEntry());
+
+    // Start first process
+    const p1 = processNext();
+    
+    // Try to start second while first is running
+    const p2 = processNext();
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    
+    // Only one should have processed
+    expect(r1 || r2).toBe(true);
+    expect(r1 && r2).toBe(false);
+  });
+
+  it("should handle different event types", async () => {
+    const types: string[] = [];
+    
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async (event) => {
+        types.push(event.type);
+        return { success: true };
+      },
+    });
+
+    await append(createTestEntry({ type: "type-a" }));
+    await append(createTestEntry({ type: "type-b" }));
+    await append(createTestEntry({ type: "type-c" }));
+
+    await processPending();
+
+    expect(types).toEqual(["type-a", "type-b", "type-c"]);
+  });
+});

--- a/src/__tests__/gateway/adapter-wiring.test.ts
+++ b/src/__tests__/gateway/adapter-wiring.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Adapter Gateway Wiring Tests
+ * 
+ * Tests cover:
+ * - Telegram adapter routing through gateway when USE_GATEWAY_TELEGRAM=true
+ * - Discord adapter routing through gateway when USE_GATEWAY_DISCORD=true
+ * - Clear error messages when respective flags are false (fail closed, no legacy fallback)
+ * - Gateway errors surfaced to users
+ * - Feature flag isolation between adapters
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the gateway module
+vi.mock("../../gateway", () => ({
+  submitTelegramToGateway: vi.fn(),
+  submitDiscordToGateway: vi.fn(),
+}));
+
+// Mock sendMessage for telegram
+const mockTelegramSendMessage = vi.fn();
+vi.mock("../../commands/telegram", () => ({
+  sendMessage: mockTelegramSendMessage,
+}));
+
+// Mock sendMessage for discord  
+const mockDiscordSendMessage = vi.fn();
+vi.mock("../../commands/discord", () => ({
+  sendMessage: mockDiscordSendMessage,
+}));
+
+// Import mocked functions after vi.mock
+import { submitTelegramToGateway, submitDiscordToGateway } from "../../gateway";
+
+describe("Adapter Gateway Wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset environment variables
+    delete process.env.USE_GATEWAY_TELEGRAM;
+    delete process.env.USE_GATEWAY_DISCORD;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Telegram Gateway Routing", () => {
+    const mockTelegramMessage = {
+      message_id: 123,
+      chat: { id: 456, type: "private" },
+      from: { id: 789, username: "testuser" },
+      text: "Hello",
+    };
+
+    it("should call submitTelegramToGateway when USE_GATEWAY_TELEGRAM=true", async () => {
+      process.env.USE_GATEWAY_TELEGRAM = "true";
+      
+      // Mock successful gateway response
+      (submitTelegramToGateway as any).mockResolvedValue({
+        success: true,
+        source: "gateway" as const,
+      });
+
+      // Simulate the routing logic that telegram.ts now uses
+      if (process.env.USE_GATEWAY_TELEGRAM === "true") {
+        const gatewayResult = await submitTelegramToGateway(mockTelegramMessage as any);
+        expect(gatewayResult.success).toBe(true);
+      }
+
+      expect(submitTelegramToGateway).toHaveBeenCalledWith(mockTelegramMessage);
+    });
+
+    it("should return clear error when USE_GATEWAY_TELEGRAM=false", async () => {
+      // USE_GATEWAY_TELEGRAM is not set (defaults to false)
+      
+      // Simulate the routing logic - when flag is false, it should NOT call gateway
+      // Instead, it returns the "being upgraded" message
+      const flag = process.env.USE_GATEWAY_TELEGRAM;
+      expect(flag).toBeUndefined();
+
+      // The code path when flag is false: sends "Claude is currently being upgraded" message
+      // and does NOT call submitTelegramToGateway
+      const shouldCallGateway = flag === "true";
+      expect(shouldCallGateway).toBe(false);
+    });
+
+    it("should surface gateway error when gateway returns failure", async () => {
+      process.env.USE_GATEWAY_TELEGRAM = "true";
+
+      // Mock failed gateway response
+      (submitTelegramToGateway as any).mockResolvedValue({
+        success: false,
+        source: "gateway" as const,
+        error: "Gateway processing failed: test error",
+      });
+
+      // Simulate the routing logic
+      if (process.env.USE_GATEWAY_TELEGRAM === "true") {
+        const gatewayResult = await submitTelegramToGateway(mockTelegramMessage as any);
+        expect(gatewayResult.success).toBe(false);
+        expect(gatewayResult.error).toBe("Gateway processing failed: test error");
+        // The calling code would then send this error to the user
+        await mockTelegramSendMessage(
+          "token",
+          456,
+          "Gateway error: Gateway processing failed: test error",
+          undefined
+        );
+      }
+
+      expect(mockTelegramSendMessage).toHaveBeenCalledWith(
+        "token",
+        456,
+        "Gateway error: Gateway processing failed: test error",
+        undefined
+      );
+    });
+
+    it("should NOT use legacy runUserMessage path when flag is false", () => {
+      // Verify that when USE_GATEWAY_TELEGRAM is false, the new routing path
+      // returns an error message rather than falling back to legacy
+      const flag = process.env.USE_GATEWAY_TELEGRAM;
+      const isGatewayEnabled = flag === "true";
+      
+      // Fail closed - no legacy fallback
+      expect(isGatewayEnabled).toBe(false);
+    });
+  });
+
+  describe("Discord Gateway Routing", () => {
+    const mockDiscordMessage = {
+      id: "123",
+      channel_id: "456",
+      author: { id: "789", username: "testuser" },
+      content: "Hello",
+      guild_id: "guild123",
+    };
+
+    it("should call submitDiscordToGateway when USE_GATEWAY_DISCORD=true", async () => {
+      process.env.USE_GATEWAY_DISCORD = "true";
+
+      // Mock successful gateway response
+      (submitDiscordToGateway as any).mockResolvedValue({
+        success: true,
+        source: "gateway" as const,
+      });
+
+      // Simulate the routing logic
+      if (process.env.USE_GATEWAY_DISCORD === "true") {
+        const gatewayResult = await submitDiscordToGateway(mockDiscordMessage as any);
+        expect(gatewayResult.success).toBe(true);
+      }
+
+      expect(submitDiscordToGateway).toHaveBeenCalledWith(mockDiscordMessage);
+    });
+
+    it("should return clear error when USE_GATEWAY_DISCORD=false", async () => {
+      // USE_GATEWAY_DISCORD is not set (defaults to false)
+      
+      const flag = process.env.USE_GATEWAY_DISCORD;
+      expect(flag).toBeUndefined();
+
+      // The code path when flag is false: sends "Claude is currently being upgraded" message
+      // and does NOT call submitDiscordToGateway
+      const shouldCallGateway = flag === "true";
+      expect(shouldCallGateway).toBe(false);
+    });
+
+    it("should surface gateway error when gateway returns failure", async () => {
+      process.env.USE_GATEWAY_DISCORD = "true";
+
+      // Mock failed gateway response
+      (submitDiscordToGateway as any).mockResolvedValue({
+        success: false,
+        source: "gateway" as const,
+        error: "Gateway processing failed: discord error",
+      });
+
+      // Simulate the routing logic
+      if (process.env.USE_GATEWAY_DISCORD === "true") {
+        const gatewayResult = await submitDiscordToGateway(mockDiscordMessage as any);
+        expect(gatewayResult.success).toBe(false);
+        expect(gatewayResult.error).toBe("Gateway processing failed: discord error");
+        
+        await mockDiscordSendMessage(
+          "token",
+          "456",
+          "Gateway error: Gateway processing failed: discord error"
+        );
+      }
+
+      expect(mockDiscordSendMessage).toHaveBeenCalledWith(
+        "token",
+        "456",
+        "Gateway error: Gateway processing failed: discord error"
+      );
+    });
+
+    it("should NOT use legacy runUserMessage path when flag is false", () => {
+      // Verify that when USE_GATEWAY_DISCORD is false, the new routing path
+      // returns an error message rather than falling back to legacy
+      const flag = process.env.USE_GATEWAY_DISCORD;
+      const isGatewayEnabled = flag === "true";
+      
+      // Fail closed - no legacy fallback
+      expect(isGatewayEnabled).toBe(false);
+    });
+  });
+
+  describe("Feature Flag Isolation", () => {
+    it("should not affect Discord routing when USE_GATEWAY_TELEGRAM is set", async () => {
+      process.env.USE_GATEWAY_TELEGRAM = "true";
+      // USE_GATEWAY_DISCORD is not set
+
+      const telegramFlag = process.env.USE_GATEWAY_TELEGRAM;
+      const discordFlag = process.env.USE_GATEWAY_DISCORD;
+
+      // Telegram is enabled
+      expect(telegramFlag).toBe("true");
+      // Discord is not enabled
+      expect(discordFlag).toBeUndefined();
+
+      // Verify independent flags
+      const telegramEnabled = telegramFlag === "true";
+      const discordEnabled = discordFlag === "true";
+
+      expect(telegramEnabled).toBe(true);
+      expect(discordEnabled).toBe(false);
+    });
+
+    it("should not affect Telegram routing when USE_GATEWAY_DISCORD is set", async () => {
+      process.env.USE_GATEWAY_DISCORD = "true";
+      // USE_GATEWAY_TELEGRAM is not set
+
+      const telegramFlag = process.env.USE_GATEWAY_TELEGRAM;
+      const discordFlag = process.env.USE_GATEWAY_DISCORD;
+
+      // Telegram is not enabled
+      expect(telegramFlag).toBeUndefined();
+      // Discord is enabled
+      expect(discordFlag).toBe("true");
+
+      // Verify independent flags
+      const telegramEnabled = telegramFlag === "true";
+      const discordEnabled = discordFlag === "true";
+
+      expect(telegramEnabled).toBe(false);
+      expect(discordEnabled).toBe(true);
+    });
+
+    it("should allow both adapters to be independently enabled", async () => {
+      process.env.USE_GATEWAY_TELEGRAM = "true";
+      process.env.USE_GATEWAY_DISCORD = "true";
+
+      const telegramEnabled = process.env.USE_GATEWAY_TELEGRAM === "true";
+      const discordEnabled = process.env.USE_GATEWAY_DISCORD === "true";
+
+      expect(telegramEnabled).toBe(true);
+      expect(discordEnabled).toBe(true);
+    });
+
+    it("should allow both adapters to be independently disabled", async () => {
+      // Both flags not set (default to disabled)
+      
+      const telegramEnabled = process.env.USE_GATEWAY_TELEGRAM === "true";
+      const discordEnabled = process.env.USE_GATEWAY_DISCORD === "true";
+
+      expect(telegramEnabled).toBe(false);
+      expect(discordEnabled).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/gateway/index.test.ts
+++ b/src/__tests__/gateway/index.test.ts
@@ -1,0 +1,791 @@
+/**
+ * Gateway Integration Tests
+ * 
+ * Tests cover:
+ * - Happy path end-to-end: normalize -> gateway -> event log -> processor
+ * - Mapping creation and reuse
+ * - Thread isolation
+ * - Feature flag behavior
+ * - Processor failure handling
+ * - Event-log append failure handling
+ * - Concurrent inbound events behave consistently
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { randomUUID } from "crypto";
+
+// Mock modules before importing gateway
+vi.mock("../event-log", () => {
+  const mockRecords: Map<string, any> = new Map();
+  let seqCounter = 0;
+
+  return {
+    append: vi.fn(async (entry: any) => {
+      seqCounter++;
+      const record = {
+        id: randomUUID(),
+        seq: seqCounter,
+        type: entry.type,
+        source: entry.source,
+        timestamp: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        status: "pending",
+        channelId: entry.channelId,
+        threadId: entry.threadId,
+        payload: entry.payload,
+        dedupeKey: entry.dedupeKey,
+        retryCount: 0,
+        nextRetryAt: null,
+        correlationId: entry.correlationId ?? null,
+        causationId: entry.causationId ?? null,
+        replayedFromEventId: entry.replayedFromEventId ?? null,
+        lastError: null,
+      };
+      mockRecords.set(record.id, record);
+      return record;
+    }),
+    initEventLog: vi.fn().mockResolvedValue(undefined),
+    resetEventLog: vi.fn().mockImplementation(() => {
+      mockRecords.clear();
+      seqCounter = 0;
+    }),
+    getLastSeq: vi.fn().mockResolvedValue(seqCounter),
+  };
+});
+
+vi.mock("../gateway/session-map", () => {
+  const mockMappings: Map<string, any> = new Map();
+
+  return {
+    get: vi.fn(async (channelId: string, threadId: string) => {
+      const key = `${channelId}:${threadId}`;
+      return mockMappings.get(key) ?? null;
+    }),
+    set: vi.fn(async (channelId: string, threadId: string, entry: any) => {
+      const key = `${channelId}:${threadId}`;
+      mockMappings.set(key, {
+        mappingId: entry.mappingId ?? randomUUID(),
+        channelId,
+        threadId,
+        claudeSessionId: entry.claudeSessionId ?? null,
+        lastSeq: entry.lastSeq ?? 0,
+        turnCount: entry.turnCount ?? 0,
+        status: entry.status ?? "pending",
+        lastActiveAt: entry.lastActiveAt ?? new Date().toISOString(),
+        createdAt: entry.createdAt ?? new Date().toISOString(),
+        updatedAt: entry.updatedAt ?? new Date().toISOString(),
+        ...entry,
+      });
+    }),
+    remove: vi.fn(async (channelId: string, threadId: string) => {
+      const key = `${channelId}:${threadId}`;
+      mockMappings.delete(key);
+    }),
+    getOrCreateMapping: vi.fn(async (channelId: string, threadId: string) => {
+      const key = `${channelId}:${threadId}`;
+      let entry = mockMappings.get(key);
+      if (!entry) {
+        entry = {
+          mappingId: randomUUID(),
+          channelId,
+          threadId,
+          claudeSessionId: null,
+          lastSeq: 0,
+          turnCount: 0,
+          status: "pending",
+          lastActiveAt: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        mockMappings.set(key, entry);
+      }
+      return entry;
+    }),
+    update: vi.fn(async (channelId: string, threadId: string, patch: any) => {
+      const key = `${channelId}:${threadId}`;
+      const existing = mockMappings.get(key);
+      if (existing) {
+        mockMappings.set(key, { ...existing, ...patch, updatedAt: new Date().toISOString() });
+      }
+    }),
+    attachClaudeSessionId: vi.fn(),
+    resetSessionMap: vi.fn().mockImplementation(() => {
+      mockMappings.clear();
+    }),
+  };
+});
+
+// Mock escalation module - must be before gateway import
+// Gateway imports from ../escalation which resolves to src/escalation from src/gateway/
+// Test file is at src/__tests__/gateway/index.test.ts, so ../../escalation resolves to src/escalation
+vi.mock("../../escalation", () => ({
+  shouldBlockAdmission: vi.fn().mockResolvedValue(false),
+  shouldBlockScheduling: vi.fn().mockResolvedValue(false),
+  handlePolicyDenial: vi.fn().mockResolvedValue({
+    actionId: "mock-action-id",
+    timestamp: new Date().toISOString(),
+    pause: false,
+    handoff: false,
+    notification: false,
+    reason: "Mocked for tests",
+  }),
+  handleEscalationTrigger: vi.fn().mockResolvedValue({
+    actionId: "mock-action-id",
+    timestamp: new Date().toISOString(),
+    pause: false,
+    handoff: false,
+    notification: false,
+    reason: "Mocked for tests",
+  }),
+  pause: vi.fn().mockResolvedValue({}),
+  resume: vi.fn().mockResolvedValue({}),
+  isPaused: vi.fn().mockResolvedValue(false),
+  getPauseState: vi.fn().mockResolvedValue({ paused: false, mode: "admission_only" }),
+  resetPauseController: vi.fn().mockResolvedValue(undefined),
+  clearPauseCache: vi.fn(),
+}));
+
+// Mock policy engine - must be before gateway import
+vi.mock("../../policy/engine", () => ({
+  evaluate: vi.fn().mockReturnValue({
+    requestId: "mock-request-id",
+    action: "allow",
+    reason: "Mocked policy - allowed",
+    evaluatedAt: new Date().toISOString(),
+    cacheable: false,
+  }),
+  loadPolicies: vi.fn().mockResolvedValue(undefined),
+  getPolicies: vi.fn().mockReturnValue([]),
+}));
+
+// Mock governance client
+vi.mock("../../governance/client", () => ({
+  getGovernanceClient: vi.fn().mockReturnValue({
+    evaluateToolRequest: vi.fn().mockResolvedValue({
+      action: "allow",
+      reason: "Mocked governance",
+    }),
+    isToolAllowed: vi.fn().mockReturnValue(true),
+    requiresApproval: vi.fn().mockReturnValue(false),
+    checkPolicy: vi.fn().mockResolvedValue({ allowed: true }),
+    checkBudget: vi.fn().mockResolvedValue({ allowed: true, reason: "Mocked budget check" }),
+    reloadPolicies: vi.fn().mockResolvedValue(undefined),
+    requestApproval: vi.fn().mockResolvedValue(null),
+    getPendingApprovals: vi.fn().mockReturnValue([]),
+    findApprovalByEvent: vi.fn().mockResolvedValue(null),
+    getApprovalById: vi.fn().mockReturnValue(null),
+    getTelemetry: vi.fn().mockResolvedValue({}),
+    getUsageStats: vi.fn().mockResolvedValue({}),
+    getBudgetState: vi.fn().mockResolvedValue([]),
+  }),
+  initGovernanceClient: vi.fn().mockResolvedValue(undefined),
+  resetGovernanceClient: vi.fn(),
+}));
+
+// Now import the gateway
+import {
+  Gateway,
+  createGateway,
+  getGateway,
+  setGateway,
+  isGatewayEnabled,
+  setGatewayEnabled,
+  clearGatewayEnabledCache,
+  processInboundEvent,
+  processEventWithFallback,
+  submitTelegramToGateway,
+  submitDiscordToGateway,
+  type GatewayDependencies,
+  type ProcessorResult,
+} from "../../gateway/index";
+
+import type { NormalizedEvent } from "../../gateway/normalizer";
+import { normalizeTelegramMessage, normalizeDiscordMessage } from "../../gateway/normalizer";
+
+describe("Gateway", () => {
+  beforeEach(() => {
+    // Reset gateway state
+    clearGatewayEnabledCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Clean up
+  });
+
+  describe("constructor and config", () => {
+    it("should create gateway with default config", () => {
+      const gateway = new Gateway();
+      expect(gateway).toBeDefined();
+      expect(gateway.isRunning()).toBe(true);
+    });
+
+    it("should create gateway with custom config", () => {
+      const gateway = new Gateway({ enabled: true });
+      expect(gateway).toBeDefined();
+    });
+
+    it("should start and stop gateway", async () => {
+      const gateway = new Gateway();
+      await gateway.start();
+      expect(gateway.isRunning()).toBe(true);
+      await gateway.stop();
+      expect(gateway.isRunning()).toBe(false);
+    });
+  });
+
+  describe("processInboundEvent", () => {
+    it("should reject events when gateway is not running", async () => {
+      const gateway = new Gateway();
+      await gateway.stop();
+
+      const event: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:123",
+        threadId: "default",
+        userId: "456",
+        text: "Hello",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      const result = await gateway.processInboundEvent(event);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Gateway is not running");
+    });
+
+    it("should reject invalid events", async () => {
+      const gateway = new Gateway();
+
+      // Missing channelId
+      const invalidEvent = {
+        id: randomUUID(),
+        channel: "telegram" as const,
+        channelId: "",
+        threadId: "default",
+        userId: "456",
+        text: "Hello",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      const result = await gateway.processInboundEvent(invalidEvent);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Invalid normalized event");
+    });
+
+    it("should process valid event and return event record", async () => {
+      const mockProcessor = vi.fn().mockResolvedValue({ success: true });
+      const deps: GatewayDependencies = {
+        eventLog: { append: vi.fn().mockResolvedValue({
+          id: randomUUID(),
+          seq: 1,
+          type: "inbound:telegram",
+          source: "telegram",
+          timestamp: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          status: "pending",
+          channelId: "telegram:123",
+          threadId: "default",
+          payload: {},
+          dedupeKey: "test",
+          retryCount: 0,
+          nextRetryAt: null,
+          correlationId: null,
+          causationId: null,
+          replayedFromEventId: null,
+          lastError: null,
+        })},
+        processor: { processPersistedEvent: mockProcessor },
+        resume: {
+          getOrCreateSessionMapping: vi.fn().mockResolvedValue({
+            mappingId: "mapping-1",
+            channelId: "telegram:123",
+            threadId: "default",
+            claudeSessionId: null,
+            lastSeq: 0,
+            turnCount: 0,
+            status: "pending",
+            lastActiveAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }),
+          getResumeArgsForEvent: vi.fn().mockResolvedValue({
+            mappingId: "mapping-1",
+            claudeSessionId: null,
+            args: [],
+            isNewMapping: true,
+            canResume: false,
+          }),
+          updateSessionAfterProcessing: vi.fn().mockResolvedValue(undefined),
+        },
+      };
+
+      const gateway = new Gateway({}, deps);
+      const event: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        sourceEventId: "msg-123",
+        channelId: "telegram:123",
+        threadId: "default",
+        userId: "456",
+        text: "Hello",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      const result = await gateway.processInboundEvent(event);
+      expect(result.success).toBe(true);
+      expect(result.eventRecord).toBeDefined();
+      expect(mockProcessor).toHaveBeenCalled();
+    });
+
+    it("should handle processor failure", async () => {
+      const mockProcessor = vi.fn().mockResolvedValue({
+        success: false,
+        error: "Processor error",
+        shouldRetry: false,
+      });
+      const deps: GatewayDependencies = {
+        eventLog: { append: vi.fn().mockResolvedValue({
+          id: randomUUID(),
+          seq: 1,
+          type: "inbound:telegram",
+          source: "telegram",
+          timestamp: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          status: "pending",
+          channelId: "telegram:123",
+          threadId: "default",
+          payload: {},
+          dedupeKey: "test",
+          retryCount: 0,
+          nextRetryAt: null,
+          correlationId: null,
+          causationId: null,
+          replayedFromEventId: null,
+          lastError: null,
+        })},
+        processor: { processPersistedEvent: mockProcessor },
+        resume: {
+          getOrCreateSessionMapping: vi.fn().mockResolvedValue({
+            mappingId: "mapping-1",
+            channelId: "telegram:123",
+            threadId: "default",
+            claudeSessionId: null,
+            lastSeq: 0,
+            turnCount: 0,
+            status: "pending",
+            lastActiveAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }),
+          getResumeArgsForEvent: vi.fn().mockResolvedValue({
+            mappingId: "mapping-1",
+            claudeSessionId: null,
+            args: [],
+            isNewMapping: true,
+            canResume: false,
+          }),
+          updateSessionAfterProcessing: vi.fn(),
+        },
+      };
+
+      const gateway = new Gateway({}, deps);
+      const event: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:123",
+        threadId: "default",
+        userId: "456",
+        text: "Hello",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      const result = await gateway.processInboundEvent(event);
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Processor error");
+    });
+  });
+
+  describe("feature flag", () => {
+    it("should default to disabled", () => {
+      clearGatewayEnabledCache();
+      expect(isGatewayEnabled()).toBe(false);
+    });
+
+    it("should be enabled when USE_GATEWAY env is true", () => {
+      clearGatewayEnabledCache();
+      process.env.USE_GATEWAY = "true";
+      expect(isGatewayEnabled()).toBe(true);
+      process.env.USE_GATEWAY = undefined;
+    });
+
+    it("should respect manually set enabled state", () => {
+      clearGatewayEnabledCache();
+      setGatewayEnabled(true);
+      expect(isGatewayEnabled()).toBe(true);
+      setGatewayEnabled(false);
+      expect(isGatewayEnabled()).toBe(false);
+    });
+
+    it("should cache the enabled state", () => {
+      clearGatewayEnabledCache();
+      setGatewayEnabled(true);
+      // Multiple calls should return the same cached value
+      expect(isGatewayEnabled()).toBe(true);
+      expect(isGatewayEnabled()).toBe(true);
+      expect(isGatewayEnabled()).toBe(true);
+      // Clear cache to reset
+      clearGatewayEnabledCache();
+      // After clearing, should recompute (default false)
+      expect(isGatewayEnabled()).toBe(false);
+    });
+  });
+
+  describe("processEventWithFallback", () => {
+    it("should use legacy handler when gateway is disabled", async () => {
+      clearGatewayEnabledCache();
+      setGatewayEnabled(false);
+
+      const legacyHandler = vi.fn().mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: "Legacy response",
+      });
+
+      const event: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:123",
+        threadId: "default",
+        userId: "456",
+        text: "Hello",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      const result = await processEventWithFallback(event, { legacyHandler });
+      expect(result.success).toBe(true);
+      expect(result.source).toBe("legacy");
+      expect(legacyHandler).toHaveBeenCalled();
+    });
+
+    it("should return error when gateway disabled and no legacy handler", async () => {
+      clearGatewayEnabledCache();
+      setGatewayEnabled(false);
+
+      const event: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:123",
+        threadId: "default",
+        userId: "456",
+        text: "Hello",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      const result = await processEventWithFallback(event, {});
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("no legacy handler");
+    });
+  });
+
+  describe("thread isolation", () => {
+    it("should create separate mappings for different threads", async () => {
+      const mappings: Map<string, any> = new Map();
+
+      const deps: GatewayDependencies = {
+        eventLog: { append: vi.fn().mockResolvedValue({
+          id: randomUUID(),
+          seq: 1,
+          type: "inbound:telegram",
+          source: "telegram",
+          timestamp: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          status: "pending",
+          channelId: "telegram:123",
+          threadId: "default",
+          payload: {},
+          dedupeKey: "test",
+          retryCount: 0,
+          nextRetryAt: null,
+          correlationId: null,
+          causationId: null,
+          replayedFromEventId: null,
+          lastError: null,
+        })},
+        processor: { processPersistedEvent: vi.fn().mockResolvedValue({ success: true }) },
+        resume: {
+          getOrCreateSessionMapping: vi.fn().mockImplementation(async (channelId: string, threadId: string) => {
+            const key = `${channelId}:${threadId}`;
+            if (!mappings.has(key)) {
+              mappings.set(key, {
+                mappingId: `mapping-${mappings.size + 1}`,
+                channelId,
+                threadId,
+                claudeSessionId: null,
+                lastSeq: 0,
+                turnCount: 0,
+                status: "pending",
+                lastActiveAt: new Date().toISOString(),
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              });
+            }
+            return mappings.get(key);
+          }),
+          getResumeArgsForEvent: vi.fn().mockImplementation(async (event: NormalizedEvent) => {
+            const key = `${event.channelId}:${event.threadId}`;
+            const entry = mappings.get(key);
+            return {
+              mappingId: entry?.mappingId ?? "unknown",
+              claudeSessionId: entry?.claudeSessionId ?? null,
+              args: entry?.claudeSessionId ? ["--resume", entry.claudeSessionId] : [],
+              isNewMapping: !entry,
+              canResume: entry?.claudeSessionId !== null,
+            };
+          }),
+          updateSessionAfterProcessing: vi.fn().mockImplementation(async (channelId: string, threadId: string, seq: number) => {
+            const key = `${channelId}:${threadId}`;
+            const existing = mappings.get(key);
+            if (existing) {
+              mappings.set(key, { ...existing, lastSeq: seq, turnCount: existing.turnCount + 1 });
+            }
+          }),
+        },
+      };
+
+      const gateway = new Gateway({}, deps);
+
+      // Process event for thread 1
+      const event1: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:123",
+        threadId: "thread-1",
+        userId: "456",
+        text: "Hello from thread 1",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      await gateway.processInboundEvent(event1);
+
+      // Process event for thread 2
+      const event2: NormalizedEvent = {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:123",
+        threadId: "thread-2",
+        userId: "456",
+        text: "Hello from thread 2",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      };
+
+      await gateway.processInboundEvent(event2);
+
+      // Verify separate mappings were created
+      expect(mappings.size).toBe(2);
+      expect(mappings.get("telegram:123:thread-1")).toBeDefined();
+      expect(mappings.get("telegram:123:thread-2")).toBeDefined();
+    });
+  });
+});
+
+describe("Normalizer integration", () => {
+  describe("normalizeTelegramMessage", () => {
+    it("should normalize a basic Telegram message", () => {
+      const telegramMessage = {
+        message_id: 123,
+        from: { id: 456, first_name: "Test", username: "testuser" },
+        chat: { id: 123, type: "private" },
+        text: "Hello world",
+      };
+
+      const normalized = normalizeTelegramMessage(telegramMessage);
+
+      expect(normalized.channel).toBe("telegram");
+      expect(normalized.sourceEventId).toBe("123");
+      expect(normalized.channelId).toBe("telegram:123");
+      expect(normalized.threadId).toBe("default");
+      expect(normalized.userId).toBe("456");
+      expect(normalized.text).toBe("Hello world");
+    });
+
+    it("should normalize thread messages", () => {
+      const telegramMessage = {
+        message_id: 123,
+        from: { id: 456, first_name: "Test" },
+        chat: { id: 123, type: "supergroup" },
+        message_thread_id: 789,
+        text: "Thread message",
+      };
+
+      const normalized = normalizeTelegramMessage(telegramMessage);
+
+      expect(normalized.threadId).toBe("789");
+    });
+  });
+
+  describe("normalizeDiscordMessage", () => {
+    it("should normalize a basic Discord message", () => {
+      const discordMessage = {
+        id: "msg-123",
+        channel_id: "channel-456",
+        author: { id: "789", username: "testuser", discriminator: "0" },
+        content: "Hello Discord",
+        attachments: [],
+        mentions: [],
+        type: 0,
+      };
+
+      const normalized = normalizeDiscordMessage(discordMessage);
+
+      expect(normalized.channel).toBe("discord");
+      expect(normalized.sourceEventId).toBe("msg-123");
+      expect(normalized.channelId).toBe("discord:dm:channel-456");
+      expect(normalized.threadId).toBe("channel-456");
+      expect(normalized.userId).toBe("789");
+      expect(normalized.text).toBe("Hello Discord");
+    });
+
+    it("should preserve guild context in channelId", () => {
+      const discordMessage = {
+        id: "msg-123",
+        channel_id: "channel-456",
+        guild_id: "guild-789",
+        author: { id: "111", username: "testuser", discriminator: "0" },
+        content: "Guild message",
+        attachments: [],
+        mentions: [],
+        type: 0,
+      };
+
+      const normalized = normalizeDiscordMessage(discordMessage);
+
+      expect(normalized.channelId).toBe("discord:guild:guild-789:channel-456");
+    });
+  });
+});
+
+describe("Concurrent events", () => {
+  it("should handle concurrent events consistently", async () => {
+    const callOrder: string[] = [];
+    const deps: GatewayDependencies = {
+      eventLog: { 
+        append: vi.fn().mockImplementation(async (entry: any) => {
+          callOrder.push(`append-${entry.channelId}-${entry.threadId}`);
+          return {
+            id: randomUUID(),
+            seq: callOrder.length,
+            type: entry.type,
+            source: entry.source,
+            timestamp: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            status: "pending",
+            channelId: entry.channelId,
+            threadId: entry.threadId,
+            payload: entry.payload,
+            dedupeKey: entry.dedupeKey,
+            retryCount: 0,
+            nextRetryAt: null,
+            correlationId: entry.correlationId ?? null,
+            causationId: entry.causationId ?? null,
+            replayedFromEventId: entry.replayedFromEventId ?? null,
+            lastError: null,
+          };
+        }),
+      },
+      processor: { processPersistedEvent: vi.fn().mockImplementation(async () => {
+        callOrder.push(`process-${Date.now()}`);
+        return { success: true };
+      })},
+      resume: {
+        getOrCreateSessionMapping: vi.fn().mockResolvedValue({
+          mappingId: "mapping-1",
+          channelId: "telegram:123",
+          threadId: "default",
+          claudeSessionId: null,
+          lastSeq: 0,
+          turnCount: 0,
+          status: "pending",
+          lastActiveAt: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
+        getResumeArgsForEvent: vi.fn().mockResolvedValue({
+          mappingId: "mapping-1",
+          claudeSessionId: null,
+          args: [],
+          isNewMapping: false,
+          canResume: false,
+        }),
+        updateSessionAfterProcessing: vi.fn().mockImplementation(async () => {
+          callOrder.push("update");
+        }),
+      },
+    };
+
+    const gateway = new Gateway({}, deps);
+
+    // Send concurrent events
+    const events: NormalizedEvent[] = [
+      {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:1",
+        threadId: "default",
+        userId: "1",
+        text: "Message 1",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      },
+      {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:2",
+        threadId: "default",
+        userId: "2",
+        text: "Message 2",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      },
+      {
+        id: randomUUID(),
+        channel: "telegram",
+        channelId: "telegram:3",
+        threadId: "default",
+        userId: "3",
+        text: "Message 3",
+        attachments: [],
+        timestamp: Date.now(),
+        metadata: {},
+      },
+    ];
+
+    const results = await Promise.all(events.map(e => gateway.processInboundEvent(e)));
+
+    // All should succeed
+    expect(results.every(r => r.success)).toBe(true);
+  });
+});

--- a/src/__tests__/gateway/normalizer.test.ts
+++ b/src/__tests__/gateway/normalizer.test.ts
@@ -1,0 +1,717 @@
+import {
+  isNormalizedEvent,
+  isValidChannel,
+  normalizeTelegramMessage,
+  normalizeDiscordMessage,
+  normalizeCronEvent,
+  normalizeWebhookEvent,
+  Channel,
+  NormalizedEvent,
+} from "../../gateway/normalizer";
+
+// --- Type guard tests ---
+
+const validNormalizedEvent: NormalizedEvent = {
+  id: "local-123",
+  channel: "telegram",
+  sourceEventId: "456",
+  channelId: "telegram:123",
+  threadId: "default",
+  userId: "789",
+  text: "Hello world",
+  attachments: [],
+  timestamp: 1700000000000,
+  metadata: {},
+};
+
+describe("isValidChannel", () => {
+  test("accepts valid channels", () => {
+    expect(isValidChannel("telegram")).toBe(true);
+    expect(isValidChannel("discord")).toBe(true);
+    expect(isValidChannel("cron")).toBe(true);
+    expect(isValidChannel("webhook")).toBe(true);
+  });
+
+  test("rejects invalid channels", () => {
+    expect(isValidChannel("slack")).toBe(false);
+    expect(isValidChannel("email")).toBe(false);
+    expect(isValidChannel("")).toBe(false);
+    expect(isValidChannel("TELEGRAM")).toBe(false);
+    expect(isValidChannel(123 as any)).toBe(false);
+    expect(isValidChannel(null)).toBe(false);
+    expect(isValidChannel(undefined)).toBe(false);
+  });
+});
+
+describe("isNormalizedEvent", () => {
+  test("accepts valid normalized event", () => {
+    expect(isNormalizedEvent(validNormalizedEvent)).toBe(true);
+  });
+
+  test("accepts minimal valid event", () => {
+    const minimal: NormalizedEvent = {
+      id: "abc",
+      channel: "cron",
+      channelId: "cron:system",
+      threadId: "default",
+      userId: "system",
+      text: "",
+      attachments: [],
+      timestamp: 1700000000000,
+      metadata: {},
+    };
+    expect(isNormalizedEvent(minimal)).toBe(true);
+  });
+
+  test("rejects null/undefined", () => {
+    expect(isNormalizedEvent(null)).toBe(false);
+    expect(isNormalizedEvent(undefined)).toBe(false);
+  });
+
+  test("rejects non-object", () => {
+    expect(isNormalizedEvent("string")).toBe(false);
+    expect(isNormalizedEvent(123)).toBe(false);
+    expect(isNormalizedEvent(true)).toBe(false);
+  });
+
+  test("rejects missing required fields", () => {
+    const missingId = { ...validNormalizedEvent, id: undefined };
+    expect(isNormalizedEvent(missingId as any)).toBe(false);
+
+    const missingChannel = { ...validNormalizedEvent, channel: "invalid" };
+    expect(isNormalizedEvent(missingChannel as any)).toBe(false);
+
+    const missingText = { ...validNormalizedEvent, text: 123 as any };
+    expect(isNormalizedEvent(missingText as any)).toBe(false);
+  });
+
+  test("rejects invalid attachments", () => {
+    const badAttachments = { ...validNormalizedEvent, attachments: ["not an array"] };
+    expect(isNormalizedEvent(badAttachments as any)).toBe(false);
+
+    const badAttachmentItem = { ...validNormalizedEvent, attachments: [{ type: "video" }] };
+    expect(isNormalizedEvent(badAttachmentItem as any)).toBe(false);
+  });
+
+  test("rejects invalid metadata", () => {
+    const arrayMetadata = { ...validNormalizedEvent, metadata: [] };
+    expect(isNormalizedEvent(arrayMetadata as any)).toBe(false);
+
+    const stringMetadata = { ...validNormalizedEvent, metadata: "bad" };
+    expect(isNormalizedEvent(stringMetadata as any)).toBe(false);
+  });
+
+  test("rejects invalid timestamp", () => {
+    const badTimestamp = { ...validNormalizedEvent, timestamp: "not a number" };
+    expect(isNormalizedEvent(badTimestamp as any)).toBe(false);
+  });
+});
+
+// --- Telegram normalization tests ---
+
+describe("normalizeTelegramMessage", () => {
+  test("normalizes basic text message", () => {
+    const input: any = {
+      message_id: 123,
+      from: { id: 456, first_name: "Alice", username: "alice" },
+      chat: { id: 789, type: "private" },
+      text: "Hello bot!",
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.channel).toBe("telegram");
+    expect(result.sourceEventId).toBe("123");
+    expect(result.channelId).toBe("telegram:789");
+    expect(result.threadId).toBe("default");
+    expect(result.userId).toBe("456");
+    expect(result.text).toBe("Hello bot!");
+    expect(result.attachments).toEqual([]);
+  });
+
+  test("normalizes caption-only message", () => {
+    const input: any = {
+      message_id: 456,
+      from: { id: 111, first_name: "Bob" },
+      chat: { id: 222, type: "group" },
+      caption: "Look at this!",
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.text).toBe("Look at this!");
+    expect(result.sourceEventId).toBe("456");
+  });
+
+  test("normalizes photo attachment", () => {
+    const input: any = {
+      message_id: 789,
+      from: { id: 333, first_name: "Carol" },
+      chat: { id: 444, type: "private" },
+      text: "Check this photo",
+      photo: [
+        { file_id: "small_photo", width: 100, height: 100 },
+        { file_id: "big_photo", width: 1920, height: 1080, file_size: 1500000 },
+        { file_id: "medium_photo", width: 800, height: 600 },
+      ],
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].type).toBe("image");
+    expect(result.attachments[0].metadata).toEqual({
+      file_id: "big_photo",
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  test("normalizes voice attachment", () => {
+    const input: any = {
+      message_id: 101,
+      from: { id: 222, first_name: "Dave" },
+      chat: { id: 333, type: "private" },
+      voice: {
+        file_id: "voice_file_123",
+        mime_type: "audio/ogg",
+        duration: 45,
+        file_size: 50000,
+      },
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].type).toBe("voice");
+    expect(result.attachments[0].mimeType).toBe("audio/ogg");
+    expect(result.attachments[0].metadata).toEqual({
+      file_id: "voice_file_123",
+      duration: 45,
+    });
+  });
+
+  test("normalizes document attachment", () => {
+    const input: any = {
+      message_id: 202,
+      from: { id: 444, first_name: "Eve" },
+      chat: { id: 555, type: "private" },
+      text: "Here's the PDF",
+      document: {
+        file_id: "doc_file_456",
+        file_name: "report.pdf",
+        mime_type: "application/pdf",
+        file_size: 250000,
+      },
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].type).toBe("document");
+    expect(result.attachments[0].filename).toBe("report.pdf");
+    expect(result.attachments[0].mimeType).toBe("application/pdf");
+  });
+
+  test("preserves reply metadata", () => {
+    const input: any = {
+      message_id: 303,
+      from: { id: 666, first_name: "Frank" },
+      chat: { id: 777, type: "group" },
+      text: "Reply to you!",
+      reply_to_message: {
+        message_id: 302,
+        from: { id: 555, first_name: "Eve" },
+      },
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.metadata.replyTo).toBe("302");
+  });
+
+  test("normalizes thread/topic message", () => {
+    const input: any = {
+      message_id: 404,
+      from: { id: 888, first_name: "Grace" },
+      chat: { id: 999, type: "supergroup" },
+      message_thread_id: 42,
+      text: "Thread reply",
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.threadId).toBe("42");
+  });
+
+  test("extracts bot command from entities", () => {
+    const input: any = {
+      message_id: 505,
+      from: { id: 111, first_name: "Henry" },
+      chat: { id: 222, type: "private" },
+      text: "/start hello",
+      entities: [{ type: "bot_command", offset: 0, length: 6 }],
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.metadata.command).toBe("/start");
+  });
+
+  test("handles message without from field", () => {
+    const input: any = {
+      message_id: 606,
+      chat: { id: 333, type: "group" },
+      text: "Anonymous message",
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.userId).toBe("unknown");
+  });
+
+  test("handles message without text or caption", () => {
+    const input: any = {
+      message_id: 707,
+      from: { id: 444, first_name: "Ivy" },
+      chat: { id: 555, type: "private" },
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.text).toBe("");
+  });
+});
+
+// --- Discord normalization tests ---
+
+describe("normalizeDiscordMessage", () => {
+  test("normalizes basic guild message", () => {
+    const input: any = {
+      id: "discord_msg_123",
+      channel_id: "channel_456",
+      guild_id: "guild_789",
+      author: { id: "user_111", username: "alice", discriminator: "0001" },
+      content: "Hello from Discord!",
+      attachments: [],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.channel).toBe("discord");
+    expect(result.sourceEventId).toBe("discord_msg_123");
+    expect(result.channelId).toBe("discord:guild:guild_789:channel_456");
+    expect(result.threadId).toBe("channel_456");
+    expect(result.userId).toBe("user_111");
+    expect(result.text).toBe("Hello from Discord!");
+    expect(result.attachments).toEqual([]);
+  });
+
+  test("normalizes DM message", () => {
+    const input: any = {
+      id: "dm_msg_999",
+      channel_id: "dm_channel_888",
+      author: { id: "user_222", username: "bob", discriminator: "0001" },
+      content: "Direct message",
+      attachments: [],
+      mentions: [],
+      type: 1, // 1 = DM
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.channelId).toBe("discord:dm:dm_channel_888");
+  });
+
+  test("normalizes image attachment", () => {
+    const input: any = {
+      id: "img_msg_111",
+      channel_id: "ch_222",
+      guild_id: "guild_333",
+      author: { id: "user_444", username: "carol", discriminator: "0001" },
+      content: "Check this image",
+      attachments: [
+        {
+          id: "att_555",
+          filename: "photo.png",
+          content_type: "image/png",
+          url: "https://cdn.discordapp.com/attachments/photo.png",
+          proxy_url: "https://media.discordapp.net/photo.png",
+          size: 120000,
+        },
+      ],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].type).toBe("image");
+    expect(result.attachments[0].url).toBe("https://cdn.discordapp.com/attachments/photo.png");
+    expect(result.attachments[0].filename).toBe("photo.png");
+  });
+
+  test("normalizes voice attachment", () => {
+    const input: any = {
+      id: "voice_msg_777",
+      channel_id: "ch_888",
+      guild_id: "guild_999",
+      author: { id: "user_aaa", username: "dave", discriminator: "0001" },
+      content: "",
+      attachments: [
+        {
+          id: "voice_att",
+          filename: "voice_message.ogg",
+          content_type: "audio/ogg",
+          url: "https://cdn.discordapp.com/attachments/voice.ogg",
+          proxy_url: "https://media.discordapp.net/voice.ogg",
+          size: 80000,
+          flags: 8192, // VOICE_MESSAGE flag
+        },
+      ],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].type).toBe("voice");
+  });
+
+  test("preserves reply/reference metadata", () => {
+    const input: any = {
+      id: "reply_msg_222",
+      channel_id: "ch_333",
+      guild_id: "guild_444",
+      author: { id: "user_555", username: "eve", discriminator: "0001" },
+      content: "Replying to you!",
+      attachments: [],
+      mentions: [],
+      referenced_message: {
+        id: "original_msg_111",
+        author: { id: "user_666", username: "frank", discriminator: "0001" },
+        content: "Original message",
+      },
+      type: 19, // REPLY type
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.metadata.replyTo).toBe("original_msg_111");
+  });
+
+  test("extracts slash command", () => {
+    const input: any = {
+      id: "cmd_msg_333",
+      channel_id: "ch_444",
+      author: { id: "user_777", username: "grace", discriminator: "0001" },
+      content: "/status check this",
+      attachments: [],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.metadata.command).toBe("status");
+  });
+
+  test("trims content whitespace", () => {
+    const input: any = {
+      id: "trim_msg_444",
+      channel_id: "ch_555",
+      author: { id: "user_888", username: "henry", discriminator: "0001" },
+      content: "   \n  Hello world  \n  ",
+      attachments: [],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.text).toBe("Hello world");
+  });
+});
+
+// --- Cron normalization tests ---
+
+describe("normalizeCronEvent", () => {
+  test("normalizes cron event without payload", () => {
+    const input: CronEvent = {};
+
+    const result = normalizeCronEvent(input);
+
+    expect(result.channel).toBe("cron");
+    expect(result.channelId).toBe("cron:system");
+    expect(result.threadId).toBe("default");
+    expect(result.userId).toBe("system");
+    expect(result.text).toBe("");
+    expect(result.attachments).toEqual([]);
+    expect(result.timestamp).toBeGreaterThan(0);
+  });
+
+  test("normalizes cron event with payload", () => {
+    const input: CronEvent = {
+      timestamp: 1700000000000,
+      payload: { job_id: "nightly_backup", status: "success" },
+    };
+
+    const result = normalizeCronEvent(input);
+
+    expect(result.timestamp).toBe(1700000000000);
+    expect(result.metadata.payload).toEqual({ job_id: "nightly_backup", status: "success" });
+  });
+
+  test("uses provided timestamp over Date.now()", () => {
+    const knownTimestamp = 1609459200000; // 2021-01-01
+    const input: CronEvent = { timestamp: knownTimestamp };
+
+    const result = normalizeCronEvent(input);
+
+    expect(result.timestamp).toBe(knownTimestamp);
+  });
+});
+
+// --- Webhook normalization tests ---
+
+describe("normalizeWebhookEvent", () => {
+  test("normalizes webhook with headers and body", () => {
+    const input: WebhookEvent = {
+      headers: {
+        "content-type": "application/json",
+        "x-custom": "value123",
+      },
+      body: { action: "create", item: "widget" },
+      path: "/api/webhooks/myhook",
+      timestamp: 1700000000000,
+    };
+
+    const result = normalizeWebhookEvent(input);
+
+    expect(result.channel).toBe("webhook");
+    expect(result.channelId).toBe("webhook:receiver");
+    expect(result.userId).toBe("system");
+    expect(result.metadata.headers).toEqual({
+      "content-type": "application/json",
+      "x-custom": "value123",
+    });
+    expect(result.metadata.body).toEqual({ action: "create", item: "widget" });
+    expect(result.metadata.path).toBe("/api/webhooks/myhook");
+  });
+
+  test("strips sensitive headers", () => {
+    const input: WebhookEvent = {
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer secret_token_abc123",
+        "x-api-key": "sk_live_xyz789",
+        cookie: "session=abc123; token=def456",
+        "x-auth": "auth_token_456",
+      },
+      body: { data: "test" },
+    };
+
+    const result = normalizeWebhookEvent(input);
+
+    // Only non-sensitive headers should remain
+    expect(result.metadata.headers).toEqual({
+      "content-type": "application/json",
+    });
+    // Sensitive ones should be stripped
+    expect(result.metadata.headers).not.toHaveProperty("authorization");
+    expect(result.metadata.headers).not.toHaveProperty("x-api-key");
+    expect(result.metadata.headers).not.toHaveProperty("cookie");
+    expect(result.metadata.headers).not.toHaveProperty("x-auth");
+  });
+
+  test("handles webhook without headers", () => {
+    const input: WebhookEvent = {
+      body: { ping: true },
+    };
+
+    const result = normalizeWebhookEvent(input);
+
+    expect(result.metadata.body).toEqual({ ping: true });
+    expect(result.metadata.headers).toBeUndefined();
+  });
+
+  test("handles webhook without body", () => {
+    const input: WebhookEvent = {
+      headers: { "user-agent": "GitHub-Hookshot" },
+    };
+
+    const result = normalizeWebhookEvent(input);
+
+    expect(result.metadata.headers).toEqual({ "user-agent": "GitHub-Hookshot" });
+    expect(result.metadata.body).toBeUndefined();
+  });
+
+  test("handles webhook without optional fields", () => {
+    const input: WebhookEvent = {};
+
+    const result = normalizeWebhookEvent(input);
+
+    expect(result.channel).toBe("webhook");
+    expect(result.metadata).toEqual({});
+  });
+});
+
+// --- Edge cases ---
+
+describe("unicode handling", () => {
+  test("handles unicode text in Telegram", () => {
+    const input: any = {
+      message_id: 999,
+      from: { id: 111, first_name: "UnicodeUser" },
+      chat: { id: 222, type: "private" },
+      text: "Hello! 👋🎉 Привет! こんにちは！",
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.text).toBe("Hello! 👋🎉 Привет! こんにちは！");
+  });
+
+  test("handles unicode text in Discord", () => {
+    const input: any = {
+      id: "unicode_msg_888",
+      channel_id: "ch_999",
+      author: { id: "user_000", username: "unicodedave", discriminator: "0001" },
+      content: "Unicode: 🎯 🔥 ✨ مرحبا שלום",
+      attachments: [],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.text).toBe("Unicode: 🎯 🔥 ✨ مرحبا שלום");
+  });
+});
+
+describe("large metadata payloads", () => {
+  test("handles large metadata in Telegram", () => {
+    const largeEntities = Array.from({ length: 100 }, (_, i) => ({
+      type: "mention",
+      offset: i * 10,
+      length: 5,
+    }));
+
+    const input: any = {
+      message_id: 111,
+      from: { id: 222, first_name: "LargeMeta" },
+      chat: { id: 333, type: "private" },
+      text: "Test message with lots of entities",
+      entities: largeEntities,
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.metadata.entities).toHaveLength(100);
+  });
+
+  test("handles large payload in Cron", () => {
+    const largePayload = {
+      items: Array.from({ length: 1000 }, (_, i) => ({ id: i, data: `item_${i}` })),
+    };
+
+    const input: CronEvent = { payload: largePayload };
+
+    const result = normalizeCronEvent(input);
+
+    expect((result.metadata.payload as any).items).toHaveLength(1000);
+  });
+
+  test("handles large body in Webhook", () => {
+    const largeBody = {
+      records: Array.from({ length: 500 }, (_, i) => ({
+        id: `rec_${i}`,
+        values: Array.from({ length: 50 }, (_, j) => j * i),
+      })),
+    };
+
+    const input: WebhookEvent = { body: largeBody };
+
+    const result = normalizeWebhookEvent(input);
+
+    expect((result.metadata.body as any).records).toHaveLength(500);
+  });
+});
+
+describe("empty content", () => {
+  test("handles empty Telegram message with attachments only", () => {
+    const input: any = {
+      message_id: 222,
+      from: { id: 333, first_name: "PhotoOnly" },
+      chat: { id: 444, type: "private" },
+      photo: [{ file_id: "photo_abc", width: 1920, height: 1080 }],
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.text).toBe("");
+    expect(result.attachments).toHaveLength(1);
+  });
+
+  test("handles Discord message with only attachments", () => {
+    const input: any = {
+      id: "att_only_msg",
+      channel_id: "ch_555",
+      author: { id: "user_666", username: "附件", discriminator: "0001" },
+      content: "",
+      attachments: [
+        {
+          id: "att_777",
+          filename: "file.pdf",
+          content_type: "application/pdf",
+          url: "https://example.com/file.pdf",
+          proxy_url: "https://example.com/file.pdf",
+          size: 50000,
+        },
+      ],
+      mentions: [],
+      type: 0,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.text).toBe("");
+    expect(result.attachments).toHaveLength(1);
+  });
+});
+
+describe("missing optional fields", () => {
+  test("handles Telegram message without optional fields", () => {
+    const input: any = {
+      message_id: 333,
+      chat: { id: 444, type: "private" },
+    };
+
+    const result = normalizeTelegramMessage(input);
+
+    expect(result.sourceEventId).toBe("333");
+    expect(result.userId).toBe("unknown");
+    expect(result.threadId).toBe("default");
+    expect(result.metadata).toEqual({});
+  });
+
+  test("handles Discord message without guild_id", () => {
+    const input: any = {
+      id: "no_guild_msg",
+      channel_id: "dm_123",
+      author: { id: "user_456", username: "lonely", discriminator: "0001" },
+      content: "Just me",
+      attachments: [],
+      mentions: [],
+      type: 1,
+    };
+
+    const result = normalizeDiscordMessage(input);
+
+    expect(result.channelId).toBe("discord:dm:dm_123");
+  });
+});

--- a/src/__tests__/gateway/resume.test.ts
+++ b/src/__tests__/gateway/resume.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { rm } from "fs/promises";
+import { join } from "path";
+import {
+  getOrCreateSessionMapping,
+  getResumeArgs,
+  getResumeArgsForEvent,
+  recordClaudeSessionId,
+  updateSessionAfterProcessing,
+  getSessionStats,
+  resetSession,
+  isSessionStale,
+  shouldWarnCompact,
+  DEFAULT_STALE_THRESHOLD_MS,
+  COMPACT_WARNING_THRESHOLD_MS,
+} from "../../gateway/resume";
+import {
+  resetSessionMap,
+  getWriteQueueLength,
+  get,
+  type SessionEntry,
+} from "../../gateway/session-map";
+import type { NormalizedEvent } from "../../gateway/normalizer";
+
+const SESSION_MAP_FILE = join(process.cwd(), ".claude", "claudeclaw", "session-map.json");
+
+// Test helper to create a mock NormalizedEvent
+function createMockEvent(overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
+  return {
+    id: "test-event-id",
+    channel: "telegram",
+    channelId: "telegram:123456",
+    threadId: "default",
+    userId: "123456",
+    text: "Hello, world!",
+    attachments: [],
+    timestamp: Date.now(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// Test helper to wait for write queue to drain
+async function waitForWriteQueue(): Promise<void> {
+  // Wait for write queue to empty
+  while (getWriteQueueLength() > 0) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe("resume.ts", () => {
+  beforeEach(async () => {
+    // Reset session map state
+    resetSessionMap();
+    // Wait for any pending writes to complete
+    await waitForWriteQueue();
+    // Clear persisted file to ensure clean state
+    try {
+      await rm(SESSION_MAP_FILE, { force: true });
+    } catch {
+      // File might not exist, ignore
+    }
+  });
+
+  // ============ Task 1: Core lookup and resume argument logic ============
+
+  describe("getOrCreateSessionMapping", () => {
+    test("creates a new mapping when none exists", async () => {
+      const channelId = "telegram:123";
+      const threadId = "default";
+
+      const entry = await getOrCreateSessionMapping(channelId, threadId);
+
+      expect(entry).toBeDefined();
+      expect(entry.mappingId).toBeDefined();
+      expect(entry.claudeSessionId).toBeNull();
+      expect(entry.channelId).toBeUndefined(); // Not stored at entry level
+      expect(entry.threadId).toBeUndefined();
+      expect(entry.status).toBe("pending");
+      expect(entry.turnCount).toBe(0);
+      expect(entry.lastSeq).toBe(0);
+    });
+
+    test("returns existing mapping when one exists", async () => {
+      const channelId = "telegram:456";
+      const threadId = "thread-1";
+
+      // Create first time
+      const first = await getOrCreateSessionMapping(channelId, threadId);
+      
+      // Get again - should return same mapping
+      const second = await getOrCreateSessionMapping(channelId, threadId);
+
+      expect(first.mappingId).toBe(second.mappingId);
+    });
+
+    test("new mapping starts with null claudeSessionId", async () => {
+      const entry = await getOrCreateSessionMapping("discord:789", "default");
+      expect(entry.claudeSessionId).toBeNull();
+    });
+  });
+
+  describe("getResumeArgs", () => {
+    test("new mapping returns empty args and canResume=false", async () => {
+      const result = await getResumeArgs("telegram:111", "default");
+
+      expect(result.args).toEqual([]);
+      expect(result.canResume).toBe(false);
+      expect(result.isNewMapping).toBe(true);
+      expect(result.claudeSessionId).toBeNull();
+    });
+
+    test("existing mapping with null claudeSessionId returns empty args", async () => {
+      const channelId = "telegram:222";
+      const threadId = "default";
+
+      // Create mapping but don't attach Claude session ID
+      await getOrCreateSessionMapping(channelId, threadId);
+
+      const result = await getResumeArgs(channelId, threadId);
+
+      expect(result.args).toEqual([]);
+      expect(result.canResume).toBe(false);
+      expect(result.isNewMapping).toBe(false);
+    });
+
+    test("mapping with real claudeSessionId returns --resume args", async () => {
+      const channelId = "telegram:333";
+      const threadId = "default";
+      const realSessionId = "abc-123-session-id";
+
+      // Create mapping and attach real Claude session ID
+      await getOrCreateSessionMapping(channelId, threadId);
+      await recordClaudeSessionId(channelId, threadId, realSessionId);
+
+      const result = await getResumeArgs(channelId, threadId);
+
+      expect(result.args).toEqual(["--resume", realSessionId]);
+      expect(result.canResume).toBe(true);
+      expect(result.isNewMapping).toBe(false);
+      expect(result.claudeSessionId).toBe(realSessionId);
+    });
+
+    test("different channels/threads have independent mappings", async () => {
+      const channel1 = "telegram:100";
+      const channel2 = "telegram:200";
+      const thread1 = "default";
+      const thread2 = "thread-a";
+
+      await getOrCreateSessionMapping(channel1, thread1);
+      await getOrCreateSessionMapping(channel2, thread2);
+
+      const result1 = await getResumeArgs(channel1, thread1);
+      const result2 = await getResumeArgs(channel2, thread2);
+
+      expect(result1.mappingId).not.toBe(result2.mappingId);
+    });
+  });
+
+  describe("getResumeArgsForEvent", () => {
+    test("extracts channelId and threadId from event", async () => {
+      const event = createMockEvent({
+        channelId: "discord:guild:123:456",
+        threadId: "789",
+      });
+
+      const result = await getResumeArgsForEvent(event);
+
+      expect(result.canResume).toBe(false);
+      expect(result.isNewMapping).toBe(true);
+    });
+
+    test("returns resume args when event's session has real Claude session ID", async () => {
+      const event = createMockEvent({
+        channelId: "telegram:999",
+        threadId: "default",
+      });
+
+      // Create mapping first, then record the session ID
+      await getOrCreateSessionMapping(event.channelId, event.threadId);
+      await recordClaudeSessionId(event.channelId, event.threadId, "real-session-xyz");
+
+      const result = await getResumeArgsForEvent(event);
+
+      expect(result.args).toEqual(["--resume", "real-session-xyz"]);
+      expect(result.canResume).toBe(true);
+    });
+  });
+
+  // ============ Task 2: Post-processing metadata updates ============
+
+  describe("recordClaudeSessionId", () => {
+    test("records real Claude session ID on mapping", async () => {
+      const channelId = "telegram:1000";
+      const threadId = "default";
+      const sessionId = "claude-session-abc";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await recordClaudeSessionId(channelId, threadId, sessionId);
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.claudeSessionId).toBe(sessionId);
+      expect(entry?.status).toBe("active");
+    });
+
+    test("does not overwrite existing real session ID without force", async () => {
+      const channelId = "telegram:1001";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await recordClaudeSessionId(channelId, threadId, "first-session");
+      await recordClaudeSessionId(channelId, threadId, "second-session");
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.claudeSessionId).toBe("first-session");
+    });
+
+    test("overwrites with force=true", async () => {
+      const channelId = "telegram:1002";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await recordClaudeSessionId(channelId, threadId, "first-session");
+      
+      // Use internal attachClaudeSessionId with force
+      const { attachClaudeSessionId } = await import("../../gateway/session-map");
+      await attachClaudeSessionId(channelId, threadId, "second-session", true);
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.claudeSessionId).toBe("second-session");
+    });
+
+    test("ignores empty session IDs", async () => {
+      const channelId = "telegram:1003";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await recordClaudeSessionId(channelId, threadId, "");
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.claudeSessionId).toBeNull();
+    });
+  });
+
+  describe("updateSessionAfterProcessing", () => {
+    test("updates lastSeq after processing", async () => {
+      const channelId = "telegram:2000";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await updateSessionAfterProcessing(channelId, threadId, 42);
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.lastSeq).toBe(42);
+    });
+
+    test("increments turnCount by default", async () => {
+      const channelId = "telegram:2001";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      
+      // Process multiple turns
+      await updateSessionAfterProcessing(channelId, threadId, 1);
+      await updateSessionAfterProcessing(channelId, threadId, 2);
+      await updateSessionAfterProcessing(channelId, threadId, 3);
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.turnCount).toBe(3);
+    });
+
+    test("respects custom turnCountIncrement", async () => {
+      const channelId = "telegram:2002";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await updateSessionAfterProcessing(channelId, threadId, 1, { turnCountIncrement: 5 });
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.turnCount).toBe(5);
+    });
+
+    test("updates pending status to active on first successful processing", async () => {
+      const channelId = "telegram:2003";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      const initial = await get(channelId, threadId);
+      expect(initial?.status).toBe("pending");
+
+      await updateSessionAfterProcessing(channelId, threadId, 1);
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.status).toBe("active");
+    });
+
+    test("can set custom status via options", async () => {
+      const channelId = "telegram:2004";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await updateSessionAfterProcessing(channelId, threadId, 1, { status: "stale" });
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.status).toBe("stale");
+    });
+
+    test("updates lastActiveAt timestamp", async () => {
+      const channelId = "telegram:2005";
+      const threadId = "default";
+      const before = new Date().toISOString();
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await updateSessionAfterProcessing(channelId, threadId, 1);
+
+      const entry = await get(channelId, threadId);
+      expect(entry?.lastActiveAt >= before).toBe(true);
+    });
+  });
+
+  describe("getSessionStats", () => {
+    test("returns null for non-existent mapping", async () => {
+      const stats = await getSessionStats("nonexistent:channel", "default");
+      expect(stats).toBeNull();
+    });
+
+    test("returns comprehensive stats for existing mapping", async () => {
+      const channelId = "telegram:3000";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await updateSessionAfterProcessing(channelId, threadId, 10);
+      await recordClaudeSessionId(channelId, threadId, "session-xyz");
+
+      const stats = await getSessionStats(channelId, threadId);
+
+      expect(stats).not.toBeNull();
+      expect(stats!.mappingId).toBeDefined();
+      expect(stats!.claudeSessionId).toBe("session-xyz");
+      expect(stats!.lastSeq).toBe(10);
+      expect(stats!.turnCount).toBe(1);
+      expect(stats!.canResume).toBe(true);
+      expect(stats!.isStale).toBe(false);
+    });
+
+    test("marks session as stale when past threshold", async () => {
+      const channelId = "telegram:3001";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      
+      // Manually set lastActiveAt to past threshold
+      const oldDate = new Date(Date.now() - DEFAULT_STALE_THRESHOLD_MS - 1000).toISOString();
+      const { update } = await import("../../gateway/session-map");
+      await update(channelId, threadId, { lastActiveAt: oldDate });
+
+      const stats = await getSessionStats(channelId, threadId);
+      expect(stats!.isStale).toBe(true);
+    });
+  });
+
+  // ============ Task 3: Lifecycle helpers ============
+
+  describe("resetSession", () => {
+    test("removes the targeted mapping", async () => {
+      const channelId = "telegram:4000";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await resetSession(channelId, threadId);
+
+      const entry = await get(channelId, threadId);
+      expect(entry).toBeNull();
+    });
+
+    test("handles non-existent mapping gracefully", async () => {
+      await resetSession("nonexistent:channel", "default");
+      // Should not throw
+    });
+
+    test("multiple resets are idempotent", async () => {
+      const channelId = "telegram:4001";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      await resetSession(channelId, threadId);
+      await resetSession(channelId, threadId); // Second reset should not throw
+
+      const entry = await get(channelId, threadId);
+      expect(entry).toBeNull();
+    });
+  });
+
+  describe("isSessionStale", () => {
+    test("returns true for non-existent mapping", async () => {
+      const isStale = await isSessionStale("nonexistent:channel", "default");
+      expect(isStale).toBe(true);
+    });
+
+    test("returns false for recently active session", async () => {
+      const channelId = "telegram:5000";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      const isStale = await isSessionStale(channelId, threadId);
+
+      expect(isStale).toBe(false);
+    });
+
+    test("respects custom threshold", async () => {
+      const channelId = "telegram:5001";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      
+      // Set lastActiveAt to 30 minutes ago
+      const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+      const { update } = await import("../../gateway/session-map");
+      await update(channelId, threadId, { lastActiveAt: thirtyMinutesAgo });
+
+      // 1 hour threshold = not stale
+      const isStale1hr = await isSessionStale(channelId, threadId, 60 * 60 * 1000);
+      expect(isStale1hr).toBe(false);
+
+      // 15 minute threshold = stale
+      const isStale15min = await isSessionStale(channelId, threadId, 15 * 60 * 1000);
+      expect(isStale15min).toBe(true);
+    });
+  });
+
+  describe("shouldWarnCompact", () => {
+    test("returns false for non-existent mapping", async () => {
+      const shouldWarn = await shouldWarnCompact("nonexistent:channel", "default");
+      expect(shouldWarn).toBe(false);
+    });
+
+    test("returns false for fresh session", async () => {
+      const channelId = "telegram:6000";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      const shouldWarn = await shouldWarnCompact(channelId, threadId);
+
+      expect(shouldWarn).toBe(false);
+    });
+
+    test("returns true for long session with many turns", async () => {
+      const channelId = "telegram:6001";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      
+      // Set high turn count but keep active (within compact warning threshold)
+      const { update } = await import("../../gateway/session-map");
+      await update(channelId, threadId, { turnCount: 100 });
+
+      const shouldWarn = await shouldWarnCompact(channelId, threadId);
+      expect(shouldWarn).toBe(true);
+    });
+
+    test("returns false for long session with few turns", async () => {
+      const channelId = "telegram:6002";
+      const threadId = "default";
+
+      await getOrCreateSessionMapping(channelId, threadId);
+      
+      // Set low turn count
+      const { update } = await import("../../gateway/session-map");
+      await update(channelId, threadId, { turnCount: 10 });
+
+      const shouldWarn = await shouldWarnCompact(channelId, threadId);
+      expect(shouldWarn).toBe(false);
+    });
+  });
+
+  // ============ Full flow tests ============
+
+  describe("full flow", () => {
+    test("create mapping -> first success -> record Claude session ID -> later resume", async () => {
+      const channelId = "telegram:7000";
+      const threadId = "default";
+
+      // Step 1: Create new mapping (should not be resumable)
+      const step1 = await getResumeArgs(channelId, threadId);
+      expect(step1.canResume).toBe(false);
+      expect(step1.args).toEqual([]);
+      expect(step1.isNewMapping).toBe(true);
+
+      // Step 2: First processing - should update stats but still not resumable
+      await updateSessionAfterProcessing(channelId, threadId, 1);
+      const step2 = await getResumeArgs(channelId, threadId);
+      expect(step2.canResume).toBe(false); // No real session ID yet
+      expect(step2.args).toEqual([]);
+
+      // Step 3: Runner returns real Claude session ID - record it
+      const realSessionId = "claude-runner-session-123";
+      await recordClaudeSessionId(channelId, threadId, realSessionId);
+
+      // Step 4: Now resume should work
+      const step4 = await getResumeArgs(channelId, threadId);
+      expect(step4.canResume).toBe(true);
+      expect(step4.args).toEqual(["--resume", realSessionId]);
+      expect(step4.claudeSessionId).toBe(realSessionId);
+
+      // Step 5: More processing - turn count increases
+      await updateSessionAfterProcessing(channelId, threadId, 2);
+      await updateSessionAfterProcessing(channelId, threadId, 3);
+
+      // Step 6: Final state check
+      const final = await getSessionStats(channelId, threadId);
+      expect(final!.turnCount).toBe(3);
+      expect(final!.lastSeq).toBe(3);
+      expect(final!.canResume).toBe(true);
+    });
+
+    test("sequential event processing maintains consistency", async () => {
+      const channelId = "telegram:8000";
+      const threadId = "default";
+
+      // Create initial mapping
+      await getOrCreateSessionMapping(channelId, threadId);
+
+      // Process multiple events sequentially (write queue serializes anyway)
+      for (let i = 1; i <= 5; i++) {
+        await updateSessionAfterProcessing(channelId, threadId, i);
+      }
+
+      const stats = await getSessionStats(channelId, threadId);
+      // After 5 sequential updates, turnCount should be 5
+      expect(stats!.turnCount).toBe(5);
+      // lastSeq should be the last value processed
+      expect(stats!.lastSeq).toBe(5);
+    });
+  });
+});

--- a/src/__tests__/gateway/session-map.test.ts
+++ b/src/__tests__/gateway/session-map.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Tests for session-map.ts
+ * 
+ * Run with: bun test src/__tests__/gateway/session-map.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm } from "fs/promises";
+import { join } from "path";
+import {
+  get,
+  set,
+  remove,
+  update,
+  updateLastSeq,
+  incrementTurnCount,
+  attachClaudeSessionId,
+  getOrCreateMapping,
+  listChannels,
+  listThreads,
+  markStale,
+  cleanup,
+  resetSessionMap,
+  getWriteQueueLength,
+  type SessionEntry,
+  DEFAULT_THREAD_ID,
+} from "../../gateway/session-map";
+
+const TEST_SESSION_MAP_FILE = join(process.cwd(), ".claude", "claudeclaw", "session-map.json");
+
+// Helper to create a test entry
+const createTestEntry = (overrides: Partial<SessionEntry> = {}): SessionEntry => ({
+  mappingId: "test-mapping-id",
+  claudeSessionId: null,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  lastActiveAt: new Date().toISOString(),
+  lastSeq: 0,
+  turnCount: 0,
+  status: "pending",
+  ...overrides,
+});
+
+describe("Session Map - Core CRUD", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should return null for missing mapping", async () => {
+    const result = await get("channel-1", "thread-1");
+    expect(result).toBeNull();
+  });
+
+  it("should set and get the same entry", async () => {
+    const entry = createTestEntry();
+    await set("channel-1", "thread-1", entry);
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved).not.toBeNull();
+    expect(retrieved?.mappingId).toBe(entry.mappingId);
+    expect(retrieved?.claudeSessionId).toBeNull();
+  });
+
+  it("should delete only the targeted thread mapping", async () => {
+    const entry1 = createTestEntry({ mappingId: "entry-1" });
+    const entry2 = createTestEntry({ mappingId: "entry-2" });
+    
+    await set("channel-1", "thread-1", entry1);
+    await set("channel-1", "thread-2", entry2);
+    await set("channel-2", "thread-1", entry1);
+    
+    await remove("channel-1", "thread-1");
+    
+    // thread-1 in channel-1 should be gone
+    expect(await get("channel-1", "thread-1")).toBeNull();
+    
+    // thread-2 in channel-1 should still exist
+    expect(await get("channel-1", "thread-2")).not.toBeNull();
+    
+    // thread-1 in channel-2 should still exist
+    expect(await get("channel-2", "thread-1")).not.toBeNull();
+  });
+
+  it("should use default thread ID when not specified", async () => {
+    const entry = createTestEntry();
+    await set("channel-1", DEFAULT_THREAD_ID, entry);
+    
+    const retrieved = await get("channel-1");
+    expect(retrieved?.mappingId).toBe(entry.mappingId);
+  });
+
+  it("should handle malformed JSON file gracefully", async () => {
+    // Write malformed JSON
+    await Bun.write(TEST_SESSION_MAP_FILE, "not valid json {{{");
+    
+    // Reset to force re-read
+    resetSessionMap();
+    
+    // Should not throw, should return empty map
+    const result = await get("channel-1", "thread-1");
+    expect(result).toBeNull();
+  });
+
+  it("should handle missing file gracefully", async () => {
+    // File doesn't exist - reset forces re-read
+    resetSessionMap();
+    
+    // Should not throw, should return empty map
+    const result = await get("channel-1", "thread-1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("Session Map - Same Channel / Different Thread Isolation", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should have different mapping entries for same channel with different threads", async () => {
+    const entry1 = createTestEntry({ mappingId: "id-1" });
+    const entry2 = createTestEntry({ mappingId: "id-2" });
+    
+    await set("channel-1", "thread-1", entry1);
+    await set("channel-1", "thread-2", entry2);
+    
+    const retrieved1 = await get("channel-1", "thread-1");
+    const retrieved2 = await get("channel-1", "thread-2");
+    
+    expect(retrieved1?.mappingId).toBe("id-1");
+    expect(retrieved2?.mappingId).toBe("id-2");
+  });
+});
+
+describe("Session Map - Same Thread Repeat Lookup Consistency", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should return the same entry on repeated lookups", async () => {
+    const entry = createTestEntry({ mappingId: "consistent-id" });
+    await set("channel-1", "thread-1", entry);
+    
+    // Multiple reads
+    const retrieved1 = await get("channel-1", "thread-1");
+    const retrieved2 = await get("channel-1", "thread-1");
+    const retrieved3 = await get("channel-1", "thread-1");
+    
+    expect(retrieved1?.mappingId).toBe("consistent-id");
+    expect(retrieved2?.mappingId).toBe("consistent-id");
+    expect(retrieved3?.mappingId).toBe("consistent-id");
+  });
+});
+
+describe("Session Map - Metadata Updates", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should get or create mapping returning existing entry", async () => {
+    const entry = createTestEntry({ mappingId: "existing-id" });
+    await set("channel-1", "thread-1", entry);
+    
+    const retrieved = await getOrCreateMapping("channel-1", "thread-1");
+    expect(retrieved.mappingId).toBe("existing-id");
+  });
+
+  it("should get or create mapping creating new entry with null claudeSessionId", async () => {
+    const retrieved = await getOrCreateMapping("channel-1", "thread-1");
+    
+    expect(retrieved.mappingId).toBeTruthy();
+    expect(retrieved.claudeSessionId).toBeNull();
+    expect(retrieved.status).toBe("pending");
+  });
+
+  it("should attach real Claude session ID once available", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    
+    await attachClaudeSessionId("channel-1", "thread-1", "claude-session-123");
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.claudeSessionId).toBe("claude-session-123");
+    expect(retrieved?.status).toBe("active");
+  });
+
+  it("should not overwrite existing non-null Claude session ID without force", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await attachClaudeSessionId("channel-1", "thread-1", "claude-session-123");
+    
+    // Try to overwrite
+    await attachClaudeSessionId("channel-1", "thread-1", "claude-session-456");
+    
+    // Should still be the original
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.claudeSessionId).toBe("claude-session-123");
+  });
+
+  it("should force overwrite when forced", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await attachClaudeSessionId("channel-1", "thread-1", "claude-session-123");
+    
+    // Force overwrite
+    await attachClaudeSessionId("channel-1", "thread-1", "claude-session-456", true);
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.claudeSessionId).toBe("claude-session-456");
+  });
+
+  it("should update lastSeq", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await updateLastSeq("channel-1", "thread-1", 42);
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.lastSeq).toBe(42);
+  });
+
+  it("should increment turn count", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    
+    await incrementTurnCount("channel-1", "thread-1");
+    await incrementTurnCount("channel-1", "thread-1");
+    await incrementTurnCount("channel-1", "thread-1");
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.turnCount).toBe(3);
+  });
+
+  it("should list all channels", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await getOrCreateMapping("channel-2", "thread-1");
+    await getOrCreateMapping("channel-3", "thread-1");
+    
+    const channels = await listChannels();
+    expect(channels).toContain("channel-1");
+    expect(channels).toContain("channel-2");
+    expect(channels).toContain("channel-3");
+    expect(channels.length).toBe(3);
+  });
+
+  it("should list all threads for a channel", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await getOrCreateMapping("channel-1", "thread-2");
+    await getOrCreateMapping("channel-1", "thread-3");
+    await getOrCreateMapping("channel-2", "thread-1");
+    
+    const threads = await listThreads("channel-1");
+    expect(threads).toContain("thread-1");
+    expect(threads).toContain("thread-2");
+    expect(threads).toContain("thread-3");
+    expect(threads.length).toBe(3);
+  });
+
+  it("should mark entry as stale", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await markStale("channel-1", "thread-1");
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.status).toBe("stale");
+  });
+});
+
+describe("Session Map - Concurrent Writes", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should serialize concurrent writes without corruption", async () => {
+    // Create multiple entries concurrently
+    const entries = Array.from({ length: 10 }, (_, i) => 
+      createTestEntry({ mappingId: `concurrent-${i}` })
+    );
+    
+    await Promise.all(
+      entries.map((entry, i) => set(`channel-${i}`, `thread-1`, entry))
+    );
+    
+    // All entries should be present and correct
+    for (let i = 0; i < 10; i++) {
+      const retrieved = await get(`channel-${i}`, "thread-1");
+      expect(retrieved?.mappingId).toBe(`concurrent-${i}`);
+    }
+  });
+
+  it("should complete concurrent writes without data loss", async () => {
+    const entries = Array.from({ length: 10 }, (_, i) => 
+      createTestEntry({ mappingId: `concurrent-${i}` })
+    );
+    
+    // Start concurrent writes
+    await Promise.all(
+      entries.map((entry, i) => set(`channel-${i}`, "thread-1", entry))
+    );
+    
+    // All entries should be present and correct after concurrent writes
+    for (let i = 0; i < 10; i++) {
+      const retrieved = await get(`channel-${i}`, "thread-1");
+      expect(retrieved?.mappingId).toBe(`concurrent-${i}`);
+    }
+    
+    // Queue should be empty after
+    expect(getWriteQueueLength()).toBe(0);
+  });
+});
+
+describe("Session Map - Cleanup", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should preserve active entries during cleanup", async () => {
+    await getOrCreateMapping("channel-1", "thread-1");
+    await attachClaudeSessionId("channel-1", "thread-1", "claude-session-123");
+    
+    const removed = await cleanup(1); // 1 day TTL
+    
+    expect(removed).toBe(0);
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved).not.toBeNull();
+  });
+
+  it("should remove empty channels after cleanup", async () => {
+    // Create entry
+    await getOrCreateMapping("channel-1", "thread-1");
+    
+    // Delete it
+    await remove("channel-1", "thread-1");
+    
+    // Cleanup should remove empty channel
+    await cleanup(1);
+    
+    const channels = await listChannels();
+    expect(channels).not.toContain("channel-1");
+  });
+
+  it("should not delete entries with null claudeSessionId that are recent", async () => {
+    // Create entry (will have null claudeSessionId)
+    await getOrCreateMapping("channel-1", "thread-1");
+    
+    // Very short TTL - but entry was just created
+    const removed = await cleanup(1);
+    
+    expect(removed).toBe(0);
+    expect(await get("channel-1", "thread-1")).not.toBeNull();
+  });
+
+  it("should delete reset entries that are old", async () => {
+    // Create entry
+    await getOrCreateMapping("channel-1", "thread-1");
+    
+    // Manually set to reset status (simulating an old reset entry)
+    const entry = await get("channel-1", "thread-1");
+    if (entry) {
+      entry.status = "reset";
+      entry.updatedAt = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString(); // 100 days ago
+      await set("channel-1", "thread-1", entry);
+    }
+    
+    // Cleanup with 1 day TTL
+    const removed = await cleanup(1);
+    
+    expect(removed).toBe(1);
+    expect(await get("channel-1", "thread-1")).toBeNull();
+  });
+});
+
+describe("Session Map - Edge Cases", () => {
+  beforeEach(() => {
+    resetSessionMap();
+  });
+
+  afterEach(async () => {
+    resetSessionMap();
+    try {
+      await rm(TEST_SESSION_MAP_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should throw when updating non-existent entry", async () => {
+    await expect(
+      update("nonexistent", "thread", { status: "active" })
+    ).rejects.toThrow();
+  });
+
+  it("should throw when attaching session ID to non-existent entry", async () => {
+    await expect(
+      attachClaudeSessionId("nonexistent", "thread", "session-123")
+    ).rejects.toThrow();
+  });
+
+  it("should throw when incrementing turn count for non-existent entry", async () => {
+    await expect(
+      incrementTurnCount("nonexistent", "thread")
+    ).rejects.toThrow();
+  });
+
+  it("should handle empty channel ID", async () => {
+    const entry = createTestEntry();
+    await set("", "thread-1", entry);
+    
+    const retrieved = await get("", "thread-1");
+    expect(retrieved?.mappingId).toBe(entry.mappingId);
+  });
+
+  it("should handle empty thread ID", async () => {
+    const entry = createTestEntry();
+    await set("channel-1", "", entry);
+    
+    const retrieved = await get("channel-1", "");
+    expect(retrieved?.mappingId).toBe(entry.mappingId);
+  });
+
+  it("should preserve metadata through updates", async () => {
+    const entry = createTestEntry({
+      metadata: { key: "value", nested: { deep: true } }
+    });
+    await set("channel-1", "thread-1", entry);
+    
+    await updateLastSeq("channel-1", "thread-1", 100);
+    
+    const retrieved = await get("channel-1", "thread-1");
+    expect(retrieved?.metadata).toEqual({ key: "value", nested: { deep: true } });
+  });
+});

--- a/src/__tests__/governance/budget-engine.test.ts
+++ b/src/__tests__/governance/budget-engine.test.ts
@@ -1,0 +1,326 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  initBudgetEngine,
+  evaluateBudget,
+  getBudgetState,
+  upsertBudgetPolicy,
+  deleteBudgetPolicy,
+  loadPricingConfig,
+  loadPolicies,
+  calculateEstimatedCost,
+  createDefaultPoliciesForChannel,
+  resetBudgetEngine,
+  type BudgetPolicy,
+} from "../../governance/budget-engine";
+import { join } from "path";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+
+const BUDGET_POLICIES_FILE = join(process.cwd(), ".claude", "claudeclaw", "budget-policies.json");
+const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
+
+describe("BudgetEngine", () => {
+  beforeEach(async () => {
+    const { rm, readdir } = await import("fs/promises");
+    
+    // Clean budget policies file for test isolation
+    try {
+      await rm(BUDGET_POLICIES_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    
+    // Clean usage directory for test isolation
+    try {
+      const files = await readdir(USAGE_DIR);
+      await Promise.all(
+        files
+          .filter(f => f !== ".gitkeep")
+          .map(f => rm(join(USAGE_DIR, f), { force: true }))
+      );
+    } catch {
+      // Directory might not exist
+    }
+    
+    resetBudgetEngine();
+    resetUsageTracker();
+    await initUsageTracker();
+    await initBudgetEngine();
+  });
+
+  afterEach(async () => {
+    resetBudgetEngine();
+    resetUsageTracker();
+  });
+
+  test("should initialize with default pricing", async () => {
+    const pricing = await loadPricingConfig();
+    expect(pricing.version).toBe("1.0.0");
+    expect(pricing.tiers.length).toBeGreaterThan(0);
+    expect(pricing.tiers[0].provider).toBe("anthropic");
+  });
+
+  test("should create budget policy", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Test Policy",
+      scope: { channelId: "test-channel" },
+      thresholds: {
+        warnAt: 10,
+        degradeAt: 20,
+        blockAt: 50,
+      },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    expect(policy.id).toBeDefined();
+    expect(policy.name).toBe("Test Policy");
+    expect(policy.thresholds.warnAt).toBe(10);
+    expect(policy.thresholds.degradeAt).toBe(20);
+    expect(policy.thresholds.blockAt).toBe(50);
+  });
+
+  test("should update existing policy", async () => {
+    const created = await upsertBudgetPolicy({
+      name: "Original Name",
+      scope: {},
+      thresholds: {},
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const updated = await upsertBudgetPolicy({
+      id: created.id,
+      name: "Updated Name",
+      scope: {},
+      thresholds: { warnAt: 5 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    expect(updated.id).toBe(created.id);
+    expect(updated.name).toBe("Updated Name");
+    expect(updated.thresholds.warnAt).toBe(5);
+  });
+
+  test("should delete budget policy", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "To Delete",
+      scope: {},
+      thresholds: {},
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const deleted = await deleteBudgetPolicy(policy.id);
+    expect(deleted).toBe(true);
+
+    const policies = await loadPolicies();
+    expect(policies.find((p) => p.id === policy.id)).toBeUndefined();
+  });
+
+  test("should evaluate healthy budget when under threshold", async () => {
+    await upsertBudgetPolicy({
+      name: "Low Limit Policy",
+      scope: { channelId: "test-chan" },
+      thresholds: { warnAt: 100, degradeAt: 200, blockAt: 500 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Create a small invocation
+    const start = await recordInvocationStart({
+      channelId: "test-chan",
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 100, outputTokens: 100 },
+      { currency: "USD", totalCost: 0.001 }
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "test-chan" });
+    expect(evaluation.length).toBeGreaterThan(0);
+    expect(evaluation[0].state).toBe("healthy");
+  });
+
+  test("should evaluate warn state at threshold", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Warn Test",
+      scope: { channelId: "warn-chan" },
+      thresholds: { warnAt: 0.05, degradeAt: 0.10 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "warn-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 10000, outputTokens: 5000 },
+      { currency: "USD", totalCost: 0.06 } // Above warnAt
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "warn-chan" });
+    expect(evaluation[0].state).toBe("warn");
+    expect(evaluation[0].actions.shouldWarn).toBe(true);
+  });
+
+  test("should return degrade state when threshold exceeded", async () => {
+    await upsertBudgetPolicy({
+      name: "Degrade Test",
+      scope: { channelId: "degrade-chan" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.05, blockAt: 0.10 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "degrade-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 20000, outputTokens: 10000 },
+      { currency: "USD", totalCost: 0.08 } // Above degradeAt
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "degrade-chan" });
+    expect(["degrade", "reroute", "block"]).toContain(evaluation[0].state);
+  });
+
+  test("should return block state at block threshold", async () => {
+    await upsertBudgetPolicy({
+      name: "Block Test",
+      scope: { channelId: "block-chan" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.05, blockAt: 0.10 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "block-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 40000, outputTokens: 20000 },
+      { currency: "USD", totalCost: 0.15 } // Above blockAt
+    );
+
+    const evaluation = await evaluateBudget({ channelId: "block-chan" });
+    expect(evaluation[0].state).toBe("block");
+    expect(evaluation[0].actions.shouldBlock).toBe(true);
+  });
+
+  test("should calculate estimated cost correctly", async () => {
+    const cost = calculateEstimatedCost(
+      {
+        inputTokens: 1000000, // 1M input
+        outputTokens: 500000, // 500K output
+        cacheCreationInputTokens: 100000,
+        cacheReadInputTokens: 200000,
+      },
+      "anthropic",
+      "claude-3-5-sonnet"
+    );
+
+    expect(cost).not.toBeNull();
+    // 1M * $3 + 500K * $15 + 100K * $3.75 + 200K * $0.30 / 1M
+    // = $3 + $7.5 + $0.375 + $0.06 = $10.935
+    expect(cost!.totalCost).toBeCloseTo(10.935, 2);
+  });
+
+  test("should create default policies for channel", async () => {
+    const policies = await createDefaultPoliciesForChannel("new-channel", {
+      dailyLimit: 10,
+      monthlyLimit: 100,
+    });
+
+    expect(policies.length).toBe(2);
+    expect(policies.find((p) => p.period === "daily")).toBeDefined();
+    expect(policies.find((p) => p.period === "monthly")).toBeDefined();
+  });
+
+  test("should scope policies correctly", async () => {
+    // Policy for specific channel
+    await upsertBudgetPolicy({
+      name: "Channel Specific",
+      scope: { channelId: "specific-chan" },
+      thresholds: { blockAt: 1 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Policy for all channels
+    await upsertBudgetPolicy({
+      name: "Global",
+      scope: {},
+      thresholds: { blockAt: 1000 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const evalForSpecific = await evaluateBudget({ channelId: "specific-chan" });
+    const evalForOther = await evaluateBudget({ channelId: "other-chan" });
+
+    // Should have both policies for specific channel
+    expect(evalForSpecific.length).toBe(2);
+
+    // Should only have global policy for other channel
+    expect(evalForOther.length).toBe(1);
+    expect(evalForOther[0].policyName).toBe("Global");
+  });
+
+  test("should respect period boundaries", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Session Policy",
+      scope: {},
+      thresholds: { warnAt: 0.001 },
+      period: "session",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Session-scoped policy should evaluate based on session usage
+    const start = await recordInvocationStart({
+      sessionId: "test-session",
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.005 }
+    );
+
+    const eval_ = await evaluateBudget({ sessionId: "test-session" });
+    // Should evaluate session policy
+    expect(eval_.some((e) => e.policyId === policy.id)).toBe(true);
+  });
+});

--- a/src/__tests__/governance/model-router.test.ts
+++ b/src/__tests__/governance/model-router.test.ts
@@ -1,0 +1,237 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  selectModel,
+  getFallbackChain,
+  isModelAllowed,
+  configureRouter,
+  getRouterConfig,
+} from "../../governance/model-router";
+import {
+  initBudgetEngine,
+  upsertBudgetPolicy,
+  resetBudgetEngine,
+} from "../../governance/budget-engine";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+import { join } from "path";
+
+const BUDGET_POLICIES_FILE = join(process.cwd(), ".claude", "claudeclaw", "budget-policies.json");
+
+describe("ModelRouter", () => {
+  beforeEach(async () => {
+    resetUsageTracker();
+    resetBudgetEngine();
+    
+    // Clear budget policies file for test isolation
+    try {
+      const { rm } = await import("fs/promises");
+      await rm(BUDGET_POLICIES_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    
+    await initUsageTracker();
+    await initBudgetEngine();
+    
+    // Reset router config
+    configureRouter({
+      defaultProvider: "anthropic",
+      defaultModel: "claude-3-5-sonnet",
+      fallbackChain: [
+        { provider: "anthropic", model: "claude-3-5-sonnet" },
+        { provider: "anthropic", model: "claude-3-haiku" },
+        { provider: "openai", model: "gpt-4o-mini" },
+      ],
+    });
+  });
+
+  test("should select default model with healthy budget", async () => {
+    const decision = await selectModel({});
+
+    expect(decision.selectedProvider).toBe("anthropic");
+    expect(decision.selectedModel).toBe("claude-3-5-sonnet");
+    expect(decision.budgetState).toBe("healthy");
+    expect(decision.reason).toContain("Default model selection");
+  });
+
+  test("should respect preferred provider/model", async () => {
+    const decision = await selectModel({
+      preferredProvider: "openai",
+      preferredModel: "gpt-4o",
+    });
+
+    expect(decision.selectedProvider).toBe("openai");
+    expect(decision.selectedModel).toBe("gpt-4o");
+  });
+
+  test("should return auditable decision", async () => {
+    const decision = await selectModel({});
+
+    expect(decision.requestId).toBeDefined();
+    expect(decision.decidedAt).toBeDefined();
+    expect(decision.reason).toBeDefined();
+    expect(decision.fallbackChain).toBeDefined();
+    expect(Array.isArray(decision.fallbackChain)).toBe(true);
+  });
+
+  test("should block execution when budget exceeded", async () => {
+    // Create a policy that will be exceeded
+    await upsertBudgetPolicy({
+      name: "Very Low Limit",
+      scope: { channelId: "low-limit-chan" },
+      thresholds: { blockAt: 0.001 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Add usage that exceeds the limit
+    const start = await recordInvocationStart({
+      channelId: "low-limit-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 100000, outputTokens: 50000 },
+      { currency: "USD", totalCost: 0.50 }
+    );
+
+    const decision = await selectModel({ channelId: "low-limit-chan" });
+
+    expect(decision.selectedModel).toBe("");
+    expect(decision.budgetState).toBe("block");
+    expect(decision.reason).toContain("blocked");
+  });
+
+  test("should allow explicit override when permitted", async () => {
+    const decision = await selectModel({
+      explicitOverride: {
+        provider: "openai",
+        model: "gpt-4o",
+        allowed: true,
+      },
+    });
+
+    expect(decision.selectedProvider).toBe("openai");
+    expect(decision.selectedModel).toBe("gpt-4o");
+    expect(decision.reason).toContain("override");
+  });
+
+  test("should use capability mapping", async () => {
+    const decision = await selectModel({
+      capability: "coding",
+    });
+
+    expect(decision.selectedProvider).toBe("anthropic");
+    expect(decision.selectedModel).toBe("claude-3-5-sonnet");
+  });
+
+  test("should use fast capability for quick tasks", async () => {
+    const decision = await selectModel({
+      capability: "fast",
+    });
+
+    expect(decision.selectedProvider).toBe("anthropic");
+    expect(decision.selectedModel).toBe("claude-3-haiku");
+  });
+
+  test("should provide fallback chain", async () => {
+    const chain = await getFallbackChain({});
+
+    expect(chain.length).toBeGreaterThan(0);
+    expect(chain[0]).toHaveProperty("provider");
+    expect(chain[0]).toHaveProperty("model");
+  });
+
+  test("should check model allowed status", async () => {
+    const result = await isModelAllowed("anthropic", "claude-3-5-sonnet", {});
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBeDefined();
+  });
+
+  test("should deny model when budget exceeded", async () => {
+    // Create a policy that will be exceeded
+    await upsertBudgetPolicy({
+      name: "Deny Test",
+      scope: { channelId: "deny-chan" },
+      thresholds: { blockAt: 0.001 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Add usage
+    const start = await recordInvocationStart({
+      channelId: "deny-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 100000, outputTokens: 50000 },
+      { currency: "USD", totalCost: 0.50 }
+    );
+
+    const result = await isModelAllowed(
+      "anthropic",
+      "claude-3-5-sonnet",
+      { channelId: "deny-chan" }
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain("blocked");
+  });
+
+  test("should configure router", () => {
+    configureRouter({
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o",
+      degradeToModel: "claude-3-haiku",
+      rerouteToProvider: "google",
+    });
+
+    const config = getRouterConfig();
+    expect(config.defaultProvider).toBe("openai");
+    expect(config.defaultModel).toBe("gpt-4o");
+    expect(config.degradeToModel).toBe("claude-3-haiku");
+    expect(config.rerouteToProvider).toBe("google");
+  });
+
+  test("should include budget state in decision", async () => {
+    // Create usage that will trigger warn state
+    await upsertBudgetPolicy({
+      name: "Warn Test",
+      scope: { channelId: "warn-chan" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.05 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const start = await recordInvocationStart({
+      channelId: "warn-chan",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 5000, outputTokens: 2500 },
+      { currency: "USD", totalCost: 0.02 } // Above warnAt
+    );
+
+    const decision = await selectModel({ channelId: "warn-chan" });
+
+    expect(decision.budgetState).toBeDefined();
+    expect(["warn", "degrade", "block"]).toContain(decision.budgetState);
+    expect(decision.matchedPolicyId).toBeDefined();
+  });
+});

--- a/src/__tests__/governance/telemetry.test.ts
+++ b/src/__tests__/governance/telemetry.test.ts
@@ -1,0 +1,247 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  getTelemetry,
+  getTelemetrySummary,
+  getProviderBreakdown,
+  getModelBreakdown,
+  getChannelBreakdown,
+  getBudgetHealth,
+} from "../../governance/telemetry";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+import {
+  initBudgetEngine,
+  upsertBudgetPolicy,
+  resetBudgetEngine,
+} from "../../governance/budget-engine";
+
+describe("Telemetry", () => {
+  beforeEach(async () => {
+    resetUsageTracker();
+    resetBudgetEngine();
+    await initUsageTracker();
+    await initBudgetEngine();
+  });
+
+  test("should return telemetry summary", async () => {
+    const summary = await getTelemetrySummary();
+
+    expect(summary).toHaveProperty("totalInvocations");
+    expect(summary).toHaveProperty("estimatedTotalCost");
+    expect(summary).toHaveProperty("activeBudgets");
+    expect(summary).toHaveProperty("blockedBudgets");
+    expect(typeof summary.totalInvocations).toBe("number");
+    expect(typeof summary.estimatedTotalCost).toBe("number");
+  });
+
+  test("should return comprehensive telemetry", async () => {
+    // Create some usage data
+    const context = {
+      sessionId: "telemetry-session",
+      channelId: "telegram:telemetry",
+      source: "telegram",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const start = await recordInvocationStart(context);
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      {
+        inputTokens: 5000,
+        outputTokens: 10000,
+      },
+      {
+        currency: "USD",
+        totalCost: 0.165,
+      }
+    );
+
+    const telemetry = await getTelemetry({});
+
+    expect(telemetry.estimatedTotalCost).toBeGreaterThan(0);
+    expect(telemetry.invocationStats.total).toBeGreaterThan(0);
+    expect(telemetry.invocationStats.completed).toBeGreaterThan(0);
+    expect(telemetry.providerStats["anthropic"]).toBeDefined();
+    expect(telemetry.modelStats["claude-3-5-sonnet"]).toBeDefined();
+  });
+
+  test("should filter telemetry by date range", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.02 }
+    );
+
+    // Future date should return empty
+    const futureFilter = await getTelemetry({
+      startDate: "2099-01-01T00:00:00Z",
+    });
+    expect(futureFilter.invocationStats.total).toBe(0);
+
+    // Past date should include data
+    const pastFilter = await getTelemetry({
+      startDate: "1970-01-01T00:00:00Z",
+    });
+    expect(pastFilter.invocationStats.total).toBeGreaterThan(0);
+  });
+
+  test("should filter telemetry by provider", async () => {
+    // Anthropic invocation
+    const anthropicStart = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+    await recordInvocationCompletion(
+      anthropicStart.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.02 }
+    );
+
+    // OpenAI invocation
+    const openaiStart = await recordInvocationStart({
+      provider: "openai",
+      model: "gpt-4o",
+    });
+    await recordInvocationCompletion(
+      openaiStart.invocationId,
+      { inputTokens: 1000, outputTokens: 500 },
+      { currency: "USD", totalCost: 0.03 }
+    );
+
+    const anthropicTelemetry = await getTelemetry({ provider: "anthropic" });
+    expect(anthropicTelemetry.providerStats["anthropic"]).toBeDefined();
+    expect(anthropicTelemetry.providerStats["openai"]).toBeUndefined();
+  });
+
+  test("should return provider breakdown", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 10000, outputTokens: 5000 },
+      { currency: "USD", totalCost: 0.105 }
+    );
+
+    const breakdown = await getProviderBreakdown();
+
+    expect(Array.isArray(breakdown)).toBe(true);
+    const anthropic = breakdown.find((p) => p.provider === "anthropic");
+    expect(anthropic).toBeDefined();
+    expect(anthropic!.calls).toBeGreaterThan(0);
+    expect(anthropic!.tokens).toBeGreaterThan(0);
+  });
+
+  test("should return model breakdown", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 500, outputTokens: 250 },
+      { currency: "USD", totalCost: 0.005 }
+    );
+
+    const breakdown = await getModelBreakdown();
+
+    expect(Array.isArray(breakdown)).toBe(true);
+    const haiku = breakdown.find((m) => m.model === "claude-3-haiku");
+    expect(haiku).toBeDefined();
+    expect(haiku!.calls).toBeGreaterThan(0);
+  });
+
+  test("should return channel breakdown", async () => {
+    const start = await recordInvocationStart({
+      channelId: "discord:12345",
+      source: "discord",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      { inputTokens: 2000, outputTokens: 1000 },
+      { currency: "USD", totalCost: 0.045 }
+    );
+
+    const breakdown = await getChannelBreakdown();
+
+    expect(Array.isArray(breakdown)).toBe(true);
+    const discord = breakdown.find((c) => c.channelId === "discord:12345");
+    expect(discord).toBeDefined();
+    expect(discord!.invocations).toBeGreaterThan(0);
+  });
+
+  test("should return budget health", async () => {
+    // Create a policy
+    await upsertBudgetPolicy({
+      name: "Health Test Policy",
+      scope: { channelId: "health-chan" },
+      thresholds: { warnAt: 10, degradeAt: 20, blockAt: 50 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    const health = await getBudgetHealth();
+
+    expect(Array.isArray(health)).toBe(true);
+    const policy = health.find((h) => h.policyName === "Health Test Policy");
+    expect(policy).toBeDefined();
+    expect(policy!.state).toBeDefined();
+  });
+
+  test("should handle empty telemetry gracefully", async () => {
+    const telemetry = await getTelemetry({
+      startDate: "2099-01-01T00:00:00Z",
+    });
+
+    expect(telemetry.totalSessions).toBe(0);
+    expect(telemetry.invocationStats.total).toBe(0);
+    expect(telemetry.estimatedTotalCost).toBe(0);
+  });
+
+  test("should include cost breakdown in aggregates", async () => {
+    const start = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(
+      start.invocationId,
+      {
+        inputTokens: 1000000, // 1M
+        outputTokens: 500000, // 500K
+      },
+      {
+        currency: "USD",
+        inputCost: 3.0,
+        outputCost: 7.5,
+        cacheCost: 0.5,
+        totalCost: 11.0,
+      }
+    );
+
+    const telemetry = await getTelemetry({});
+
+    expect(telemetry.estimatedTotalCost).toBeGreaterThan(0);
+    const anthropicStats = telemetry.providerStats["anthropic"];
+    expect(anthropicStats).toBeDefined();
+    expect(anthropicStats!.estimatedCost).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/governance/usage-tracker.test.ts
+++ b/src/__tests__/governance/usage-tracker.test.ts
@@ -1,0 +1,276 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  recordInvocationFailure,
+  recordInvocationKilled,
+  getInvocation,
+  getSessionUsage,
+  getChannelUsage,
+  getAggregates,
+  getUsageStats,
+  resetUsageTracker,
+} from "../../governance/usage-tracker";
+import { join } from "path";
+
+// The usage tracker uses .claude/claudeclaw/usage/ - clean this for test isolation
+const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
+
+describe("UsageTracker", () => {
+  beforeEach(async () => {
+    resetUsageTracker();
+    // Clear usage data directory for test isolation
+    try {
+      const { rm, readdir } = await import("fs/promises");
+      const files = await readdir(USAGE_DIR);
+      for (const file of files) {
+        if (file !== ".gitkeep") {
+          await rm(join(USAGE_DIR, file), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // Directory might not exist yet
+    }
+  });
+
+  afterEach(async () => {
+    resetUsageTracker();
+  });
+
+  test("should initialize without error", async () => {
+    await initUsageTracker();
+    const stats = await getUsageStats();
+    expect(stats.totalRecords).toBe(0);
+  });
+
+  test("should record invocation start", async () => {
+    await initUsageTracker();
+
+    const context = {
+      sessionId: "session-123",
+      channelId: "telegram:12345",
+      source: "telegram",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const record = await recordInvocationStart(context);
+
+    expect(record.invocationId).toBeDefined();
+    expect(record.sessionId).toBe("session-123");
+    expect(record.channelId).toBe("telegram:12345");
+    expect(record.provider).toBe("anthropic");
+    expect(record.model).toBe("claude-3-5-sonnet");
+    expect(record.status).toBe("started");
+    expect(record.startedAt).toBeDefined();
+  });
+
+  test("should record invocation completion with usage", async () => {
+    await initUsageTracker();
+
+    const context = {
+      sessionId: "session-123",
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+
+    const usage = {
+      inputTokens: 1000,
+      outputTokens: 2000,
+      cacheCreationInputTokens: 500,
+      cacheReadInputTokens: 300,
+    };
+
+    const estimatedCost = {
+      currency: "USD",
+      inputCost: 0.003,
+      outputCost: 0.03,
+      cacheCost: 0.002,
+      totalCost: 0.035,
+      pricingVersion: "1.0.0",
+    };
+
+    const completed = await recordInvocationCompletion(
+      startRecord.invocationId,
+      usage,
+      estimatedCost
+    );
+
+    expect(completed).not.toBeNull();
+    expect(completed!.status).toBe("completed");
+    expect(completed!.completedAt).toBeDefined();
+    expect(completed!.usage).toEqual(usage);
+    expect(completed!.estimatedCost).toEqual(estimatedCost);
+  });
+
+  test("should record invocation failure", async () => {
+    await initUsageTracker();
+
+    const context = {
+      provider: "anthropic",
+      model: "claude-3-haiku",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+
+    const error = { type: "rate_limit", message: "Rate limit exceeded" };
+
+    const failed = await recordInvocationFailure(startRecord.invocationId, error);
+
+    expect(failed).not.toBeNull();
+    expect(failed!.status).toBe("failed");
+    expect(failed!.error).toEqual(error);
+  });
+
+  test("should record invocation killed by watchdog", async () => {
+    await initUsageTracker();
+
+    const context = {
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+
+    const killed = await recordInvocationKilled(
+      startRecord.invocationId,
+      "maxToolCalls exceeded"
+    );
+
+    expect(killed).not.toBeNull();
+    expect(killed!.status).toBe("killed");
+    expect(killed!.error?.type).toBe("watchdog");
+    expect(killed!.error?.message).toBe("maxToolCalls exceeded");
+  });
+
+  test("should get invocation by id", async () => {
+    await initUsageTracker();
+
+    const context = {
+      provider: "openai",
+      model: "gpt-4o",
+    };
+
+    const startRecord = await recordInvocationStart(context);
+    const retrieved = await getInvocation(startRecord.invocationId);
+
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.invocationId).toBe(startRecord.invocationId);
+  });
+
+  test("should get session usage", async () => {
+    await initUsageTracker();
+
+    const sessionId = "session-session-test";
+
+    // Create multiple invocations for the same session
+    for (let i = 0; i < 3; i++) {
+      await recordInvocationStart({
+        sessionId,
+        provider: "anthropic",
+        model: "claude-3-5-sonnet",
+      });
+    }
+
+    const usage = await getSessionUsage(sessionId);
+    expect(usage.length).toBe(3);
+  });
+
+  test("should get channel usage", async () => {
+    await initUsageTracker();
+
+    const channelId = "telegram:channel-test";
+
+    // Create invocations for the same channel
+    for (let i = 0; i < 2; i++) {
+      await recordInvocationStart({
+        channelId,
+        provider: "anthropic",
+        model: "claude-3-haiku",
+      });
+    }
+
+    const usage = await getChannelUsage(channelId);
+    expect(usage.length).toBe(2);
+  });
+
+  test("should compute aggregates correctly", async () => {
+    await initUsageTracker();
+
+    // Create invocations with usage
+    for (let i = 0; i < 3; i++) {
+      const start = await recordInvocationStart({
+        sessionId: "agg-session",
+        channelId: "telegram:agg",
+        source: "telegram",
+        provider: "anthropic",
+        model: "claude-3-5-sonnet",
+      });
+
+      await recordInvocationCompletion(
+        start.invocationId,
+        {
+          inputTokens: 1000,
+          outputTokens: 2000,
+        },
+        {
+          currency: "USD",
+          totalCost: 0.035,
+        }
+      );
+    }
+
+    const aggregates = await getAggregates({});
+
+    expect(aggregates.totalInvocations).toBe(3);
+    expect(aggregates.completedInvocations).toBe(3);
+    expect(aggregates.totalInputTokens).toBe(3000);
+    expect(aggregates.totalOutputTokens).toBe(6000);
+    expect(aggregates.totalEstimatedCost).toBeCloseTo(0.105);
+    expect(aggregates.byProvider["anthropic"]).toBeDefined();
+    expect(aggregates.byProvider["anthropic"].count).toBe(3);
+  });
+
+  test("should handle missing invocation gracefully", async () => {
+    await initUsageTracker();
+
+    const result = await getInvocation("non-existent-id");
+    expect(result).toBeNull();
+  });
+
+  test("should track failed and killed invocations separately", async () => {
+    await initUsageTracker();
+
+    // Create one of each status
+    const started = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    await recordInvocationCompletion(started.invocationId);
+
+    const failedStart = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+    await recordInvocationFailure(failedStart.invocationId, {
+      type: "error",
+      message: "Test error",
+    });
+
+    const killedStart = await recordInvocationStart({
+      provider: "anthropic",
+      model: "claude-3-5-sonnet",
+    });
+    await recordInvocationKilled(killedStart.invocationId, "Watchdog triggered");
+
+    const aggregates = await getAggregates({});
+
+    expect(aggregates.completedInvocations).toBe(1);
+    expect(aggregates.failedInvocations).toBe(1);
+    expect(aggregates.killedInvocations).toBe(1);
+  });
+});

--- a/src/__tests__/governance/watchdog.test.ts
+++ b/src/__tests__/governance/watchdog.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  initWatchdog,
+  recordExecutionMetric,
+  incrementToolCall,
+  incrementTurnCount,
+  checkLimits,
+  handleTrigger,
+  getActiveInvocation,
+  getSessionActiveInvocations,
+  clearInvocation,
+  getWatchdogStats,
+  configureWatchdog,
+  getWatchdogConfig,
+  resetWatchdog,
+} from "../../governance/watchdog";
+import { join } from "path";
+
+const WATCHDOG_DIR = join(process.cwd(), ".claude", "claudeclaw", "watchdog");
+
+describe("Watchdog", () => {
+  beforeEach(async () => {
+    resetWatchdog();
+    
+    // Clear watchdog directory for test isolation
+    try {
+      const { rm, readdir } = await import("fs/promises");
+      const files = await readdir(WATCHDOG_DIR);
+      for (const file of files) {
+        if (file !== ".gitkeep") {
+          await rm(join(WATCHDOG_DIR, file), { recursive: true, force: true });
+        }
+      }
+    } catch {
+      // Directory might not exist yet
+    }
+    
+    await initWatchdog();
+    
+    // Configure with relaxed limits for testing
+    configureWatchdog({
+      limits: {
+        maxToolCalls: 10,
+        maxTurns: 5,
+        maxRuntimeSeconds: 60,
+        maxRepeatedTools: 3,
+        repeatedToolThreshold: 2,
+      },
+      enabled: true,
+    });
+  });
+
+  test("should initialize with config", async () => {
+    const config = getWatchdogConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.limits.maxToolCalls).toBe(10);
+  });
+
+  test("should configure watchdog limits", () => {
+    configureWatchdog({
+      limits: {
+        maxToolCalls: 50,
+        maxTurns: 20,
+      },
+    });
+
+    const config = getWatchdogConfig();
+    expect(config.limits.maxToolCalls).toBe(50);
+    expect(config.limits.maxTurns).toBe(20);
+  });
+
+  test("should record execution metrics", async () => {
+    const invocationId = "test-invocation-1";
+
+    await recordExecutionMetric({
+      invocationId,
+      sessionId: "test-session",
+    }, {
+      toolCallCount: 5,
+      turnCount: 2,
+    });
+
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics).not.toBeNull();
+    expect(metrics!.toolCallCount).toBe(5);
+    expect(metrics!.turnCount).toBe(2);
+    expect(metrics!.invocationId).toBe(invocationId);
+  });
+
+  test("should increment tool call count", async () => {
+    const invocationId = "test-invocation-2";
+
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/test.txt" });
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/test.txt" });
+    await incrementToolCall(invocationId, "write_file", { path: "/tmp/output.txt" });
+
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics!.toolCallCount).toBe(3);
+    expect(metrics!.toolCalls.length).toBe(3);
+  });
+
+  test("should increment turn count", async () => {
+    const invocationId = "test-invocation-3";
+
+    await incrementTurnCount(invocationId);
+    await incrementTurnCount(invocationId);
+
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics!.turnCount).toBe(2);
+  });
+
+  test("should return healthy when under limits", async () => {
+    const invocationId = "test-invocation-healthy";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 3,
+      turnCount: 2,
+    });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("healthy");
+    expect(decision.triggeredLimits.length).toBe(0);
+  });
+
+  test("should warn at 80% of tool call limit", async () => {
+    const invocationId = "test-invocation-warn";
+
+    // 8 out of 10 = 80%
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 8,
+      turnCount: 1,
+    });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("warn");
+    expect(decision.triggeredLimits.length).toBeGreaterThan(0);
+  });
+
+  test("should trigger suspend at tool call limit", async () => {
+    const invocationId = "test-invocation-suspend";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 10, // At limit
+      turnCount: 1,
+    });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("suspend");
+    expect(decision.triggeredLimits.some(l => l.includes("maxToolCalls"))).toBe(true);
+  });
+
+  test("should detect repeated tool patterns", async () => {
+    const invocationId = "test-invocation-repeat";
+
+    // Make same tool call 3 times with same input
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/same.txt" });
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/same.txt" });
+    await incrementToolCall(invocationId, "read_file", { path: "/tmp/same.txt" });
+
+    const decision = await checkLimits({ invocationId });
+
+    expect(decision.state).toBe("suspend");
+    expect(decision.triggeredLimits.some(l => l.includes("Repeated"))).toBe(true);
+  });
+
+  test("should handle trigger for warn state", async () => {
+    const invocationId = "test-invocation-warn-handle";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 8, // Warning level
+    });
+
+    const decision = await checkLimits({ invocationId });
+    const result = await handleTrigger({ invocationId }, decision);
+
+    expect(result.success).toBe(true);
+    expect(["warning_logged", "no_action"]).toContain(result.action);
+  });
+
+  test("should handle trigger for suspend state", async () => {
+    const invocationId = "test-invocation-suspend-handle";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 10, // At limit
+    });
+
+    const decision = await checkLimits({ invocationId });
+    const result = await handleTrigger({ invocationId }, decision);
+
+    expect(result.success).toBe(true);
+    expect(["suspended", "paused"]).toContain(result.action);
+  });
+
+  test("should handle trigger for kill state", async () => {
+    const invocationId = "test-invocation-kill";
+
+    await recordExecutionMetric({
+      invocationId,
+    }, {
+      toolCallCount: 100, // Way over
+    });
+
+    const decision = await checkLimits({ invocationId });
+    decision.state = "kill"; // Force kill state for testing
+
+    const result = await handleTrigger({ invocationId }, decision);
+
+    expect(result.success).toBe(true);
+    expect(result.action).toBe("terminated");
+
+    // Should be cleared from active invocations
+    const metrics = await getActiveInvocation(invocationId);
+    expect(metrics).toBeNull();
+  });
+
+  test("should get session active invocations", async () => {
+    const sessionId = "test-session-watchdog";
+
+    await recordExecutionMetric({ invocationId: "inv-1", sessionId }, { toolCallCount: 1 });
+    await recordExecutionMetric({ invocationId: "inv-2", sessionId }, { toolCallCount: 2 });
+    await recordExecutionMetric({ invocationId: "inv-3", sessionId: "other" }, { toolCallCount: 3 });
+
+    const invocations = await getSessionActiveInvocations(sessionId);
+
+    expect(invocations.length).toBe(2);
+    expect(invocations.find(i => i.invocationId === "inv-1")).toBeDefined();
+    expect(invocations.find(i => i.invocationId === "inv-2")).toBeDefined();
+  });
+
+  test("should clear invocation", async () => {
+    const invocationId = "inv-to-clear";
+
+    await recordExecutionMetric({ invocationId }, { toolCallCount: 5 });
+
+    let metrics = await getActiveInvocation(invocationId);
+    expect(metrics).not.toBeNull();
+
+    await clearInvocation(invocationId);
+
+    metrics = await getActiveInvocation(invocationId);
+    expect(metrics).toBeNull();
+  });
+
+  test("should get watchdog stats", async () => {
+    await recordExecutionMetric({ invocationId: "stats-inv-1" }, { toolCallCount: 5 });
+    await recordExecutionMetric({ invocationId: "stats-inv-2" }, { toolCallCount: 3 });
+
+    // Trigger a watchdog decision to log an event
+    await checkLimits({ invocationId: "stats-inv-1" });
+
+    const stats = await getWatchdogStats();
+
+    expect(stats.activeInvocations).toBe(2);
+    expect(stats.config.enabled).toBe(true);
+    expect(stats.eventsLogged).toBeGreaterThan(0);
+  });
+
+  test("should return healthy for unknown invocation", async () => {
+    const decision = await checkLimits({ invocationId: "unknown-invocation" });
+
+    expect(decision.state).toBe("healthy");
+    expect(decision.reason).toContain("No execution metrics");
+  });
+});

--- a/src/__tests__/integration/escalation-wiring.test.ts
+++ b/src/__tests__/integration/escalation-wiring.test.ts
@@ -1,0 +1,622 @@
+/**
+ * Escalation Wiring Integration Tests
+ * 
+ * Tests that escalation functions are properly wired into:
+ * - Gateway (shouldBlockAdmission)
+ * - Orchestrator (shouldBlockScheduling)
+ * - Runner (handleWatchdogTrigger, handleOrchestrationFailure)
+ * 
+ * Run with: bun test src/__tests__/integration/escalation-wiring.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
+import { randomUUID } from "crypto";
+import { rm, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const PAUSE_STATE_FILE = join(ESCALATION_DIR, "paused.json");
+const PAUSE_ACTIONS_FILE = join(ESCALATION_DIR, "pause-actions.jsonl");
+const WORKFLOW_DIR = join(process.cwd(), ".claude", "claudeclaw", "workflows");
+
+// =============================================================================
+// Mock External Dependencies
+// =============================================================================
+
+// Mock event-log
+vi.mock("../event-log", () => {
+  const mockRecords: Map<string, any> = new Map();
+  let seqCounter = 0;
+
+  return {
+    append: vi.fn(async (entry: any) => {
+      seqCounter++;
+      const record = {
+        id: randomUUID(),
+        seq: seqCounter,
+        type: entry.type,
+        source: entry.source,
+        timestamp: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        status: "pending",
+        channelId: entry.channelId,
+        threadId: entry.threadId,
+        payload: entry.payload,
+        dedupeKey: entry.dedupeKey,
+        retryCount: 0,
+        nextRetryAt: null,
+        correlationId: entry.correlationId ?? null,
+        causationId: entry.causationId ?? null,
+        replayedFromEventId: entry.replayedFromEventId ?? null,
+        lastError: null,
+      };
+      mockRecords.set(record.id, record);
+      return record;
+    }),
+    initEventLog: vi.fn().mockResolvedValue(undefined),
+    resetEventLog: vi.fn().mockImplementation(() => {
+      mockRecords.clear();
+      seqCounter = 0;
+    }),
+    getLastSeq: vi.fn().mockResolvedValue(seqCounter),
+  };
+});
+
+// Mock session-map
+vi.mock("../gateway/session-map", () => {
+  const mockMappings: Map<string, any> = new Map();
+
+  return {
+    get: vi.fn(async (channelId: string, threadId: string) => {
+      const key = `${channelId}:${threadId}`;
+      return mockMappings.get(key) ?? null;
+    }),
+    set: vi.fn(async (channelId: string, threadId: string, entry: any) => {
+      const key = `${channelId}:${threadId}`;
+      mockMappings.set(key, {
+        mappingId: entry.mappingId ?? randomUUID(),
+        channelId,
+        threadId,
+        claudeSessionId: entry.claudeSessionId ?? null,
+        lastSeq: entry.lastSeq ?? 0,
+        turnCount: entry.turnCount ?? 0,
+        status: entry.status ?? "pending",
+        lastActiveAt: entry.lastActiveAt ?? new Date().toISOString(),
+        createdAt: entry.createdAt ?? new Date().toISOString(),
+        updatedAt: entry.updatedAt ?? new Date().toISOString(),
+        ...entry,
+      });
+    }),
+    remove: vi.fn(async (channelId: string, threadId: string) => {
+      const key = `${channelId}:${threadId}`;
+      mockMappings.delete(key);
+    }),
+    getOrCreateMapping: vi.fn(async (channelId: string, threadId: string) => {
+      const key = `${channelId}:${threadId}`;
+      let entry = mockMappings.get(key);
+      if (!entry) {
+        entry = {
+          mappingId: randomUUID(),
+          channelId,
+          threadId,
+          claudeSessionId: null,
+          lastSeq: 0,
+          turnCount: 0,
+          status: "pending",
+          lastActiveAt: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+        mockMappings.set(key, entry);
+      }
+      return entry;
+    }),
+    update: vi.fn(async (channelId: string, threadId: string, patch: any) => {
+      const key = `${channelId}:${threadId}`;
+      const existing = mockMappings.get(key);
+      if (existing) {
+        mockMappings.set(key, { ...existing, ...patch, updatedAt: new Date().toISOString() });
+      }
+    }),
+    attachClaudeSessionId: vi.fn(),
+    resetSessionMap: vi.fn().mockImplementation(() => {
+      mockMappings.clear();
+    }),
+  };
+});
+
+// Mock workflow-state
+vi.mock("../orchestrator/workflow-state", () => {
+  const mockStates: Map<string, any> = new Map();
+  const mockDefinitions: Map<string, any> = new Map();
+
+  return {
+    saveState: vi.fn().mockImplementation(async (state: any) => {
+      mockStates.set(state.workflowId, state);
+    }),
+    loadState: vi.fn().mockImplementation(async (workflowId: string) => {
+      return mockStates.get(workflowId) ?? null;
+    }),
+    saveDefinition: vi.fn().mockImplementation(async (_workflowId: string, def: any) => {
+      mockDefinitions.set(def.id, def);
+    }),
+    loadDefinition: vi.fn().mockImplementation(async (workflowId: string) => {
+      const def = mockDefinitions.get(`def-${workflowId}`);
+      return def ?? null;
+    }),
+    rebuildExecutionView: vi.fn().mockImplementation((state: any, _def: any) => state),
+    resetWorkflowState: vi.fn().mockImplementation(() => {
+      mockStates.clear();
+      mockDefinitions.clear();
+    }),
+  };
+});
+
+// =============================================================================
+// Import After Mocks
+// =============================================================================
+
+import {
+  Gateway,
+  clearGatewayEnabledCache,
+  setGatewayEnabled,
+  processInboundEvent,
+  processEventWithFallback,
+  type GatewayDependencies,
+} from "../../gateway/index";
+
+import {
+  executeReadyTasks,
+  executeWorkflow,
+  registerHandlers,
+  setGovernanceClient,
+} from "../../orchestrator/executor";
+
+import type { NormalizedEvent } from "../../gateway/normalizer";
+
+// Import pause controller for test setup
+import {
+  initPauseController,
+  pause,
+  resume,
+  resetPauseController,
+  clearPauseCache,
+  shouldBlockAdmission,
+  shouldBlockScheduling,
+} from "../../escalation/pause";
+
+// Import trigger integration
+import {
+  handleWatchdogTrigger,
+  handleOrchestrationFailure,
+  resetTriggerIntegration,
+  getFailureCounts,
+} from "../../escalation/triggers";
+
+// Import watchdog for reset
+import { resetWatchdog } from "../../governance/watchdog";
+
+// Import watchdog types
+import type { WatchdogDecision, WatchdogState } from "../../governance/watchdog";
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+async function setupEscalationDir() {
+  await mkdir(ESCALATION_DIR, { recursive: true });
+  await mkdir(WORKFLOW_DIR, { recursive: true });
+}
+
+async function cleanupEscalationFiles() {
+  try {
+    await rm(PAUSE_STATE_FILE, { force: true });
+    await rm(PAUSE_ACTIONS_FILE, { force: true });
+  } catch {
+    // Ignore
+  }
+}
+
+async function fullCleanup() {
+  // Reset pause controller FIRST (clears cache and resets file)
+  await resetPauseController();
+  // Then remove any lingering files
+  await cleanupEscalationFiles();
+  // Clear gateway cache
+  clearGatewayEnabledCache();
+  // Reset trigger integration
+  resetTriggerIntegration();
+  // Reset watchdog state
+  resetWatchdog();
+}
+
+function createTestEvent(): NormalizedEvent {
+  return {
+    id: randomUUID(),
+    channel: "telegram",
+    channelId: "telegram:123",
+    threadId: "default",
+    userId: "456",
+    text: "Test message",
+    attachments: [],
+    timestamp: Date.now(),
+    metadata: {},
+  };
+}
+
+function createWatchdogDecision(state: WatchdogState, reason: string): WatchdogDecision {
+  return {
+    invocationId: randomUUID(),
+    state,
+    reason,
+    triggeredLimits: [],
+    recommendedAction: state === "kill" ? "terminate" : "suspend",
+    evaluatedAt: new Date().toISOString(),
+  };
+}
+
+// =============================================================================
+// Gateway Escalation Wiring Tests
+// =============================================================================
+
+describe("Gateway Escalation Wiring", () => {
+  beforeEach(async () => {
+    await fullCleanup(); // Clean slate before each test
+    await setupEscalationDir();
+  });
+
+  afterEach(async () => {
+    await fullCleanup();
+  });
+
+  describe("shouldBlockAdmission integration", () => {
+    it("should reject events when system is paused (admission_only mode)", async () => {
+      // Pause the system
+      await pause("admission_only", { reason: "Test pause" });
+
+      const mockDeps: GatewayDependencies = {
+        eventLog: { append: vi.fn() },
+        processor: { processPersistedEvent: vi.fn() },
+        resume: {
+          getOrCreateSessionMapping: vi.fn(),
+          getResumeArgsForEvent: vi.fn(),
+          updateSessionAfterProcessing: vi.fn(),
+        },
+      };
+
+      const gateway = new Gateway({}, mockDeps);
+      const event = createTestEvent();
+
+      const result = await gateway.processInboundEvent(event);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("paused");
+      expect(result.error).toContain("not being admitted");
+    });
+
+    it("should reject events when system is paused (admission_and_scheduling mode)", async () => {
+      // Pause with both admission and scheduling blocked
+      await pause("admission_and_scheduling", { reason: "Full pause" });
+
+      const mockDeps: GatewayDependencies = {
+        eventLog: { append: vi.fn() },
+        processor: { processPersistedEvent: vi.fn() },
+        resume: {
+          getOrCreateSessionMapping: vi.fn(),
+          getResumeArgsForEvent: vi.fn(),
+          updateSessionAfterProcessing: vi.fn(),
+        },
+      };
+
+      const gateway = new Gateway({}, mockDeps);
+      const event = createTestEvent();
+
+      const result = await gateway.processInboundEvent(event);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("paused");
+    });
+
+    it("should accept events when system is not paused", async () => {
+      // Ensure system is not paused
+      await resume({});
+
+      const mockDeps: GatewayDependencies = {
+        eventLog: { append: vi.fn().mockResolvedValue({
+          id: randomUUID(),
+          seq: 1,
+          type: "inbound:telegram",
+          source: "telegram",
+          timestamp: new Date().toISOString(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          status: "pending",
+          channelId: "telegram:123",
+          threadId: "default",
+          payload: {},
+          dedupeKey: "test",
+          retryCount: 0,
+          nextRetryAt: null,
+          correlationId: null,
+          causationId: null,
+          replayedFromEventId: null,
+          lastError: null,
+        })},
+        processor: { processPersistedEvent: vi.fn().mockResolvedValue({ success: true }) },
+        resume: {
+          getOrCreateSessionMapping: vi.fn().mockResolvedValue({
+            mappingId: "mapping-1",
+            channelId: "telegram:123",
+            threadId: "default",
+            claudeSessionId: null,
+            lastSeq: 0,
+            turnCount: 0,
+            status: "pending",
+            lastActiveAt: new Date().toISOString(),
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }),
+          getResumeArgsForEvent: vi.fn().mockResolvedValue({
+            mappingId: "mapping-1",
+            claudeSessionId: null,
+            args: [],
+            isNewMapping: true,
+            canResume: false,
+          }),
+          updateSessionAfterProcessing: vi.fn(),
+        },
+      };
+
+      const gateway = new Gateway({}, mockDeps);
+      const event = createTestEvent();
+
+      const result = await gateway.processInboundEvent(event);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should check pause state in standalone processInboundEvent function", async () => {
+      // Pause the system
+      await pause("admission_only", { reason: "Test pause" });
+
+      const event = createTestEvent();
+
+      const result = await processInboundEvent(event);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("paused");
+      expect(result.error).toContain("not being admitted");
+    });
+
+    it("should check pause state in processEventWithFallback", async () => {
+      // Pause the system
+      await pause("admission_only", { reason: "Test pause" });
+      setGatewayEnabled(true);
+
+      const event = createTestEvent();
+      const legacyHandler = vi.fn().mockResolvedValue({
+        success: true,
+        exitCode: 0,
+        stdout: "Legacy response",
+      });
+
+      const result = await processEventWithFallback(event, { legacyHandler });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("paused");
+      expect(result.error).toContain("not being admitted");
+      // Legacy handler should NOT be called when paused
+      expect(legacyHandler).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// =============================================================================
+// Orchestrator Escalation Wiring Tests
+// =============================================================================
+
+describe("Orchestrator Escalation Wiring", () => {
+  const testWorkflowId = "test-workflow-escalation";
+
+  beforeEach(async () => {
+    await fullCleanup(); // Clean slate before each test
+    await setupEscalationDir();
+    
+    // Register a handler that fails for test-action
+    registerHandlers({
+      actions: {
+        "test-action": async (_input, _context) => {
+          throw new Error("Task execution failed");
+        },
+      },
+      compensations: {},
+    });
+    
+    // Clear governance client
+    setGovernanceClient(null);
+  });
+
+  afterEach(async () => {
+    await fullCleanup();
+  });
+
+  describe("shouldBlockScheduling integration", () => {
+    it("should skip task execution when scheduling is paused", async () => {
+      // Pause with scheduling blocked
+      await pause("admission_and_scheduling", { reason: "Stop scheduling" });
+
+      // Execute ready tasks - should return early due to pause
+      const result = await executeReadyTasks(testWorkflowId);
+
+      // If workflow doesn't exist, result is null - that's fine
+      // The key is that it should NOT throw and should NOT execute tasks
+      if (result !== null) {
+        // Workflow should remain in its original state
+        // because the pause check happens before getting ready tasks
+        expect(result).toBeDefined();
+      }
+    });
+
+    it("should allow task execution when only admission is paused", async () => {
+      // Pause with only admission blocked (not scheduling)
+      // Note: This test just verifies the system doesn't throw
+      // when only admission is paused - scheduling should still work
+      await pause("admission_only", { reason: "Only block admission" });
+
+      // Execute ready tasks - scheduling should still be allowed
+      const result = await executeReadyTasks(testWorkflowId);
+
+      // Should not throw - either null (no workflow) or a valid state
+      expect(result === null || typeof result === "object").toBe(true);
+    });
+  });
+
+  describe("handleOrchestrationFailure integration", () => {
+    it("should track failure counts when tasks fail", async () => {
+      // Ensure not paused so tasks can run
+      await resume({});
+
+      // Clear any previous failure counts
+      const initialCounts = getFailureCounts();
+
+      // Try to execute ready tasks for a non-existent workflow
+      // This should not throw
+      await executeReadyTasks("non-existent-workflow");
+
+      // The failure tracking happens in the triggers module
+      // but only when actual task execution fails
+      // Since we don't have a real workflow set up, we just verify
+      // the escalation module is properly integrated
+      expect(getFailureCounts()).toBeDefined();
+    });
+  });
+});
+
+// =============================================================================
+// Watchdog Escalation Wiring Tests  
+// =============================================================================
+
+describe("Watchdog Escalation Wiring", () => {
+  beforeEach(async () => {
+    await fullCleanup(); // Clean slate before each test
+    await setupEscalationDir();
+  });
+
+  afterEach(async () => {
+    await fullCleanup();
+  });
+
+  describe("handleWatchdogTrigger integration", () => {
+    it("should handle watchdog suspend trigger", async () => {
+      const decision = createWatchdogDecision("suspend", "Budget limit approaching");
+
+      const context = {
+        invocationId: decision.invocationId,
+        sessionId: randomUUID(),
+      };
+
+      // This should not throw
+      await expect(
+        handleWatchdogTrigger(decision, context)
+      ).resolves.toBeDefined();
+    });
+
+    it("should handle watchdog kill trigger", async () => {
+      const decision = createWatchdogDecision("kill", "Budget limit exceeded");
+
+      const context = {
+        invocationId: decision.invocationId,
+        sessionId: randomUUID(),
+      };
+
+      // This should not throw
+      await expect(
+        handleWatchdogTrigger(decision, context)
+      ).resolves.toBeDefined();
+    });
+
+    it("should trigger auto-pause on watchdog kill", async () => {
+      const decision = createWatchdogDecision("kill", "Budget limit exceeded");
+
+      const context = {
+        invocationId: decision.invocationId,
+        sessionId: randomUUID(),
+      };
+
+      await handleWatchdogTrigger(decision, context);
+
+      // System should be paused after kill trigger
+      const blocked = await shouldBlockAdmission();
+      expect(blocked).toBe(true);
+    });
+  });
+});
+
+// =============================================================================
+// Full Integration Scenario Tests
+// =============================================================================
+
+describe("Escalation Integration Scenarios", () => {
+  beforeEach(async () => {
+    await fullCleanup(); // Clean slate before each test
+    await setupEscalationDir();
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fullCleanup();
+  });
+
+  it("should allow pause -> resume lifecycle", async () => {
+    // Initially not paused
+    expect(await shouldBlockAdmission()).toBe(false);
+    expect(await shouldBlockScheduling()).toBe(false);
+
+    // Pause with admission only
+    await pause("admission_only", { reason: "Maintenance" });
+    expect(await shouldBlockAdmission()).toBe(true);
+    expect(await shouldBlockScheduling()).toBe(false);
+
+    // Resume
+    await resume({ reason: "Maintenance complete" });
+    expect(await shouldBlockAdmission()).toBe(false);
+    expect(await shouldBlockScheduling()).toBe(false);
+  });
+
+  it("should block both admission and scheduling in full pause mode", async () => {
+    await pause("admission_and_scheduling", { reason: "Critical incident" });
+
+    expect(await shouldBlockAdmission()).toBe(true);
+    expect(await shouldBlockScheduling()).toBe(true);
+  });
+
+  it("should allow events after resume from full pause", async () => {
+    // Full pause
+    await pause("admission_and_scheduling", { reason: "Critical incident" });
+    expect(await shouldBlockAdmission()).toBe(true);
+    expect(await shouldBlockScheduling()).toBe(true);
+
+    // Resume
+    await resume({ reason: "Incident resolved" });
+    expect(await shouldBlockAdmission()).toBe(false);
+    expect(await shouldBlockScheduling()).toBe(false);
+  });
+
+  it("should track orchestration failure counts", async () => {
+    // Trigger a failure notification
+    const workflowId = "test-workflow-" + randomUUID().slice(0, 8);
+    
+    await handleOrchestrationFailure(workflowId, "Test error message");
+
+    // Check failure was tracked
+    const counts = getFailureCounts();
+    expect(counts[workflowId]).toBeDefined();
+    expect(counts[workflowId].count).toBe(1);
+  });
+});

--- a/src/__tests__/policy/approval-queue.test.ts
+++ b/src/__tests__/policy/approval-queue.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for policy/approval-queue.ts
+ * 
+ * Run with: bun test src/__tests__/policy/approval-queue.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  enqueue,
+  approve,
+  deny,
+  listPending,
+  loadState,
+  findByEventId,
+  findById,
+  isPending,
+  getLoadedAt,
+} from "../../policy/approval-queue";
+import { loadRules, type ToolRequestContext, type PolicyDecision } from "../../policy/engine";
+
+const APPROVAL_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const APPROVAL_QUEUE_FILE = join(APPROVAL_DIR, "approval-queue.jsonl");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-" + Math.random().toString(36).slice(2),
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+// Helper to create a test decision
+const createDecision = (overrides: Partial<PolicyDecision> = {}): PolicyDecision => ({
+  requestId: "req-" + Math.random().toString(36).slice(2),
+  action: "require_approval",
+  reason: "Test approval required",
+  evaluatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("Approval Queue - Enqueue", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should enqueue a request for approval", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(entry).toBeDefined();
+    expect(entry.id).toBeDefined();
+    expect(entry.eventId).toBe(request.eventId);
+    expect(entry.status).toBe("pending");
+    expect(entry.request).toEqual(request);
+    expect(entry.decision).toEqual(decision);
+    expect(entry.requestedAt).toBeDefined();
+  });
+
+  it("should persist entry to queue file", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(existsSync(APPROVAL_QUEUE_FILE)).toBe(true);
+    
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    const found = lines.some(line => {
+      const parsed = JSON.parse(line);
+      return parsed.id === entry.id;
+    });
+    expect(found).toBe(true);
+  });
+
+  it("should generate unique IDs for each entry", async () => {
+    const request1 = createRequest();
+    const request2 = createRequest();
+    const decision = createDecision();
+    
+    const entry1 = await enqueue(request1, decision);
+    const entry2 = await enqueue(request2, decision);
+    
+    expect(entry1.id).not.toBe(entry2.id);
+  });
+
+  it("should set default expiry time", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    
+    expect(entry.expiresAt).toBeDefined();
+    
+    const expiryDate = new Date(entry.expiresAt!);
+    const now = new Date();
+    const diffHours = (expiryDate.getTime() - now.getTime()) / (1000 * 60 * 60);
+    
+    expect(diffHours).toBeGreaterThan(23);
+    expect(diffHours).toBeLessThan(25);
+  });
+});
+
+describe("Approval Queue - Approve", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should approve a pending request", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    const result = await approve(request.eventId, "operator-1", "Looks good");
+    
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("approved");
+    expect(result?.approvedBy).toBe("operator-1");
+    expect(result?.approvedAt).toBeDefined();
+    expect(result?.resolutionReason).toBe("Looks good");
+  });
+
+  it("should persist approval to queue file", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    await approve(request.eventId, "operator-1");
+    
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Find the approval entry
+    const approvalLine = lines.find(line => {
+      const parsed = JSON.parse(line);
+      return parsed.eventId === request.eventId && parsed.status === "approved";
+    });
+    
+    expect(approvalLine).toBeDefined();
+  });
+
+  it("should be idempotent for already approved requests", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    const first = await approve(request.eventId, "operator-1", "First approval");
+    const second = await approve(request.eventId, "operator-2", "Second approval");
+    
+    expect(first?.approvedBy).toBe("operator-1");
+    expect(second?.approvedBy).toBe("operator-1"); // Should remain first approver
+    expect(second?.resolutionReason).toBe("First approval");
+  });
+
+  it("should return null for non-existent event", async () => {
+    const result = await approve("non-existent-event", "operator-1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("Approval Queue - Deny", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should deny a pending request", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    const entry = await enqueue(request, decision);
+    const result = await deny(request.eventId, "operator-1", "Not allowed");
+    
+    expect(result).toBeDefined();
+    expect(result?.status).toBe("denied");
+    expect(result?.deniedBy).toBe("operator-1");
+    expect(result?.deniedAt).toBeDefined();
+    expect(result?.resolutionReason).toBe("Not allowed");
+  });
+
+  it("should be idempotent for already denied requests", async () => {
+    const request = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request, decision);
+    const first = await deny(request.eventId, "operator-1", "First denial");
+    const second = await deny(request.eventId, "operator-2", "Second denial");
+    
+    expect(first?.deniedBy).toBe("operator-1");
+    expect(second?.deniedBy).toBe("operator-1"); // Should remain first denier
+  });
+});
+
+describe("Approval Queue - List Pending", () => {
+  beforeEach(async () => {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should list only pending requests", async () => {
+    const request1 = createRequest();
+    const request2 = createRequest();
+    const request3 = createRequest();
+    const decision = createDecision();
+    
+    await enqueue(request1, decision);
+    await enqueue(request2, decision);
+    await enqueue(request3, decision);
+    
+    await approve(request1.eventId, "operator-1");
+    
+    const pending = listPending();
+    
+    expect(pending).toHaveLength(2);
+    expect(pending.every(e => e.status === "pending")).toBe(true);
+  });
+
+  it("should sort pending by oldest first", async () => {
+    const decision = createDecision();
+    
+    const entry1 = await enqueue(createRequest({ eventId: "event-1" }), decision);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const entry2 = await enqueue(createRequest({ eventId: "event-2" }), decision);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    const entry3 = await enqueue(createRequest({ eventId: "event-3" }), decision);
+    
+    const pending = listPending();
+    
+    expect(pending[0].eventId).toBe("event-1");
+    expect(pending[1].eventId).toBe("event-2");
+    expect(pending[2].eventId).toBe("event-3");
+  });
+});
+
+describe("Approval Queue - Persistence", () => {
+  afterEach(async () => {
+    try {
+      await rm(APPROVAL_QUEUE_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should recover state after restart", async () => {
+    const decision = createDecision();
+    
+    // Create some entries
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+    
+    const entry1 = await enqueue(createRequest({ eventId: "restart-event-1" }), decision);
+    const entry2 = await enqueue(createRequest({ eventId: "restart-event-2" }), decision);
+    
+    await approve(entry1.eventId, "operator-1");
+    
+    // Simulate restart - reload state from disk
+    await loadState();
+    
+    // Should recover state
+    const pending = listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].eventId).toBe("restart-event-2");
+    
+    const recoveredEntry2 = await findById(entry2.id);
+    expect(recoveredEntry2).toBeDefined();
+    expect(recoveredEntry2?.status).toBe("pending");
+  });
+
+  it("should find entry by eventId", async () => {
+    const decision = createDecision();
+    
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    await loadState();
+    await loadRules();
+    
+    const entry = await enqueue(createRequest({ eventId: "find-me-event" }), decision);
+    
+    const found = await findByEventId("find-me-event");
+    expect(found).toBeDefined();
+    expect(found?.id).toBe(entry.id);
+  });
+});

--- a/src/__tests__/policy/audit-log.test.ts
+++ b/src/__tests__/policy/audit-log.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for policy/audit-log.ts
+ * 
+ * Run with: bun test src/__tests__/policy/audit-log.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import {
+  log,
+  logPolicyDecision,
+  logApproval,
+  logDenial,
+  query,
+  exportEntries,
+  getStats,
+  cleanupRetention,
+  getRetentionPolicy,
+  type AuditEntry,
+  type AuditAction,
+} from "../../policy/audit-log";
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
+
+describe("Audit Log - Basic Operations", () => {
+  beforeEach(async () => {
+    // Clean audit log before test to ensure isolation
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // File might not exist
+    }
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should log an audit entry", async () => {
+    const entry: AuditEntry = {
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      channelId: "telegram:123",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Tool denied by policy",
+      matchedRuleId: "global-deny-bash",
+    };
+    
+    await log(entry);
+    
+    expect(existsSync(AUDIT_LOG_FILE)).toBe(true);
+    
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    expect(lines).toHaveLength(1);
+    
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.eventId).toBe("event-1");
+    expect(parsed.action).toBe("deny");
+  });
+
+  it("should append multiple entries", async () => {
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Denied",
+    });
+    
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-2",
+      requestId: "req-2",
+      source: "discord",
+      toolName: "View",
+      action: "allow",
+      reason: "Allowed",
+    });
+    
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    expect(lines).toHaveLength(2);
+  });
+});
+
+describe("Audit Log - Policy Decision Logging", () => {
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should log a policy decision", async () => {
+    await logPolicyDecision(
+      "event-1",
+      "req-1",
+      "telegram",
+      "Bash",
+      "deny",
+      "Global policy denies Bash",
+      { matchedRuleId: "global-deny-bash" }
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("deny");
+    expect(entries[0].matchedRuleId).toBe("global-deny-bash");
+  });
+
+  it("should log an approval action", async () => {
+    await logApproval(
+      "event-1",
+      "req-1",
+      "telegram",
+      "Edit",
+      "operator-1",
+      "Looks good"
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("approved");
+    expect(entries[0].operatorId).toBe("operator-1");
+    expect(entries[0].reason).toBe("Looks good");
+  });
+
+  it("should log a denial action", async () => {
+    await logDenial(
+      "event-1",
+      "req-1",
+      "discord",
+      "Bash",
+      "operator-2",
+      "Not allowed"
+    );
+    
+    const entries = await query({});
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("denied");
+    expect(entries[0].operatorId).toBe("operator-2");
+  });
+});
+
+describe("Audit Log - Querying", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    
+    // Create some test entries
+    await logPolicyDecision("event-1", "req-1", "telegram", "Bash", "deny", "Denied");
+    await logPolicyDecision("event-2", "req-2", "telegram", "View", "allow", "Allowed");
+    await logPolicyDecision("event-3", "req-3", "discord", "Edit", "require_approval", "Needs approval");
+    await logApproval("event-4", "req-4", "telegram", "Edit", "operator-1", "Approved");
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return all entries with no filters", async () => {
+    const entries = await query({});
+    expect(entries).toHaveLength(4);
+  });
+
+  it("should filter by source", async () => {
+    const entries = await query({ source: "telegram" });
+    expect(entries).toHaveLength(3);
+    expect(entries.every(e => e.source === "telegram")).toBe(true);
+  });
+
+  it("should filter by action", async () => {
+    const entries = await query({ action: "deny" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe("deny");
+  });
+
+  it("should filter by toolName", async () => {
+    const entries = await query({ toolName: "Edit" });
+    expect(entries).toHaveLength(2); // require_approval and approved
+  });
+
+  it("should filter by operatorId", async () => {
+    const entries = await query({ operatorId: "operator-1" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].operatorId).toBe("operator-1");
+  });
+
+  it("should filter by eventId", async () => {
+    const entries = await query({ eventId: "event-2" });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].eventId).toBe("event-2");
+  });
+
+  it("should sort by timestamp descending (newest first)", async () => {
+    // Add another entry with a newer timestamp
+    await log({
+      timestamp: new Date(Date.now() + 10000).toISOString(), // 10 seconds in future
+      eventId: "event-5",
+      requestId: "req-5",
+      source: "slack",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Latest",
+    });
+    
+    const entries = await query({});
+    expect(entries[0].eventId).toBe("event-5");
+  });
+});
+
+describe("Audit Log - Export", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should export entries within date range", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "event-1",
+      requestId: "req-1",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Test",
+    });
+    
+    const entries = await exportEntries(yesterday, tomorrow);
+    expect(entries).toHaveLength(1);
+  });
+});
+
+describe("Audit Log - Statistics", () => {
+  beforeEach(async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return correct statistics", async () => {
+    await logPolicyDecision("event-1", "req-1", "telegram", "Bash", "deny", "Deny");
+    await logPolicyDecision("event-2", "req-2", "telegram", "View", "allow", "Allow");
+    await logPolicyDecision("event-3", "req-3", "discord", "Edit", "require_approval", "Approve");
+    
+    const stats = await getStats();
+    
+    expect(stats.totalEntries).toBe(3);
+    expect(stats.byAction.deny).toBe(1);
+    expect(stats.byAction.allow).toBe(1);
+    expect(stats.byAction.require_approval).toBe(1);
+    expect(stats.bySource.telegram).toBe(2);
+    expect(stats.bySource.discord).toBe(1);
+  });
+
+  it("should return empty stats for no entries", async () => {
+    const stats = await getStats();
+    
+    expect(stats.totalEntries).toBe(0);
+    expect(stats.oldestTimestamp).toBeNull();
+    expect(stats.newestTimestamp).toBeNull();
+  });
+});
+
+describe("Audit Log - Retention", () => {
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should report retention policy", () => {
+    const policy = getRetentionPolicy();
+    
+    expect(policy.defaultRetentionDays).toBe(30);
+    expect(policy.defaultMaxFileSizeBytes).toBe(10 * 1024 * 1024);
+    expect(policy.recommendation).toContain("30 days");
+  });
+
+  it("should identify entries older than retention period", async () => {
+    await mkdir(AUDIT_DIR, { recursive: true });
+    
+    // Create an old entry
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 60); // 60 days ago
+    await log({
+      timestamp: oldDate.toISOString(),
+      eventId: "old-event",
+      requestId: "old-req",
+      source: "telegram",
+      toolName: "Bash",
+      action: "deny",
+      reason: "Old entry",
+    });
+    
+    // Create a recent entry
+    await log({
+      timestamp: new Date().toISOString(),
+      eventId: "new-event",
+      requestId: "new-req",
+      source: "telegram",
+      toolName: "View",
+      action: "allow",
+      reason: "New entry",
+    });
+    
+    const result = await cleanupRetention({ maxAgeDays: 30 });
+    
+    expect(result.deleted).toBe(1);
+    expect(result.remaining).toBe(1);
+  });
+});

--- a/src/__tests__/policy/channel-policies.test.ts
+++ b/src/__tests__/policy/channel-policies.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for policy/channel-policies.ts
+ * 
+ * Run with: bun test src/__tests__/policy/channel-policies.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { writeFile, rm, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  getScopedRules,
+  mergeScopedPolicies,
+  validateScopedPolicyConfig,
+  createDefaultScopedPolicyConfig,
+  getExampleScopedPolicyConfig,
+  reloadScopedPolicy,
+  type ScopedPolicyConfig,
+} from "../../policy/channel-policies";
+import { loadRules, type ToolRequestContext, type PolicyRule } from "../../policy/engine";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SCOPED_POLICY_FILE = join(POLICY_DIR, "scoped-policies.json");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-1",
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+describe("Channel Policies - Scoped Rules", () => {
+  beforeEach(async () => {
+    // Clear any cached config
+    reloadScopedPolicy();
+    
+    // Ensure directory exists
+    await mkdir(POLICY_DIR, { recursive: true });
+    
+    // Clean up
+    try {
+      await rm(SCOPED_POLICY_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+    
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(SCOPED_POLICY_FILE, { force: true });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it("should return empty array when no scoped policy file exists", () => {
+    const request = createRequest();
+    const rules = getScopedRules(request);
+    expect(Array.isArray(rules)).toBe(true);
+  });
+
+  it("should resolve channel-specific deny rules", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "telegram:123": {
+              channelId: "telegram:123",
+              denyRules: [
+                {
+                  id: "channel-deny-bash",
+                  priority: 200,
+                  tool: "Bash",
+                  action: "deny",
+                  reason: "Bash denied in this channel",
+                },
+              ],
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const request = createRequest({ toolName: "Bash" });
+    const rules = getScopedRules(request);
+    
+    // Should have the channel deny rule
+    const denyRule = rules.find(r => r.id === "channel-deny-bash");
+    expect(denyRule).toBeDefined();
+    expect(denyRule?.action).toBe("deny");
+  });
+
+  it("should resolve user-specific overrides", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "telegram:123": {
+              channelId: "telegram:123",
+              userOverrides: {
+                "admin-user": {
+                  userId: "admin-user",
+                  allowRules: [
+                    {
+                      id: "admin-allow-all",
+                      priority: 200,
+                      tool: "*",
+                      action: "allow",
+                      reason: "Admin has full access",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const request = createRequest({ userId: "admin-user", toolName: "Bash" });
+    const rules = getScopedRules(request);
+    
+    const adminRule = rules.find(r => r.id === "admin-allow-all");
+    expect(adminRule).toBeDefined();
+    expect(adminRule?.action).toBe("allow");
+  });
+
+  it("should handle discord and telegram as different contexts", async () => {
+    const scopedConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          defaultRules: [
+            {
+              id: "telegram-deny-bash",
+              priority: 100,
+              tool: "Bash",
+              action: "deny",
+            },
+          ],
+        },
+        discord: {
+          source: "discord",
+          defaultRules: [
+            {
+              id: "discord-allow-bash",
+              priority: 100,
+              tool: "Bash",
+              action: "allow",
+            },
+          ],
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    await writeFile(SCOPED_POLICY_FILE, JSON.stringify(scopedConfig, null, 2), "utf8");
+    reloadScopedPolicy();
+    
+    const telegramRequest = createRequest({ source: "telegram", toolName: "Bash" });
+    const telegramRules = getScopedRules(telegramRequest);
+    const telegramDeny = telegramRules.find(r => r.id === "telegram-deny-bash");
+    expect(telegramDeny?.action).toBe("deny");
+    
+    const discordRequest = createRequest({ source: "discord", toolName: "Bash" });
+    const discordRules = getScopedRules(discordRequest);
+    const discordAllow = discordRules.find(r => r.id === "discord-allow-bash");
+    expect(discordAllow?.action).toBe("allow");
+  });
+});
+
+describe("Channel Policies - Merge Scoped Policies", () => {
+  it("should merge global and scoped rules without duplicates", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "global-allow", tool: "View", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "scoped-deny", tool: "Edit", action: "deny" },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged).toHaveLength(2);
+    expect(merged.find(r => r.id === "global-allow")).toBeDefined();
+    expect(merged.find(r => r.id === "scoped-deny")).toBeDefined();
+  });
+
+  it("should prefer scoped rules over global rules with same ID", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "same-id", tool: "View", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "same-id", tool: "View", action: "deny" },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged).toHaveLength(1);
+    expect(merged[0].action).toBe("deny");
+  });
+
+  it("should filter out disabled rules", () => {
+    const globalRules: PolicyRule[] = [
+      { id: "disabled-global", tool: "View", action: "allow", enabled: false },
+      { id: "enabled-global", tool: "Edit", action: "allow" },
+    ];
+    
+    const scopedRules: PolicyRule[] = [
+      { id: "disabled-scoped", tool: "Bash", action: "deny", enabled: false },
+    ];
+    
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+    
+    expect(merged.find(r => r.id === "disabled-global")).toBeUndefined();
+    expect(merged.find(r => r.id === "enabled-global")).toBeDefined();
+    expect(merged.find(r => r.id === "disabled-scoped")).toBeUndefined();
+  });
+});
+
+describe("Channel Policies - Validation", () => {
+  it("should validate a correct scoped policy config", () => {
+    const config = getExampleScopedPolicyConfig();
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should detect missing version", () => {
+    const config = {
+      sources: {},
+      globalRules: [],
+    } as any;
+    
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes("version"))).toBe(true);
+  });
+
+  it("should detect mismatched channel IDs", () => {
+    const config: ScopedPolicyConfig = {
+      version: 1,
+      sources: {
+        telegram: {
+          source: "telegram",
+          channels: {
+            "channel-1": {
+              channelId: "different-id", // Mismatch!
+            },
+          },
+        },
+      },
+      globalRules: [],
+      updatedAt: new Date().toISOString(),
+    };
+    
+    const result = validateScopedPolicyConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes("mismatch"))).toBe(true);
+  });
+});
+
+describe("Channel Policies - Default Config", () => {
+  it("should create a valid default config", () => {
+    const config = createDefaultScopedPolicyConfig();
+    expect(config.version).toBe(1);
+    expect(config.sources).toEqual({});
+    expect(config.globalRules).toEqual([]);
+  });
+
+  it("should have proper structure in example config", () => {
+    const config = getExampleScopedPolicyConfig();
+    
+    // Should have telegram and discord sources
+    expect(config.sources["telegram"]).toBeDefined();
+    expect(config.sources["discord"]).toBeDefined();
+    
+    // Telegram should have channel config
+    expect(config.sources["telegram"].channels?.["telegram:123"]).toBeDefined();
+    
+    // Should have global deny rule
+    const globalDeny = config.globalRules.find(r => r.id === "global-deny-dangerous");
+    expect(globalDeny).toBeDefined();
+    expect(globalDeny?.action).toBe("deny");
+  });
+});

--- a/src/__tests__/policy/engine.test.ts
+++ b/src/__tests__/policy/engine.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Tests for policy/engine.ts
+ * 
+ * Run with: bun test src/__tests__/policy/engine.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { rm, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  evaluate,
+  loadRules,
+  validateRules,
+  getRules,
+  clearCache,
+  isCacheEnabled,
+  type ToolRequestContext,
+  type PolicyRule,
+} from "../../policy/engine";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const POLICY_FILE = join(POLICY_DIR, "policies.json");
+
+// Helper to create a test request
+const createRequest = (overrides: Partial<ToolRequestContext> = {}): ToolRequestContext => ({
+  eventId: "test-event-1",
+  source: "telegram",
+  channelId: "telegram:123",
+  threadId: "thread-1",
+  userId: "user-1",
+  skillName: undefined,
+  toolName: "Bash",
+  toolArgs: {},
+  sessionId: "session-1",
+  claudeSessionId: null,
+  timestamp: new Date().toISOString(),
+  metadata: {},
+  ...overrides,
+});
+
+// Helper to write a policy file
+async function writePolicyFile(rules: PolicyRule[], cache?: { enabled: boolean; maxEntries: number; ttlMs: number }): Promise<void> {
+  const policy = {
+    version: 1,
+    rules,
+    cache: cache || { enabled: false, maxEntries: 1000, ttlMs: 60000 },
+    updatedAt: new Date().toISOString(),
+  };
+  await mkdir(POLICY_DIR, { recursive: true });
+  await writeFile(POLICY_FILE, JSON.stringify(policy, null, 2), "utf8");
+}
+
+describe("Policy Engine - Core Evaluation", () => {
+  beforeEach(async () => {
+    clearCache();
+    await loadRules();
+  });
+
+  afterEach(async () => {
+    clearCache();
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should deny request when no rules match", async () => {
+    await writePolicyFile([]);
+    
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBeUndefined();
+    expect(decision.reason).toContain("No matching policy rule");
+  });
+
+  it("should allow request when explicit allow rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-telegram",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "*",
+        action: "allow",
+        reason: "Allow all tools on telegram",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("allow");
+    expect(decision.matchedRuleId).toBe("allow-telegram");
+  });
+
+  it("should deny request when explicit deny rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-telegram",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "*",
+        action: "allow",
+      },
+      {
+        id: "deny-bash",
+        priority: 200,
+        tool: "Bash",
+        action: "deny",
+        reason: "Deny bash tool",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("deny-bash");
+  });
+
+  it("should require_approval when require_approval rule matches", async () => {
+    await writePolicyFile([
+      {
+        id: "approval-edit",
+        priority: 100,
+        tool: "Edit",
+        action: "require_approval",
+        reason: "Edit requires approval",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Edit" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("require_approval");
+    expect(decision.matchedRuleId).toBe("approval-edit");
+  });
+
+  it("should evaluate rules by highest priority first", async () => {
+    await writePolicyFile([
+      {
+        id: "low-priority-allow",
+        priority: 50,
+        tool: "Bash",
+        action: "allow",
+      },
+      {
+        id: "high-priority-deny",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("high-priority-deny");
+  });
+
+  it("should use specificity as tiebreaker when priorities equal", async () => {
+    await writePolicyFile([
+      {
+        id: "global-allow",
+        priority: 100,
+        tool: "Bash",
+        action: "allow",
+        reason: "Global allow",
+      },
+      {
+        id: "telegram-deny",
+        priority: 100,
+        scope: { source: "telegram" },
+        tool: "Bash",
+        action: "deny",
+        reason: "Telegram specific deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    // More specific rule (telegram-deny) should win
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("telegram-deny");
+  });
+
+  it("should deny when no allow rule matches but deny rule exists", async () => {
+    await writePolicyFile([
+      {
+        id: "deny-bash",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Bash" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+
+  it("should match wildcard tool", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest({ toolName: "AnyTool" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("allow");
+  });
+
+  it("should match tool array", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-view-edit",
+        priority: 100,
+        tool: ["View", "Edit", "GrepTool"],
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const viewRequest = createRequest({ toolName: "View" });
+    expect(evaluate(viewRequest).action).toBe("allow");
+    
+    const editRequest = createRequest({ toolName: "Edit" });
+    expect(evaluate(editRequest).action).toBe("allow");
+    
+    const bashRequest = createRequest({ toolName: "Bash" });
+    expect(evaluate(bashRequest).action).toBe("deny");
+  });
+
+  it("should match source array", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-multiple-sources",
+        priority: 100,
+        scope: { source: ["telegram", "discord"] },
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const telegramRequest = createRequest({ source: "telegram" });
+    expect(evaluate(telegramRequest).action).toBe("allow");
+    
+    const discordRequest = createRequest({ source: "discord" });
+    expect(evaluate(discordRequest).action).toBe("allow");
+    
+    const slackRequest = createRequest({ source: "slack" });
+    expect(evaluate(slackRequest).action).toBe("deny");
+  });
+
+  it("should skip disabled rules", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-disabled",
+        priority: 100,
+        enabled: false,
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+
+  it("should handle userId scope correctly", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-admin",
+        priority: 100,
+        scope: { userId: "admin-user" },
+        tool: "*",
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const adminRequest = createRequest({ userId: "admin-user" });
+    expect(evaluate(adminRequest).action).toBe("allow");
+    
+    const regularRequest = createRequest({ userId: "regular-user" });
+    expect(evaluate(regularRequest).action).toBe("deny");
+  });
+
+  it("should handle skillName scope correctly", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-code-review",
+        priority: 100,
+        scope: { skillName: "code-review" },
+        tool: ["View", "GlobTool", "GrepTool"],
+        action: "allow",
+      },
+    ]);
+    
+    await loadRules();
+    
+    const codeReviewRequest = createRequest({ 
+      skillName: "code-review",
+      toolName: "View",
+    });
+    expect(evaluate(codeReviewRequest).action).toBe("allow");
+    
+    const otherSkillRequest = createRequest({ 
+      skillName: "other-skill",
+      toolName: "View",
+    });
+    expect(evaluate(otherSkillRequest).action).toBe("deny");
+  });
+});
+
+describe("Policy Engine - Time Window Conditions", () => {
+  afterEach(async () => {
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should deny request outside time window", async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const tomorrow = new Date(Date.now() + 86400000).toISOString();
+    const lastWeek = new Date(Date.now() - 7 * 86400000).toISOString();
+    const nextWeek = new Date(Date.now() + 7 * 86400000).toISOString();
+    
+    await writePolicyFile([
+      {
+        id: "allow-business-hours",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+        conditions: {
+          timeWindow: { start: lastWeek, end: yesterday }, // Past window
+        },
+      },
+    ]);
+    
+    await loadRules();
+    const request = createRequest();
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("deny");
+  });
+});
+
+describe("Policy Engine - Validation", () => {
+  it("should return valid for correct rules", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "valid-rule",
+        tool: "Bash",
+        action: "allow",
+        reason: "Valid rule",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should reject rule without id", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "",
+        tool: "Bash",
+        action: "allow",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "id")).toBe(true);
+  });
+
+  it("should reject rule without tool", () => {
+    // Cast to PolicyRule[] to test validation catches missing tool
+    const rules = [
+      {
+        id: "no-tool",
+        action: "allow",
+      },
+    ] as unknown as PolicyRule[];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "tool")).toBe(true);
+  });
+
+  it("should reject rule with invalid action", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "invalid-action",
+        tool: "Bash",
+        action: "invalid" as any,
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.field === "action")).toBe(true);
+  });
+
+  it("should warn about unscoped allow rules", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "unscoped-allow",
+        tool: "*",
+        action: "allow",
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.warnings.some(w => w.field === "scope")).toBe(true);
+  });
+
+  it("should detect duplicate rule IDs", () => {
+    const rules: PolicyRule[] = [
+      { id: "duplicate", tool: "Bash", action: "allow" },
+      { id: "duplicate", tool: "Edit", action: "deny" },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes("Duplicate"))).toBe(true);
+  });
+
+  it("should warn on invalid time window dates", () => {
+    const rules: PolicyRule[] = [
+      {
+        id: "bad-timewindow",
+        tool: "Bash",
+        action: "allow",
+        conditions: {
+          timeWindow: { start: "not-a-date", end: "also-not-a-date" },
+        },
+      },
+    ];
+    
+    const result = validateRules(rules);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("Policy Engine - Cache", () => {
+  afterEach(async () => {
+    try {
+      await rm(POLICY_FILE, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should cache decisions when cache enabled", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    expect(isCacheEnabled()).toBe(true);
+    
+    const request = createRequest();
+    const decision1 = evaluate(request);
+    expect(decision1.action).toBe("allow");
+    
+    // Second evaluation should use cache
+    const decision2 = evaluate(request);
+    expect(decision2.action).toBe("allow");
+  });
+
+  it("should clear cache on reload", async () => {
+    await writePolicyFile([
+      {
+        id: "allow-all",
+        priority: 100,
+        tool: "*",
+        action: "allow",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const request = createRequest();
+    evaluate(request);
+    
+    // Change policy
+    await writePolicyFile([
+      {
+        id: "deny-all",
+        priority: 100,
+        tool: "*",
+        action: "deny",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const decision = evaluate(request);
+    
+    // Should reflect new policy, not cached
+    expect(decision.action).toBe("deny");
+    expect(decision.matchedRuleId).toBe("deny-all");
+  });
+
+  it("should not cache require_approval decisions", async () => {
+    await writePolicyFile([
+      {
+        id: "approval-edit",
+        priority: 100,
+        tool: "Edit",
+        action: "require_approval",
+      },
+    ], { enabled: true, maxEntries: 100, ttlMs: 60000 });
+    
+    await loadRules();
+    const request = createRequest({ toolName: "Edit" });
+    const decision = evaluate(request);
+    
+    expect(decision.action).toBe("require_approval");
+    expect(decision.cacheable).toBe(false);
+  });
+});

--- a/src/__tests__/policy/skill-overlays.test.ts
+++ b/src/__tests__/policy/skill-overlays.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for policy/skill-overlays.ts
+ * 
+ * Run with: bun test src/__tests__/policy/skill-overlays.test.ts
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  parseSkillMetadata,
+  getSkillOverlayFromContent,
+  overlayToRules,
+  evaluateSkillPolicy,
+  validateRequiredTools,
+  getExampleSkillOverlays,
+  type SkillOverlay,
+} from "../../policy/skill-overlays";
+
+describe("Skill Overlays - Metadata Parsing", () => {
+  it("should parse requiredTools from SKILL.md frontmatter", () => {
+    const content = `---
+requiredTools:
+  - View
+  - GlobTool
+  - GrepTool
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.requiredTools).toEqual(["View", "GlobTool", "GrepTool"]);
+  });
+
+  it("should parse preferredTools from SKILL.md frontmatter", () => {
+    const content = `---
+preferredTools:
+  - View
+  - Bash
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.preferredTools).toEqual(["View", "Bash"]);
+  });
+
+  it("should parse deniedTools from SKILL.md frontmatter", () => {
+    const content = `---
+deniedTools:
+  - Bash
+  - Edit
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.deniedTools).toEqual(["Bash", "Edit"]);
+  });
+
+  it("should parse all policy fields together", () => {
+    const content = `---
+requiredTools:
+  - View
+preferredTools:
+  - View
+  - GrepTool
+deniedTools:
+  - Bash
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "code-review");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.skillName).toBe("code-review");
+    expect(overlay?.requiredTools).toEqual(["View"]);
+    expect(overlay?.preferredTools).toEqual(["View", "GrepTool"]);
+    expect(overlay?.deniedTools).toEqual(["Bash"]);
+  });
+
+  it("should return null when no policy fields present", () => {
+    const content = `---
+description: A test skill
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).toBeNull();
+  });
+
+  it("should return null for content without frontmatter", () => {
+    const content = `# Skill Content
+This is just regular markdown content.
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).toBeNull();
+  });
+
+  it("should handle empty tool lists", () => {
+    const content = `---
+requiredTools: []
+preferredTools: []
+deniedTools: []
+---
+
+# Skill Content
+`;
+    
+    const overlay = parseSkillMetadata(content, "test-skill");
+    expect(overlay).not.toBeNull();
+    expect(overlay?.requiredTools).toEqual([]);
+    expect(overlay?.preferredTools).toEqual([]);
+    expect(overlay?.deniedTools).toEqual([]);
+  });
+});
+
+describe("Skill Overlays - Overlay to Rules Conversion", () => {
+  it("should convert denied tools to deny rules", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const rules = overlayToRules(overlay);
+    
+    expect(rules).toHaveLength(2);
+    
+    const bashRule = rules.find(r => r.tool === "Bash");
+    expect(bashRule).toBeDefined();
+    expect(bashRule?.action).toBe("deny");
+    expect(bashRule?.scope?.skillName).toBe("code-review");
+    expect(bashRule?.id).toContain("code-review");
+    
+    const editRule = rules.find(r => r.tool === "Edit");
+    expect(editRule).toBeDefined();
+    expect(editRule?.action).toBe("deny");
+  });
+
+  it("should not create rules for empty deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "read-only",
+      deniedTools: [],
+    };
+    
+    const rules = overlayToRules(overlay);
+    expect(rules).toHaveLength(0);
+  });
+
+  it("should use custom base priority when provided", () => {
+    const overlay: SkillOverlay = {
+      skillName: "test",
+      deniedTools: ["Bash"],
+    };
+    
+    const rules = overlayToRules(overlay, 200);
+    expect(rules[0].priority).toBe(250); // base + 50
+  });
+
+  it("should not create rules for preferredTools or requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "test",
+      requiredTools: ["View"],
+      preferredTools: ["View", "GrepTool"],
+    };
+    
+    const rules = overlayToRules(overlay);
+    expect(rules).toHaveLength(0);
+  });
+});
+
+describe("Skill Overlays - Policy Evaluation", () => {
+  it("should deny when tool is in deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "Bash");
+    
+    expect(result.allowed).toBe(false);
+    expect(result.deniedTools).toContain("Bash");
+    expect(result.skillOverlay).toBe(overlay);
+  });
+
+  it("should allow when tool is not in deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      deniedTools: ["Bash", "Edit"],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "View");
+    
+    expect(result.allowed).toBe(true);
+    expect(result.deniedTools).toBeUndefined();
+  });
+
+  it("should handle empty deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "open-skill",
+      deniedTools: [],
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "Bash");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("should handle overlay with no deniedTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+    };
+    
+    const result = evaluateSkillPolicy(overlay, "View");
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("Skill Overlays - Required Tools Validation", () => {
+  it("should validate all required tools are available", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+    };
+    
+    const availableTools = ["View", "GlobTool", "GrepTool", "Bash"];
+    const result = validateRequiredTools(overlay, availableTools);
+    
+    expect(result.valid).toBe(true);
+    expect(result.missingTools).toHaveLength(0);
+  });
+
+  it("should detect missing required tools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+    };
+    
+    const availableTools = ["View", "Bash"];
+    const result = validateRequiredTools(overlay, availableTools);
+    
+    expect(result.valid).toBe(false);
+    expect(result.missingTools).toContain("GlobTool");
+    expect(result.missingTools).toContain("GrepTool");
+  });
+
+  it("should handle empty requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+      requiredTools: [],
+    };
+    
+    const result = validateRequiredTools(overlay, []);
+    expect(result.valid).toBe(true);
+  });
+
+  it("should handle undefined requiredTools", () => {
+    const overlay: SkillOverlay = {
+      skillName: "basic-skill",
+    };
+    
+    const result = validateRequiredTools(overlay, []);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("Skill Overlays - Example Configurations", () => {
+  it("should provide valid example overlays", () => {
+    const examples = getExampleSkillOverlays();
+    
+    // Code review should be read-only
+    const codeReview = examples["code-review"];
+    expect(codeReview.deniedTools).toContain("Bash");
+    expect(codeReview.deniedTools).toContain("Edit");
+    expect(codeReview.deniedTools).toContain("Write");
+    expect(codeReview.requiredTools).toContain("View");
+    
+    // Admin should have full access
+    const admin = examples["admin"];
+    expect(admin.deniedTools).toHaveLength(0);
+    expect(admin.requiredTools).toContain("Bash");
+    
+    // Web scrape needs network
+    const webScrape = examples["web-scrape"];
+    expect(webScrape.requiredTools).toContain("WebFetch");
+    expect(webScrape.requiredTools).toContain("Bash");
+  });
+});

--- a/src/__tests__/policy/wiring.test.ts
+++ b/src/__tests__/policy/wiring.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { evaluate } from "../../../src/policy/engine";
+import { enqueue, loadState, listPending, findByEventId } from "../../../src/policy/approval-queue";
+import { initGovernanceClient, getGovernanceClient, type GovernanceClient } from "../../../src/governance/client";
+
+describe("Policy Wiring Integration", () => {
+  beforeEach(async () => {
+    // Reset and reinitialize
+    await loadState();
+    initGovernanceClient({ policyEnabled: true, approvalEnabled: true });
+  });
+
+  describe("GovernanceClient", () => {
+    it("should evaluate tool requests through policy engine", () => {
+      const gc = getGovernanceClient();
+      const request = {
+        eventId: "test-event-1",
+        source: "telegram",
+        channelId: "telegram:123",
+        userId: "user1",
+        toolName: "Read",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = gc.evaluateToolRequest(request);
+      expect(decision).toBeDefined();
+      expect(decision.action).toMatch(/^(allow|deny|require_approval)$/);
+    });
+
+    it("should detect allow decisions", () => {
+      const gc = getGovernanceClient();
+      const request = {
+        eventId: "test-event-2",
+        source: "telegram",
+        channelId: "telegram:123",
+        toolName: "Read",
+        timestamp: new Date().toISOString(),
+      };
+
+      const allowed = gc.isToolAllowed(request);
+      expect(typeof allowed).toBe("boolean");
+    });
+
+    it("should detect require_approval decisions", () => {
+      const gc = getGovernanceClient();
+      const request = {
+        eventId: "test-event-3",
+        source: "discord",
+        channelId: "discord:456",
+        toolName: "Edit",
+        timestamp: new Date().toISOString(),
+      };
+
+      const requiresApproval = gc.requiresApproval(request);
+      expect(typeof requiresApproval).toBe("boolean");
+    });
+  });
+
+  describe("Policy Engine evaluate()", () => {
+    it("should return deny when no rules match (default deny)", () => {
+      const request = {
+        eventId: "test-event-deny",
+        source: "unknown",
+        toolName: "SomeTool",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = evaluate(request);
+      expect(decision.action).toBe("deny");
+      expect(decision.reason).toContain("No matching policy rule");
+    });
+
+    it("should include requestId and evaluatedAt in decision", () => {
+      const request = {
+        eventId: "test-event-meta",
+        source: "telegram",
+        toolName: "View",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = evaluate(request);
+      expect(decision.requestId).toBeDefined();
+      expect(decision.evaluatedAt).toBeDefined();
+    });
+  });
+
+  describe("Approval Queue enqueue()", () => {
+    it("should enqueue require_approval requests", async () => {
+      const request = {
+        eventId: "test-approval-event",
+        source: "telegram",
+        toolName: "Edit",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = {
+        requestId: "test-req-id",
+        action: "require_approval" as const,
+        reason: "Edit requires approval",
+        evaluatedAt: new Date().toISOString(),
+      };
+
+      const entry = await enqueue(request, decision);
+      expect(entry).toBeDefined();
+      expect(entry.id).toBeDefined();
+      expect(entry.status).toBe("pending");
+      expect(entry.eventId).toBe("test-approval-event");
+    });
+
+    it("should find enqueued approval by eventId", async () => {
+      const eventId = "test-find-event-" + Date.now();
+      const request = {
+        eventId,
+        source: "discord",
+        toolName: "Bash",
+        timestamp: new Date().toISOString(),
+      };
+
+      const decision = {
+        requestId: "test-req-id-2",
+        action: "require_approval" as const,
+        reason: "Bash requires approval",
+        evaluatedAt: new Date().toISOString(),
+      };
+
+      await enqueue(request, decision);
+      const found = await findByEventId(eventId);
+      expect(found).toBeDefined();
+      expect(found?.eventId).toBe(eventId);
+    });
+
+    it("should list pending approvals", async () => {
+      const pending = listPending();
+      expect(Array.isArray(pending)).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/retry-queue.test.ts
+++ b/src/__tests__/retry-queue.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for retry-queue.ts
+ * 
+ * Run with: bun test src/__tests__/retry-queue.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm } from "fs/promises";
+import { join } from "path";
+import {
+  initEventLog,
+  append,
+  resetEventLog,
+  type EventEntryInput,
+} from "../event-log";
+import {
+  initRetryScheduler,
+  schedule,
+  popDue,
+  remove,
+  rebuildFromState,
+  rebuildFromEventLog,
+  getPendingRetryCount,
+  getRetryStats,
+  stopCheckLoop,
+  resetRetryScheduler,
+  isScheduled,
+} from "../retry-queue";
+
+const TEST_DIR = join(process.cwd(), ".claude", "claudeclaw");
+
+const createTestEntry = (overrides: Partial<EventEntryInput> = {}): EventEntryInput => ({
+  type: "test",
+  source: "test-source",
+  channelId: "test-channel",
+  threadId: "test-thread",
+  payload: { message: "hello" },
+  dedupeKey: `test-${Date.now()}-${Math.random()}`,
+  ...overrides,
+});
+
+beforeEach(async () => {
+  resetEventLog();
+  await resetRetryScheduler();
+  
+  await rm(join(TEST_DIR, "event-log"), { recursive: true, force: true });
+  await rm(join(TEST_DIR, "retry"), { recursive: true, force: true });
+  await mkdir(join(TEST_DIR, "event-log"), { recursive: true });
+  await mkdir(join(TEST_DIR, "retry"), { recursive: true });
+});
+
+afterEach(async () => {
+  stopCheckLoop();
+  await resetRetryScheduler();
+});
+
+describe("Retry Scheduler", () => {
+  it("should initialize scheduler", async () => {
+    await initRetryScheduler({
+      baseDelayMs: 1000,
+      maxDelayMs: 30000,
+      maxRetries: 3,
+      checkIntervalMs: 100,
+    });
+
+    const stats = getRetryStats();
+    expect(stats.pendingCount).toBe(0);
+    expect(stats.maxRetries).toBe(3);
+    expect(stats.baseDelayMs).toBe(1000);
+  });
+
+  it("should schedule an event for retry", async () => {
+    await initRetryScheduler({ baseDelayMs: 1000, maxRetries: 5 });
+    
+    const entry = await append(createTestEntry());
+    await schedule(entry.id, 0);
+
+    expect(getPendingRetryCount()).toBe(1);
+    expect(isScheduled(entry.id)).toBe(true);
+  });
+
+  it("should calculate exponential backoff", async () => {
+    await initRetryScheduler({ baseDelayMs: 1000, maxDelayMs: 10000, maxRetries: 5 });
+    
+    const entry = await append(createTestEntry());
+    
+    // Schedule with retryCount 0 (1st retry)
+    await schedule(entry.id, 0);
+    const stats1 = getRetryStats();
+    
+    // Should use 1000 * 2^0 = 1000ms delay
+    expect(stats1.pendingCount).toBe(1);
+  });
+
+  it("should reject scheduling when max retries exceeded", async () => {
+    await initRetryScheduler({ maxRetries: 3 });
+    
+    const entry = await append(createTestEntry());
+    
+    expect(async () => {
+      await schedule(entry.id, 3); // Already at max
+    }).toThrow();
+  });
+
+  it("should pop due entries", async () => {
+    await initRetryScheduler({ baseDelayMs: 1, maxRetries: 5 }); // Very short delay
+    
+    const entry = await append(createTestEntry());
+    await schedule(entry.id, 0);
+
+    // Wait for delay
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const due = popDue();
+    expect(due).not.toBeNull();
+    expect(due?.eventId).toBe(entry.id);
+    expect(getPendingRetryCount()).toBe(0);
+  });
+
+  it("should remove scheduled entry", async () => {
+    await initRetryScheduler();
+    
+    const entry = await append(createTestEntry());
+    await schedule(entry.id, 0);
+
+    expect(getPendingRetryCount()).toBe(1);
+
+    await remove(entry.id);
+
+    expect(getPendingRetryCount()).toBe(0);
+    expect(isScheduled(entry.id)).toBe(false);
+  });
+
+  it("should rebuild from state", async () => {
+    await initRetryScheduler();
+    
+    const entry = await append(createTestEntry());
+    await schedule(entry.id, 0);
+
+    expect(getPendingRetryCount()).toBe(1);
+
+    // Simulate restart by clearing in-memory queue
+    await rebuildFromState();
+
+    expect(getPendingRetryCount()).toBe(1);
+    expect(isScheduled(entry.id)).toBe(true);
+  });
+
+  it("should rebuild from event log", async () => {
+    await initRetryScheduler({ maxRetries: 5 });
+    
+    // Create an event and mark it for retry
+    const entry = await append(createTestEntry());
+    
+    // Manually update event to retry_scheduled status
+    const { appendStatusUpdate } = await import("../event-log");
+    await appendStatusUpdate(entry.id, {
+      status: "retry_scheduled",
+      retryCount: 1,
+      nextRetryAt: new Date(Date.now() + 60000).toISOString(),
+    });
+
+    const count = await rebuildFromEventLog();
+    expect(count).toBe(1);
+    expect(getPendingRetryCount()).toBe(1);
+  });
+
+  it("should provide statistics", async () => {
+    await initRetryScheduler({
+      baseDelayMs: 5000,
+      maxDelayMs: 600000,
+      maxRetries: 5,
+    });
+
+    const stats = getRetryStats();
+    expect(stats.pendingCount).toBe(0);
+    expect(stats.baseDelayMs).toBe(5000);
+    expect(stats.maxDelayMs).toBe(600000);
+    expect(stats.maxRetries).toBe(5);
+    expect(stats.nextRetryAt).toBeNull();
+  });
+});
+
+describe("Retry Scheduler - Edge Cases", () => {
+  it("should handle non-existent event", async () => {
+    await initRetryScheduler();
+
+    expect(async () => {
+      await schedule("non-existent-id", 0);
+    }).toThrow();
+  });
+
+  it("should return null when no due entries", async () => {
+    await initRetryScheduler({ baseDelayMs: 60000, maxRetries: 5 }); // Long delay
+    
+    const entry = await append(createTestEntry());
+    await schedule(entry.id, 0);
+
+    const due = popDue();
+    expect(due).toBeNull();
+  });
+
+  it("should sort retries by time", async () => {
+    await initRetryScheduler({ baseDelayMs: 1, maxRetries: 5 });
+    
+    const entry1 = await append(createTestEntry());
+    const entry2 = await append(createTestEntry());
+    const entry3 = await append(createTestEntry());
+
+    // Schedule with different retry counts (different delays)
+    await schedule(entry1.id, 2); // Longest delay
+    await schedule(entry2.id, 0); // Shortest delay
+    await schedule(entry3.id, 1); // Medium delay
+
+    // Wait for shortest delay
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    // Should pop in order: entry2 (retry 0), entry3 (retry 1), entry1 (retry 2)
+    const first = popDue();
+    expect(first?.eventId).toBe(entry2.id);
+  });
+});

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,7 +1,6 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
-import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -9,6 +8,9 @@ import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
+import { processEventWithFallback, setGatewayEnabled } from "../gateway";
+import { normalizeDiscordMessage, type NormalizedEvent } from "../gateway/normalizer";
+
 
 // --- Discord API constants ---
 
@@ -107,17 +109,58 @@ let resumeGatewayUrl: string | null = null;
 let heartbeatAcked = true;
 let running = true;
 let discordDebug = false;
-
-// Bot identity (populated from READY)
 let botUserId: string | null = null;
 let botUsername: string | null = null;
 let applicationId: string | null = null;
-
-// Track guilds we were already in before this session to avoid duplicate welcome messages
 let readyGuildIds: Set<string> | null = null;
 
-// Track known thread channel IDs and their parent channel IDs for multi-session support
-const knownThreads = new Map<string, { parentId: string }>();
+// --- Security: Rate Limiting ---
+interface DiscordRateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const DISCORD_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const DISCORD_RATE_LIMIT_MAX = 30;
+const discordRateLimitMap = new Map<string, DiscordRateLimitEntry>();
+
+function checkDiscordRateLimit(userId: string): boolean {
+  const now = Date.now();
+  const entry = discordRateLimitMap.get(userId);
+
+  if (!entry || now > entry.resetAt) {
+    discordRateLimitMap.set(userId, { count: 1, resetAt: now + DISCORD_RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+
+  if (entry.count >= DISCORD_RATE_LIMIT_MAX) {
+    return false;
+  }
+
+  entry.count++;
+  return true;
+}
+
+// --- Security: File size limit ---
+const MAX_DISCORD_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25MB
+
+// --- Security: Filename sanitization ---
+function sanitizeDiscordFilename(name: string): string {
+  const sanitized = name.replace(/\x00/g, "").replace(/\.\./g, "_");
+  const safe = sanitized.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return safe.slice(0, 255);
+}
+
+// --- Security: Helper to fetch with size validation ---
+async function fetchDiscordWithSizeLimit(url: string): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Discord attachment download failed: ${response.status}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length > MAX_DISCORD_FILE_SIZE_BYTES) {
+    throw new Error(`File too large: ${bytes.length} bytes (max: ${MAX_DISCORD_FILE_SIZE_BYTES})`);
+  }
+  return bytes;
+}
 
 // --- Debug ---
 
@@ -223,38 +266,24 @@ async function sendReaction(
 
 function extractReactionDirective(text: string): { cleanedText: string; reactionEmoji: string | null } {
   let reactionEmoji: string | null = null;
-  const cleanedText = text
-    .replace(/\[react:([^\]\r\n]+)\]/gi, (_match, raw) => {
-      const candidate = String(raw).trim();
-      if (!reactionEmoji && candidate) reactionEmoji = candidate;
-      return "";
-    })
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-  return { cleanedText, reactionEmoji };
-}
 
-// --- Thread rejoin helper ---
-async function rejoinThreads(token: string): Promise<void> {
-  const threadSessions = await listThreadSessions();
-  for (const ts of threadSessions) {
-    try {
-      await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
-      if (!knownThreads.has(ts.threadId)) {
-        const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
-        if (ch.parent_id) {
-          knownThreads.set(ts.threadId, { parentId: ch.parent_id });
-        }
-      }
-      console.log(`[Discord] Rejoined thread: ${ts.threadId}`);
-    } catch (err) {
-      console.error(`[Discord] Failed to rejoin thread ${ts.threadId}: ${err}`);
-    }
-  }
-  if (threadSessions.length > 0) {
-    console.log(`[Discord] Rejoined ${threadSessions.length} thread(s) from sessions.json`);
-  }
+  // Step 1: Extract reaction directive
+  let cleanedText = text.replace(/\[react:([^\]\r\n]+)\]/gi, (_match, raw) => {
+    const candidate = String(raw).trim();
+    if (!reactionEmoji && candidate) reactionEmoji = candidate;
+    return "";
+  });
+
+  // Step 2: Remove trailing whitespace before newlines
+  cleanedText = cleanedText.replace(/[ \t]+\n/g, "\n");
+
+  // Step 3: Collapse excessive newlines
+  cleanedText = cleanedText.replace(/\n{3,}/g, "\n\n");
+
+  // Step 4: Trim final result
+  cleanedText = cleanedText.trim();
+
+  return { cleanedText, reactionEmoji };
 }
 
 // --- Guild trigger logic ---
@@ -273,62 +302,10 @@ function guildTriggerReason(message: DiscordMessage): string | null {
   const config = getSettings().discord;
   if (config.listenChannels.includes(message.channel_id)) return "listen_channel";
 
-  // Thread whose parent channel is a listen channel
-  const threadInfo = knownThreads.get(message.channel_id);
-  if (threadInfo && config.listenChannels.includes(threadInfo.parentId)) return "listen_channel_thread";
-
   return null;
 }
 
 // --- Attachment handling ---
-
-// --- AI-powered thread intent classifier (uses Sonnet via Claude OAuth) ---
-interface ThreadIntent {
-  action: "hire" | "fire";
-  names: string[];
-}
-
-async function classifyThreadIntent(text: string): Promise<ThreadIntent | null> {
-  const systemPrompt = `You classify user messages into thread management intents.
-
-If the user wants to CREATE/SPAWN/DEPLOY threads (e.g. "hire X", "派出 X", "叫 X 出來", "派 X 去打", "開 X", "建立 X"):
-Return: {"action":"hire","names":["name1","name2"]}
-
-If the user wants to DELETE/REMOVE threads (e.g. "fire X", "撤回 X", "把 X 叫回來", "刪 X", "關 X"):
-Return: {"action":"fire","names":["name1","name2"]}
-
-If the message is NOT about thread management, return: null
-
-Rules:
-- Extract individual names. "桃園三結義" = ["劉備","關羽","張飛"]. "五虎將" = ["關羽","張飛","趙雲","馬超","黃忠"].
-- Common patterns: 派/派出/出征/上陣/迎戰/出戰 = hire. 撤/撤回/收回/叫回來/滾 = fire.
-- Return ONLY valid JSON or the word null. No explanation.`;
-
-  try {
-    const { execSync } = await import("node:child_process");
-    const input = `${systemPrompt}\n\n---\nUser message: ${text}`;
-    const result = execSync(
-      `claude --model claude-sonnet-4-20250514 --print --output-format text`,
-      {
-        input,
-        encoding: "utf-8",
-        timeout: 15000,
-        env: { ...process.env, HOME: homedir() },
-      },
-    ).trim();
-
-    if (!result || result === "null") return null;
-    // Extract JSON from response (in case there's extra text)
-    const jsonMatch = result.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) return null;
-    return JSON.parse(jsonMatch[0]) as ThreadIntent;
-  } catch (err) {
-    console.error(`[Discord] Intent classifier error: ${err instanceof Error ? err.message : String(err)}`);
-    return null;
-  }
-}
-
-// --- Attachment handling (original) ---
 
 function isImageAttachment(a: DiscordAttachment): boolean {
   return Boolean(a.content_type?.startsWith("image/"));
@@ -347,14 +324,11 @@ async function downloadDiscordAttachment(
   const dir = join(process.cwd(), ".claude", "claudeclaw", "inbox", "discord");
   await mkdir(dir, { recursive: true });
 
-  const response = await fetch(attachment.url);
-  if (!response.ok) throw new Error(`Discord attachment download failed: ${response.status}`);
+  const bytes = await fetchDiscordWithSizeLimit(attachment.url);
 
-  const ext = extname(attachment.filename) || (type === "voice" ? ".ogg" : ".jpg");
+  const ext = sanitizeDiscordFilename(extname(attachment.filename)) || (type === "voice" ? ".ogg" : ".jpg");
   const filename = `${attachment.id}-${Date.now()}${ext}`;
   const localPath = join(dir, filename);
-
-  const bytes = new Uint8Array(await response.arrayBuffer());
   await Bun.write(localPath, bytes);
   debugLog(`Attachment downloaded: ${localPath} (${bytes.length} bytes)`);
   return localPath;
@@ -435,32 +409,21 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   const isGuild = !!message.guild_id;
   const content = message.content;
 
-  // Recover lost thread from sessions.json (fallback for knownThreads volatility)
-  if (isGuild && !knownThreads.has(channelId)) {
-    const persisted = await peekThreadSession(channelId);
-    if (persisted) {
-      try {
-        const ch = await discordApi<{ parent_id?: string }>(config.token, "GET", `/channels/${channelId}`);
-        if (ch.parent_id) {
-          knownThreads.set(channelId, { parentId: ch.parent_id });
-          debugLog(`Thread recovered from sessions.json: ${channelId} (parent: ${ch.parent_id})`);
-        }
-      } catch (err) {
-        debugLog(`Thread recovery failed for ${channelId}: ${err}`);
-      }
-    }
-  }
-
   // Guild trigger check
   const triggerReason = isGuild ? guildTriggerReason(message) : "direct_message";
   if (isGuild && !triggerReason) {
-    const threadInfo = knownThreads.get(channelId);
-    console.log(`[Discord][DIAG] SKIP channel=${channelId} guild=${message.guild_id} inKnown=${knownThreads.has(channelId)} threadInfo=${JSON.stringify(threadInfo)} knownSize=${knownThreads.size} listenCh=${JSON.stringify(config.listenChannels)} text="${content.slice(0, 40)}"`);
+    debugLog(`Skip guild message channel=${channelId} from=${userId} reason=no_trigger`);
     return;
   }
   debugLog(
     `Handle message channel=${channelId} from=${userId} reason=${triggerReason} text="${content.slice(0, 80)}"`,
   );
+
+  // Security: Rate limit check
+  if (!checkDiscordRateLimit(userId)) {
+    debugLog(`Rate limited: userId=${userId}`);
+    return;
+  }
 
   // Authorization check
   if (config.allowedUserIds.length > 0 && !config.allowedUserIds.includes(userId)) {
@@ -531,71 +494,6 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       }
     }
 
-    // --- Thread management: AI-powered intent classification ---
-    if (isGuild && cleanContent.length < 200) {
-      const intent = await classifyThreadIntent(cleanContent);
-      if (intent && intent.action === "hire" && intent.names.length > 0) {
-        const results: string[] = [];
-        for (const threadName of intent.names) {
-          try {
-            const thread = await discordApi<{ id: string; name: string }>(
-              config.token,
-              "POST",
-              `/channels/${channelId}/threads`,
-              {
-                name: threadName,
-                type: 11, // PUBLIC_THREAD
-                auto_archive_duration: 4320, // 3 days
-              },
-            );
-            knownThreads.set(thread.id, { parentId: channelId });
-            // Don't pre-create session — let Claude CLI create it on first message
-            // The real UUID will be captured and saved by runner.ts
-            await sendMessage(config.token, thread.id, `🧵 Thread **${threadName}** created with independent session. Start chatting!`);
-            results.push(`✅ **${threadName}** → <#${thread.id}>`);
-            console.log(`[Discord] Thread created: ${thread.id} name="${threadName}" parent=${channelId} knownSize=${knownThreads.size}`);
-          } catch (err) {
-            results.push(`❌ **${threadName}** — ${err instanceof Error ? err.message : err}`);
-          }
-        }
-        await sendMessage(config.token, channelId, results.join("\n"));
-        return;
-      }
-
-      if (intent && intent.action === "fire" && intent.names.length > 0) {
-        const results: string[] = [];
-        for (const targetName of intent.names) {
-          const targetLower = targetName.toLowerCase();
-          let foundId: string | null = null;
-          for (const [tid, info] of knownThreads.entries()) {
-            if (info.parentId === channelId) {
-              try {
-                const ch = await discordApi<{ id: string; name: string }>(config.token, "GET", `/channels/${tid}`);
-                if (ch.name.toLowerCase() === targetLower) {
-                  foundId = tid;
-                  break;
-                }
-              } catch { /* thread might be gone */ }
-            }
-          }
-          if (foundId) {
-            try {
-              await removeThreadSession(foundId);
-              await discordApi(config.token, "DELETE", `/channels/${foundId}`);
-              knownThreads.delete(foundId);
-              results.push(`🗑️ **${targetName}** — deleted`);
-            } catch (err) {
-              results.push(`❌ **${targetName}** — ${err instanceof Error ? err.message : err}`);
-            }
-          } else {
-            results.push(`❌ **${targetName}** — not found`);
-          }
-        }
-        await sendMessage(config.token, channelId, results.join("\n"));
-        return;
-      }
-    }
-
     // Skill routing: detect slash commands and resolve to SKILL.md prompts
     const command = cleanContent.startsWith("/") ? cleanContent.trim().split(/\s+/, 1)[0].toLowerCase() : null;
     let skillContext: string | null = null;
@@ -635,22 +533,57 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       );
     }
 
-    const prefixedPrompt = promptParts.join("\n");
-    // Use thread-specific session if message is in a known thread
-    const threadId = knownThreads.has(channelId) ? channelId : undefined;
-    const result = await runUserMessage("discord", prefixedPrompt, threadId);
+    // Build the prompt for Claude
+    const prompt = promptParts.join("\n");
+    debugLog(`Prompt: ${prompt.slice(0, 100)}...`);
+
+    // Use v2 gateway path if enabled
+    if (process.env.USE_GATEWAY_DISCORD === "true") {
+      // Normalize the Discord message and pass through the gateway
+      const normalized = normalizeDiscordMessage(message);
+      
+      // Store the built prompt in metadata for the event processor
+      (normalized.metadata as any).prompt = prompt;
+      (normalized.metadata as any).label = label;
+
+      const gatewayResult = await processEventWithFallback(normalized, {
+        legacyHandler: async () => {
+          const legacyRes = await runUserMessage("discord", prompt);
+          return {
+            success: legacyRes.exitCode === 0,
+            exitCode: legacyRes.exitCode,
+            stdout: legacyRes.stdout,
+            stderr: legacyRes.stderr,
+          };
+        },
+      });
+      if (!gatewayResult.success) {
+        await sendMessage(config.token, channelId, `Gateway error: ${gatewayResult.error}`);
+        return;
+      }
+
+      // Deliver response back to Discord
+      if (gatewayResult.legacyResult?.stdout) {
+        const responseText = gatewayResult.legacyResult.stdout || "Done.";
+        await sendMessage(config.token, channelId, responseText);
+      } else {
+        // Gateway path - response will be delivered asynchronously via the event processor
+        await sendMessage(config.token, channelId, "Processing your request...");
+      }
+      return;
+    }
+
+    // Legacy path - run Claude directly
+    const result = await runUserMessage("discord", prompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`);
-    } else {
-      const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
-      if (reactionEmoji) {
-        await sendReaction(config.token, channelId, message.id, reactionEmoji).catch((err) => {
-          console.error(`[Discord] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
-        });
-      }
-      await sendMessage(config.token, channelId, cleanedText || "(empty response)");
+      await sendMessage(config.token, channelId, `Error: ${result.stderr || "Unknown error"}`);
+      return;
     }
+
+    // Send response back to Discord
+    const responseText = result.stdout || "Done.";
+    await sendMessage(config.token, channelId, responseText);
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     console.error(`[Discord] Error for ${label}: ${errMsg}`);
@@ -709,7 +642,6 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
         await respondToInteraction(interaction, { content: "📊 No active session." });
         return;
       }
-      const threadSessions = await listThreadSessions();
       const lines = [
         "📊 **Session Status**",
         `Session: \`${session.sessionId.slice(0, 8)}\``,
@@ -720,15 +652,6 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
         `Last used: ${session.lastUsedAt}`,
         `Compact warned: ${(session as any).compactWarned ? "yes" : "no"}`,
       ];
-      if (threadSessions.length > 0) {
-        lines.push("", `**Thread Sessions:** ${threadSessions.length}`);
-        for (const ts of threadSessions.slice(0, 5)) {
-          lines.push(`  Thread \`${ts.threadId.slice(0, 8)}\` → Session \`${ts.sessionId.slice(0, 8)}\` (${ts.turnCount} turns)`);
-        }
-        if (threadSessions.length > 5) {
-          lines.push(`  ... and ${threadSessions.length - 5} more`);
-        }
-      }
       await respondToInteraction(interaction, { content: lines.join("\n") });
       return;
     }
@@ -914,7 +837,6 @@ function resetGatewayState(): void {
   botUserId = null;
   botUsername = null;
   applicationId = null;
-  knownThreads.clear();
 }
 
 function sendIdentify(token: string): void {
@@ -965,16 +887,12 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       break;
 
     case "RESUMED":
-      console.log("[Discord] Session resumed — rejoining threads");
-      rejoinThreads(token).catch((err) =>
-        console.error(`[Discord] Failed to rejoin threads on RESUMED: ${err}`),
-      );
+      debugLog("Session resumed successfully");
       break;
 
     case "MESSAGE_CREATE":
-      console.log(`[Discord][GW] MESSAGE_CREATE ch=${data.channel_id} author=${data.author?.username} guild=${data.guild_id || 'DM'}`);
       handleMessageCreate(token, data).catch((err) =>
-        console.error(`[Discord] MESSAGE_CREATE unhandled:`, err),
+        console.error(`[Discord] MESSAGE_CREATE unhandled: ${err}`),
       );
       break;
 
@@ -985,62 +903,9 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       break;
 
     case "GUILD_CREATE":
-      // Cache active threads for multi-session support
-      if (data.threads) {
-        console.log(`[Discord] GUILD_CREATE: ${data.threads.length} active threads in guild ${data.id}`);
-        for (const thread of data.threads) {
-          knownThreads.set(thread.id, { parentId: thread.parent_id });
-          console.log(`[Discord]   thread: ${thread.id} name="${thread.name}" parent=${thread.parent_id}`);
-        }
-      } else {
-        console.log(`[Discord] GUILD_CREATE: no active threads in guild ${data.id}`);
-      }
-      // Rejoin all known threads from sessions.json so gateway sends MESSAGE_CREATE
-      rejoinThreads(token).catch((err) =>
-        console.error(`[Discord] Failed to rejoin threads: ${err}`),
-      );
       handleGuildCreate(token, data).catch((err) =>
         console.error(`[Discord] GUILD_CREATE unhandled: ${err}`),
       );
-      break;
-
-    case "THREAD_CREATE":
-      if (data.id && data.parent_id) {
-        knownThreads.set(data.id, { parentId: data.parent_id });
-        debugLog(`Thread tracked: ${data.id} (parent: ${data.parent_id})`);
-      }
-      break;
-
-    case "THREAD_DELETE":
-      if (data.id) {
-        knownThreads.delete(data.id);
-        removeThreadSession(data.id).catch((err) =>
-          console.error(`[Discord] Failed to cleanup thread session: ${err}`),
-        );
-        debugLog(`Thread removed: ${data.id}`);
-      }
-      break;
-
-    case "THREAD_UPDATE":
-      if (data.id && data.parent_id) {
-        if (data.thread_metadata?.archived) {
-          knownThreads.delete(data.id);
-          removeThreadSession(data.id).catch((err) =>
-            console.error(`[Discord] Failed to cleanup archived thread session: ${err}`),
-          );
-          debugLog(`Thread archived and cleaned up: ${data.id}`);
-        } else {
-          knownThreads.set(data.id, { parentId: data.parent_id });
-        }
-      }
-      break;
-
-    case "THREAD_LIST_SYNC":
-      if (data.threads) {
-        for (const thread of data.threads) {
-          knownThreads.set(thread.id, { parentId: thread.parent_id });
-        }
-      }
       break;
   }
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,6 +2,7 @@ import { writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
+import { initGatewayProcessor } from "../event-processor";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs } from "../jobs";
@@ -9,6 +10,7 @@ import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
 import { getDayAndMinuteAtOffset } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
+import { initializeJobSystem } from "../orchestrator/resumable-jobs";
 import type { Job } from "../jobs";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
@@ -311,6 +313,13 @@ export async function start(args: string[] = []) {
   const settings = await loadSettings();
   await ensureProjectClaudeMd();
   const jobs = await loadJobs();
+
+  // Initialize job system: wires governance adapter and resumes any pending workflows
+  const { pendingResumed, pendingFailed } = await initializeJobSystem();
+  if (pendingResumed > 0 || pendingFailed > 0) {
+    console.log(`[${new Date().toLocaleTimeString()}] Job system: ${pendingResumed} resumed, ${pendingFailed} failed`);
+  }
+
   const webEnabled = webFlag || webPortFlag !== null || settings.web.enabled;
   const webPort = webPortFlag ?? settings.web.port;
 
@@ -369,6 +378,10 @@ export async function start(args: string[] = []) {
 
   await initTelegram(currentSettings.telegram.token);
   if (!telegramToken) console.log("  Telegram: not configured");
+
+  // --- Gateway event processor ---
+  // Wire up the event processor for gateway v2 path (Discord/Telegram → event log → processor → runUserMessage)
+  await initGatewayProcessor(async (source, prompt) => runUserMessage(source, prompt));
 
   // --- Discord ---
   let discordSendToUser: ((userId: string, text: string) => Promise<void>) | null = null;
@@ -567,9 +580,11 @@ export async function start(args: string[] = []) {
         })
         .then((r) => {
           if (!r) return;
-          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.trim().startsWith("HEARTBEAT_OK");
-          if (shouldForward) {
+          const isOk = r.stdout.trim().startsWith("HEARTBEAT_OK");
+          if (currentSettings.heartbeat.forwardToTelegram || !isOk) {
             forwardToTelegram("", r);
+          }
+          if (currentSettings.heartbeat.forwardToDiscord || !isOk) {
             forwardToDiscord("", r);
           }
         });

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -8,6 +8,7 @@ import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt, listSkills } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
+import { submitTelegramToGateway } from "../gateway";
 
 // --- Markdown → Telegram HTML conversion (ported from nanobot) ---
 
@@ -172,6 +173,57 @@ interface TelegramFile {
 }
 
 let telegramDebug = false;
+
+// --- Security: Rate Limiting ---
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
+const RATE_LIMIT_MAX = 30; // 30 messages per user per minute
+const rateLimitMap = new Map<number, RateLimitEntry>();
+
+function checkRateLimit(userId: number): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+
+  if (!entry || now > entry.resetAt) {
+    rateLimitMap.set(userId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+
+  entry.count++;
+  return true;
+}
+
+// --- Security: File size limit ---
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024; // 25MB
+
+// --- Security: Filename sanitization ---
+function sanitizeFilename(name: string): string {
+  // Remove path traversal attempts and null bytes
+  const sanitized = name.replace(/\x00/g, "").replace(/\.\./g, "_");
+  // Keep only safe characters
+  const safe = sanitized.replace(/[^a-zA-Z0-9._-]/g, "_");
+  // Limit length to 255 chars
+  return safe.slice(0, 255);
+}
+
+// --- Security: Helper to fetch with size validation ---
+async function fetchWithSizeLimit(url: string): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Telegram file download failed: ${response.status} ${response.statusText}`);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.length > MAX_FILE_SIZE_BYTES) {
+    throw new Error(`File too large: ${bytes.length} bytes (max: ${MAX_FILE_SIZE_BYTES})`);
+  }
+  return bytes;
+}
 
 function debugLog(message: string): void {
   if (!telegramDebug) return;
@@ -359,15 +411,23 @@ async function sendDocumentToChat(
 
 function extractReactionDirective(text: string): { cleanedText: string; reactionEmoji: string | null } {
   let reactionEmoji: string | null = null;
-  const cleanedText = text
-    .replace(/\[react:([^\]\r\n]+)\]/gi, (_match, raw) => {
-      const candidate = String(raw).trim();
-      if (!reactionEmoji && candidate) reactionEmoji = candidate;
-      return "";
-    })
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  
+  // Step 1: Extract reaction directive
+  let cleanedText = text.replace(/\[react:([^\]\r\n]+)\]/gi, (_match, raw) => {
+    const candidate = String(raw).trim();
+    if (!reactionEmoji && candidate) reactionEmoji = candidate;
+    return "";
+  });
+  
+  // Step 2: Remove trailing whitespace before newlines
+  cleanedText = cleanedText.replace(/[ \t]+\n/g, "\n");
+  
+  // Step 3: Collapse excessive newlines
+  cleanedText = cleanedText.replace(/\n{3,}/g, "\n\n");
+  
+  // Step 4: Trim final result
+  cleanedText = cleanedText.trim();
+  
   return { cleanedText, reactionEmoji };
 }
 
@@ -433,8 +493,7 @@ async function downloadImageFromMessage(token: string, message: TelegramMessage)
 
   const remotePath = fileMeta.result.file_path;
   const downloadUrl = `${FILE_API_BASE}${token}/${remotePath}`;
-  const response = await fetch(downloadUrl);
-  if (!response.ok) throw new Error(`Telegram file download failed: ${response.status} ${response.statusText}`);
+  const bytes = await fetchWithSizeLimit(downloadUrl);
 
   const dir = join(process.cwd(), ".claude", "claudeclaw", "inbox", "telegram");
   await mkdir(dir, { recursive: true });
@@ -442,10 +501,9 @@ async function downloadImageFromMessage(token: string, message: TelegramMessage)
   const remoteExt = extname(remotePath);
   const docExt = extname(imageDocument?.file_name ?? "");
   const mimeExt = extensionFromMimeType(imageDocument?.mime_type);
-  const ext = remoteExt || docExt || mimeExt || ".jpg";
+  const ext = sanitizeFilename(remoteExt || docExt || mimeExt || ".jpg");
   const filename = `${message.chat.id}-${message.message_id}-${Date.now()}${ext}`;
   const localPath = join(dir, filename);
-  const bytes = new Uint8Array(await response.arrayBuffer());
   await Bun.write(localPath, bytes);
   return localPath;
 }
@@ -464,8 +522,7 @@ async function downloadVoiceFromMessage(token: string, message: TelegramMessage)
   debugLog(
     `Voice download: fileId=${fileId} remotePath=${remotePath} mime=${audioLike.mime_type ?? "unknown"} expectedSize=${audioLike.file_size ?? "unknown"}`
   );
-  const response = await fetch(downloadUrl);
-  if (!response.ok) throw new Error(`Telegram file download failed: ${response.status} ${response.statusText}`);
+  const bytes = await fetchWithSizeLimit(downloadUrl);
 
   const dir = join(process.cwd(), ".claude", "claudeclaw", "inbox", "telegram");
   await mkdir(dir, { recursive: true });
@@ -474,10 +531,9 @@ async function downloadVoiceFromMessage(token: string, message: TelegramMessage)
   const docExt = extname(message.document?.file_name ?? "");
   const audioExt = extname(message.audio?.file_name ?? "");
   const mimeExt = extensionFromAudioMimeType(audioLike.mime_type);
-  const ext = remoteExt || docExt || audioExt || mimeExt || ".ogg";
+  const ext = sanitizeFilename(remoteExt || docExt || audioExt || mimeExt || ".ogg");
   const filename = `${message.chat.id}-${message.message_id}-${Date.now()}${ext}`;
   const localPath = join(dir, filename);
-  const bytes = new Uint8Array(await response.arrayBuffer());
   await Bun.write(localPath, bytes);
   const header = Array.from(bytes.slice(0, 8))
     .map((b) => b.toString(16).padStart(2, "0"))
@@ -510,19 +566,15 @@ async function downloadDocumentFromMessage(
 
   const remotePath = fileMeta.result.file_path;
   const downloadUrl = `${FILE_API_BASE}${token}/${remotePath}`;
-  const response = await fetch(downloadUrl);
-  if (!response.ok) {
-    throw new Error(`Telegram file download failed: ${response.status} ${response.statusText}`);
-  }
+  const bytes = await fetchWithSizeLimit(downloadUrl);
 
   const dir = join(process.cwd(), ".claude", "claudeclaw", "inbox", "telegram");
   await mkdir(dir, { recursive: true });
 
-  const originalName = doc.file_name ?? `document${extname(remotePath) || ""}`;
-  const ext = extname(originalName) || extname(remotePath) || "";
+  const originalName = sanitizeFilename(doc.file_name ?? `document${extname(remotePath) || ""}`);
+  const ext = sanitizeFilename(extname(originalName)) || sanitizeFilename(extname(remotePath)) || "";
   const filename = `${message.chat.id}-${message.message_id}-${Date.now()}${ext}`;
   const localPath = join(dir, filename);
-  const bytes = new Uint8Array(await response.arrayBuffer());
   await Bun.write(localPath, bytes);
   return { localPath, originalName };
 }
@@ -591,6 +643,12 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   debugLog(
     `Handle message chat=${chatId} type=${chatType} from=${userId ?? "unknown"} reason=${triggerReason} text="${(text ?? "").slice(0, 80)}"`
   );
+
+  // Security: Rate limit check
+  if (userId && !checkRateLimit(userId)) {
+    debugLog(`Rate limited: userId=${userId}`);
+    return;
+  }
 
   if (userId && config.allowedUserIds.length > 0 && !config.allowedUserIds.includes(userId)) {
     if (isPrivate) {
@@ -831,33 +889,28 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
         "The user attached a document, but downloading it failed. Respond and ask them to resend."
       );
     }
-    const prefixedPrompt = promptParts.join("\n");
-    const result = await runUserMessage("telegram", prefixedPrompt);
-
-    if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+    // Check per-adapter feature flag for gateway routing
+    if (process.env.USE_GATEWAY_TELEGRAM === "true") {
+      const gatewayResult = await submitTelegramToGateway(message);
+      if (!gatewayResult.success) {
+        await sendMessage(config.token, chatId, `Gateway error: ${gatewayResult.error}`, threadId);
+        return;
+      }
+      // Gateway processed successfully - response handled by processor
+      return;
     } else {
-      const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
-      const { cleanedText, filePaths } = extractSendFileDirectives(afterReact);
-      if (reactionEmoji) {
-        await sendReaction(config.token, chatId, message.message_id, reactionEmoji).catch((err) => {
-          console.error(`[Telegram] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
-        });
+      // Legacy path - direct Claude invocation
+      const prompt = promptParts.join("\n");
+      const result = await runUserMessage("telegram", prompt);
+
+      if (result.exitCode !== 0) {
+        await sendMessage(config.token, chatId, `Error: ${result.stderr || "Unknown error"}`, threadId);
+        return;
       }
-      if (cleanedText) {
-        await sendMessage(config.token, chatId, cleanedText, threadId);
-      }
-      for (const fp of filePaths) {
-        try {
-          await sendDocumentToChat(config.token, chatId, fp, threadId);
-        } catch (err) {
-          console.error(`[Telegram] Failed to send document for ${label}: ${err instanceof Error ? err.message : err}`);
-          await sendMessage(config.token, chatId, `Failed to send file: ${fp.split("/").pop()}`, threadId);
-        }
-      }
-      if (!cleanedText && filePaths.length === 0) {
-        await sendMessage(config.token, chatId, "(empty response)", threadId);
-      }
+
+      const responseText = result.stdout || "Done.";
+      await sendMessage(config.token, chatId, responseText, threadId);
+      return;
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
@@ -883,7 +936,13 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
     try {
       const resp = await fetch(`http://127.0.0.1:9999/confirm/${pendingId}/${action}`);
       const result = await resp.json() as { ok: boolean };
-      answerText = action === "yes" && result.ok ? "✅ Đã gửi!" : result.ok ? "❌ Dismissed" : "⚠️ Not found";
+      if (action === "yes" && result.ok) {
+        answerText = "✅ Đã gửi!";
+      } else if (result.ok) {
+        answerText = "❌ Dismissed";
+      } else {
+        answerText = "⚠️ Not found";
+      }
       if (query.message) {
         const statusLine = action === "yes" ? "\n\n✅ Sent" : "\n\n❌ Dismissed";
         const newText = (query.message.text ?? "").replace(/\n\nReply:.*$/s, statusLine);

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,7 @@ const DEFAULT_SETTINGS: Settings = {
     prompt: "",
     excludeWindows: [],
     forwardToTelegram: true,
+    forwardToDiscord: true,
   },
   telegram: { token: "", allowedUserIds: [] },
   discord: { token: "", allowedUserIds: [], listenChannels: [] },
@@ -75,6 +76,7 @@ export interface HeartbeatConfig {
   prompt: string;
   excludeWindows: HeartbeatExcludeWindow[];
   forwardToTelegram: boolean;
+  forwardToDiscord: boolean;
 }
 
 export interface TelegramConfig {
@@ -217,7 +219,7 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)
@@ -242,6 +244,7 @@ function parseSettings(raw: Record<string, any>): Settings {
       prompt: raw.heartbeat?.prompt ?? "",
       excludeWindows: parseExcludeWindows(raw.heartbeat?.excludeWindows),
       forwardToTelegram: raw.heartbeat?.forwardToTelegram ?? false,
+      forwardToDiscord: raw.heartbeat?.forwardToDiscord ?? true,
     },
     telegram: {
       token: raw.telegram?.token ?? "",
@@ -249,7 +252,9 @@ function parseSettings(raw: Record<string, any>): Settings {
     },
     discord: {
       token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
-      allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
+      allowedUserIds: discordUserIds && discordUserIds.length > 0
+        ? discordUserIds
+        : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)

--- a/src/dead-letter-queue.ts
+++ b/src/dead-letter-queue.ts
@@ -1,0 +1,390 @@
+/**
+ * Dead Letter Queue (DLQ)
+ * 
+ * Captures permanently failed events with full failure provenance.
+ * 
+ * DESIGN:
+ * - DLQ entries stored in .claude/claudeclaw/dlq.jsonl
+ * - Each entry contains full event + retry history + final error
+ * - Supports replay back to the event log for reprocessing
+ * - CLI commands: dlq list, dlq replay <id>
+ * 
+ * ENTRY SCHEMA:
+ * {
+ *   id,                    // DLQ entry ID (unique)
+ *   originalEventId,       // Reference to original event
+ *   originalSeq,
+ *   event,                 // Full event record snapshot
+ *   retryHistory,          // Array of retry attempts
+ *   firstFailureAt,        // When processing first failed
+ *   lastFailureAt,         // When moved to DLQ
+ *   finalError,            // Last error message
+ *   errorType,             // Error classification if available
+ *   deadLetteredAt,        // When moved to DLQ
+ *   replayCount,           // How many times replayed
+ *   replayHistory          // Array of replay attempts
+ * }
+ */
+
+import { join } from "path";
+import { mkdir, appendFile } from "fs/promises";
+import { randomUUID } from "crypto";
+import {
+  initEventLog,
+  append,
+  readFrom,
+  type EventRecord,
+} from "./event-log";
+
+const DLQ_DIR = join(process.cwd(), ".claude", "claudeclaw", "dlq");
+const DLQ_FILE = join(DLQ_DIR, "dlq.jsonl");
+
+interface RetryAttempt {
+  attempt: number;
+  error: string;
+  timestamp: string;
+}
+
+interface ReplayAttempt {
+  replayedAt: string;
+  newEventId: string;
+  newSeq: number;
+}
+
+export interface DLQEntry {
+  id: string;
+  originalEventId: string;
+  originalSeq: number;
+  event: EventRecord;
+  retryHistory: RetryAttempt[];
+  firstFailureAt: string;
+  lastFailureAt: string;
+  finalError: string;
+  errorType: string | null;
+  deadLetteredAt: string;
+  replayCount: number;
+  replayHistory: ReplayAttempt[];
+}
+
+let dlqEntries: DLQEntry[] = [];
+let isInitialized = false;
+
+/**
+ * Initialize the DLQ.
+ */
+export async function initDLQ(): Promise<void> {
+  if (isInitialized) return;
+  
+  await initEventLog();
+  await mkdir(DLQ_DIR, { recursive: true });
+  
+  // Load existing DLQ entries
+  await loadDLQ();
+  
+  isInitialized = true;
+}
+
+/**
+ * Load DLQ entries from disk.
+ */
+async function loadDLQ(): Promise<void> {
+  dlqEntries = [];
+  
+  try {
+    const content = await Bun.file(DLQ_FILE).text();
+    const lines = content.trim().split("\n").filter(l => l.trim());
+    
+    for (const line of lines) {
+      try {
+        const entry = JSON.parse(line) as DLQEntry;
+        dlqEntries.push(entry);
+      } catch {
+        // Skip corrupted lines
+      }
+    }
+  } catch {
+    // File doesn't exist yet, that's fine
+  }
+}
+
+/**
+ * Save a DLQ entry to disk.
+ */
+async function saveDLQEntry(entry: DLQEntry): Promise<void> {
+  const line = JSON.stringify(entry) + "\n";
+
+  try {
+    // Use appendFile for O(1) additions instead of read-whole-file + write-whole-file
+    await appendFile(DLQ_FILE, line);
+  } catch (err) {
+    console.error("[dlq] Failed to save DLQ entry:", err);
+    throw err;
+  }
+}
+
+/**
+ * Move an event to the DLQ.
+ * Called when max retries are exceeded.
+ */
+export async function enqueue(
+  event: EventRecord,
+  retryHistory: RetryAttempt[],
+  finalError: string,
+  errorType?: string
+): Promise<DLQEntry> {
+  await initDLQ();
+
+  const entry: DLQEntry = {
+    id: randomUUID(),
+    originalEventId: event.id,
+    originalSeq: event.seq,
+    event: { ...event }, // Snapshot of event at time of failure
+    retryHistory: [...retryHistory],
+    firstFailureAt: retryHistory[0]?.timestamp ?? new Date().toISOString(),
+    lastFailureAt: new Date().toISOString(),
+    finalError,
+    errorType: errorType ?? null,
+    deadLetteredAt: new Date().toISOString(),
+    replayCount: 0,
+    replayHistory: [],
+  };
+
+  // Add to in-memory array
+  dlqEntries.push(entry);
+  
+  // Persist to disk
+  await saveDLQEntry(entry);
+
+  console.log(
+    `[dlq] Event ${event.id} (seq ${event.seq}) moved to DLQ: ${finalError}`
+  );
+
+  return entry;
+}
+
+/**
+ * List all DLQ entries, most recent first.
+ */
+export function list(): DLQEntry[] {
+  return [...dlqEntries].reverse();
+}
+
+/**
+ * List DLQ entries with pagination.
+ */
+export function listPaginated(
+  page: number = 1,
+  pageSize: number = 20
+): { entries: DLQEntry[]; total: number; page: number; totalPages: number } {
+  const total = dlqEntries.length;
+  const totalPages = Math.ceil(total / pageSize);
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  
+  return {
+    entries: [...dlqEntries].reverse().slice(start, end),
+    total,
+    page,
+    totalPages,
+  };
+}
+
+/**
+ * Find a DLQ entry by ID.
+ */
+export function findById(id: string): DLQEntry | null {
+  return dlqEntries.find(e => e.id === id) ?? null;
+}
+
+/**
+ * Find a DLQ entry by original event ID.
+ */
+export function findByEventId(eventId: string): DLQEntry | null {
+  return dlqEntries.find(e => e.originalEventId === eventId) ?? null;
+}
+
+/**
+ * Replay a DLQ entry back to the event log.
+ * Creates a new event with replay provenance.
+ */
+export async function replay(dlqEntryId: string): Promise<EventRecord | null> {
+  await initDLQ();
+  
+  const entry = findById(dlqEntryId);
+  if (!entry) {
+    throw new Error(`DLQ entry ${dlqEntryId} not found`);
+  }
+
+  // Create new event from DLQ entry
+  const { append } = await import("./event-log");
+  
+  const newEvent = await append({
+    type: entry.event.type,
+    source: entry.event.source,
+    channelId: entry.event.channelId,
+    threadId: entry.event.threadId,
+    payload: entry.event.payload,
+    dedupeKey: entry.event.dedupeKey,
+    correlationId: entry.event.correlationId,
+    causationId: entry.event.id, // Original event is the causation
+    replayedFromEventId: entry.event.id,
+  });
+
+  // Update DLQ entry with replay history
+  entry.replayCount++;
+  entry.replayHistory.push({
+    replayedAt: new Date().toISOString(),
+    newEventId: newEvent.id,
+    newSeq: newEvent.seq,
+  });
+
+  // Update the entry in the file (rewrite entire file - DLQ should be small)
+  await rewriteDLQFile();
+
+  console.log(
+    `[dlq] Replayed event ${entry.originalEventId} as ${newEvent.id} (seq ${newEvent.seq})`
+  );
+
+  return newEvent;
+}
+
+/**
+ * Replay all DLQ entries.
+ * Returns count of replayed events.
+ */
+export async function replayAll(): Promise<number> {
+  await initDLQ();
+  
+  let count = 0;
+  for (const entry of dlqEntries) {
+    try {
+      await replay(entry.id);
+      count++;
+    } catch (err) {
+      console.error(`[dlq] Failed to replay ${entry.id}:`, err);
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Remove an entry from the DLQ.
+ * Useful for manual cleanup after investigation.
+ */
+export async function remove(dlqEntryId: string): Promise<void> {
+  await initDLQ();
+  
+  const index = dlqEntries.findIndex(e => e.id === dlqEntryId);
+  if (index === -1) {
+    throw new Error(`DLQ entry ${dlqEntryId} not found`);
+  }
+
+  dlqEntries.splice(index, 1);
+  await rewriteDLQFile();
+
+  console.log(`[dlq] Removed entry ${dlqEntryId}`);
+}
+
+/**
+ * Rewrite the entire DLQ file.
+ * Used after updates that modify entries.
+ */
+async function rewriteDLQFile(): Promise<void> {
+  const lines = dlqEntries.map(e => JSON.stringify(e)).join("\n") + "\n";
+  await Bun.write(DLQ_FILE, lines);
+}
+
+/**
+ * Get DLQ statistics.
+ */
+export function getStats(): {
+  totalEntries: number;
+  totalReplays: number;
+  oldestEntry: string | null;
+  newestEntry: string | null;
+} {
+  if (dlqEntries.length === 0) {
+    return {
+      totalEntries: 0,
+      totalReplays: 0,
+      oldestEntry: null,
+      newestEntry: null,
+    };
+  }
+
+  const sorted = [...dlqEntries].sort(
+    (a, b) => new Date(a.deadLetteredAt).getTime() - new Date(b.deadLetteredAt).getTime()
+  );
+
+  const totalReplays = dlqEntries.reduce((sum, e) => sum + e.replayCount, 0);
+
+  return {
+    totalEntries: dlqEntries.length,
+    totalReplays,
+    oldestEntry: sorted[0].deadLetteredAt,
+    newestEntry: sorted[sorted.length - 1].deadLetteredAt,
+  };
+}
+
+/**
+ * Clear all DLQ entries (use with caution).
+ */
+export async function clear(): Promise<void> {
+  await initDLQ();
+  
+  dlqEntries = [];
+  await Bun.write(DLQ_FILE, "");
+  
+  console.log("[dlq] Cleared all entries");
+}
+
+/**
+ * Reset DLQ state (for testing).
+ */
+export async function resetDLQ(): Promise<void> {
+  dlqEntries = [];
+  isInitialized = false;
+}
+
+/**
+ * Scan the event log for dead_lettered events and sync to DLQ.
+ * Useful for rebuilding DLQ state from event log.
+ */
+export async function syncFromEventLog(): Promise<number> {
+  await initDLQ();
+  await initEventLog();
+
+  let added = 0;
+
+  for await (const event of readFrom(1)) {
+    if (event.status === "dead_lettered") {
+      // Check if already in DLQ
+      const exists = findByEventId(event.id);
+      if (!exists) {
+        // Create synthetic DLQ entry
+        const entry: DLQEntry = {
+          id: randomUUID(),
+          originalEventId: event.id,
+          originalSeq: event.seq,
+          event: { ...event },
+          retryHistory: [],
+          firstFailureAt: event.updatedAt,
+          lastFailureAt: event.updatedAt,
+          finalError: event.lastError ?? "Unknown error",
+          errorType: null,
+          deadLetteredAt: event.updatedAt,
+          replayCount: 0,
+          replayHistory: [],
+        };
+
+        dlqEntries.push(entry);
+        await saveDLQEntry(entry);
+        added++;
+      }
+    }
+  }
+
+  console.log(`[dlq] Synced ${added} entries from event log`);
+  return added;
+}

--- a/src/escalation/handoff.ts
+++ b/src/escalation/handoff.ts
@@ -1,0 +1,598 @@
+/**
+ * Handoff Manager
+ * 
+ * Create durable, reviewable handoff packages from workflow/session/event context.
+ * 
+ * DESIGN:
+ * - Handoff packages stored at .claude/claudeclaw/handoffs/
+ * - Each handoff is a durable snapshot for human review
+ * - References workflow/task/session/event context accurately
+ * - Supports create, get, list, accept, and close operations
+ * - Handoff acceptance modeled explicitly
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - Handoff records are persisted immediately
+ * - State survives restart
+ * - No in-memory-only handoff data
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { log as logAudit } from "../policy/audit-log";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type HandoffSeverity = "info" | "warning" | "critical";
+export type HandoffStatus = "open" | "accepted" | "closed";
+
+export interface PendingEvent {
+  eventId: string;
+  type: string;
+  status: string;
+}
+
+export interface HandoffPackage {
+  handoffId: string;
+  createdAt: string;
+  reason: string;
+  severity: HandoffSeverity;
+  status: HandoffStatus;
+  workflowIds?: string[];
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  source?: string;
+  channelId?: string;
+  threadId?: string;
+  relatedEventIds?: string[];
+  pendingTasks?: string[];
+  pendingApprovals?: string[];
+  pendingEvents?: PendingEvent[];
+  summary: string;
+  attachments?: string[];
+  metadata?: Record<string, unknown>;
+  
+  // Lifecycle tracking
+  acceptedAt?: string;
+  acceptedBy?: string;
+  closedAt?: string;
+  closedBy?: string;
+  resolution?: string;
+}
+
+export interface HandoffContext {
+  workflowIds?: string[];
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  source?: string;
+  channelId?: string;
+  threadId?: string;
+  relatedEventIds?: string[];
+  pendingTasks?: string[];
+  pendingApprovals?: string[];
+  pendingEvents?: PendingEvent[];
+}
+
+export interface CreateHandoffOptions {
+  severity?: HandoffSeverity;
+  summary?: string;
+  attachments?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface AcceptHandoffOptions {
+  acceptedBy?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CloseHandoffOptions {
+  closedBy?: string;
+  resolution?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HandoffFilters {
+  status?: HandoffStatus;
+  severity?: HandoffSeverity;
+  source?: string;
+  sessionId?: string;
+  workflowId?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const HANDOFFS_DIR = join(ESCALATION_DIR, "handoffs");
+const HANDOFF_INDEX_FILE = join(HANDOFFS_DIR, "index.json");
+const HANDOFF_ACTIONS_FILE = join(ESCALATION_DIR, "handoff-actions.jsonl");
+
+interface HandoffIndex {
+  version: number;
+  handoffs: Record<string, HandoffSummary>;
+  updatedAt: string;
+}
+
+interface HandoffSummary {
+  handoffId: string;
+  createdAt: string;
+  reason: string;
+  severity: HandoffSeverity;
+  status: HandoffStatus;
+  source?: string;
+  sessionId?: string;
+  closedAt?: string;
+}
+
+interface HandoffAction {
+  actionId: string;
+  handoffId: string;
+  action: "create" | "accept" | "close" | "update";
+  actor: string;
+  timestamp: string;
+  details?: Record<string, unknown>;
+}
+
+// In-memory cache (source of truth is always the files)
+let handoffIndex: HandoffIndex | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+/**
+ * Initialize the handoff manager.
+ * Ensures directories exist and loads initial index.
+ */
+export async function initHandoffManager(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directories exist
+  await mkdir(ESCALATION_DIR, { recursive: true });
+  await mkdir(HANDOFFS_DIR, { recursive: true });
+
+  // Try to load existing index
+  handoffIndex = await loadHandoffIndex();
+
+  // If no index exists, create default
+  if (!handoffIndex) {
+    handoffIndex = {
+      version: 1,
+      handoffs: {},
+      updatedAt: new Date().toISOString(),
+    };
+    await saveHandoffIndex();
+  }
+}
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Create a new handoff package.
+ * 
+ * @param reason - The reason for creating the handoff
+ * @param context - Context including workflow/session/event references
+ * @param options - Additional options including severity and summary
+ * @returns The created handoff package
+ */
+export async function createHandoff(
+  reason: string,
+  context: HandoffContext = {},
+  options: CreateHandoffOptions = {}
+): Promise<HandoffPackage> {
+  await initHandoffManager();
+
+  const now = new Date().toISOString();
+  const handoffId = randomUUID();
+
+  const handoff: HandoffPackage = {
+    handoffId,
+    createdAt: now,
+    reason,
+    severity: options.severity || "info",
+    status: "open",
+    workflowIds: context.workflowIds,
+    sessionId: context.sessionId,
+    claudeSessionId: context.claudeSessionId,
+    source: context.source,
+    channelId: context.channelId,
+    threadId: context.threadId,
+    relatedEventIds: context.relatedEventIds,
+    pendingTasks: context.pendingTasks,
+    pendingApprovals: context.pendingApprovals,
+    pendingEvents: context.pendingEvents,
+    summary: options.summary || reason,
+    attachments: options.attachments,
+    metadata: options.metadata,
+  };
+
+  // Persist handoff package
+  await saveHandoffPackage(handoff);
+
+  // Update index
+  handoffIndex!.handoffs[handoffId] = {
+    handoffId,
+    createdAt: now,
+    reason,
+    severity: handoff.severity,
+    status: "open",
+    source: context.source,
+    sessionId: context.sessionId,
+  };
+  await saveHandoffIndex();
+
+  // Record action
+  await recordHandoffAction({
+    actionId: randomUUID(),
+    handoffId,
+    action: "create",
+    actor: "system",
+    timestamp: now,
+    details: { severity: handoff.severity, source: context.source },
+  });
+
+  // Log to audit log
+  await logAudit({
+    timestamp: now,
+    eventId: `handoff-${handoffId}`,
+    requestId: handoffId,
+    source: context.source || "escalation",
+    toolName: "HandoffManager",
+    action: "require_approval",
+    reason: `Handoff created: ${reason}`,
+    metadata: {
+      handoffId,
+      severity: handoff.severity,
+      sessionId: context.sessionId,
+      workflowIds: context.workflowIds,
+    },
+  });
+
+  console.log(`[handoff] Created handoff ${handoffId}: ${reason} (${handoff.severity})`);
+
+  return handoff;
+}
+
+/**
+ * Get a handoff package by ID.
+ * 
+ * @param handoffId - The handoff ID
+ * @returns The handoff package or null if not found
+ */
+export async function getHandoff(handoffId: string): Promise<HandoffPackage | null> {
+  await initHandoffManager();
+
+  return await loadHandoffPackage(handoffId);
+}
+
+/**
+ * List handoffs with optional filters.
+ * 
+ * @param filters - Optional filters for status, severity, source, etc.
+ * @returns Array of matching handoff summaries
+ */
+export async function listHandoffs(filters: HandoffFilters = {}): Promise<HandoffSummary[]> {
+  await initHandoffManager();
+
+  let handoffs = Object.values(handoffIndex!.handoffs);
+
+  // Apply filters
+  if (filters.status) {
+    handoffs = handoffs.filter(h => h.status === filters.status);
+  }
+
+  if (filters.severity) {
+    handoffs = handoffs.filter(h => h.severity === filters.severity);
+  }
+
+  if (filters.source) {
+    handoffs = handoffs.filter(h => h.source === filters.source);
+  }
+
+  if (filters.sessionId) {
+    handoffs = handoffs.filter(h => h.sessionId === filters.sessionId);
+  }
+
+  if (filters.workflowId) {
+    handoffs = handoffs.filter(h => 
+      h.handoffId === filters.workflowId // For now, direct ID match
+    );
+  }
+
+  if (filters.createdAfter) {
+    handoffs = handoffs.filter(h => h.createdAt >= filters.createdAfter!);
+  }
+
+  if (filters.createdBefore) {
+    handoffs = handoffs.filter(h => h.createdAt <= filters.createdBefore!);
+  }
+
+  // Sort by createdAt descending (newest first)
+  handoffs.sort((a, b) => 
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  return handoffs;
+}
+
+/**
+ * Accept a handoff.
+ * Marks the handoff as accepted by an operator.
+ * 
+ * @param handoffId - The handoff ID
+ * @param options - Accept options including actor and metadata
+ * @returns The updated handoff package or null if not found
+ */
+export async function acceptHandoff(
+  handoffId: string,
+  options: AcceptHandoffOptions = {}
+): Promise<HandoffPackage | null> {
+  await initHandoffManager();
+
+  const handoff = await loadHandoffPackage(handoffId);
+  if (!handoff) {
+    return null;
+  }
+
+  // Can only accept open handoffs
+  if (handoff.status !== "open") {
+    console.warn(`[handoff] Cannot accept handoff ${handoffId}: status is ${handoff.status}`);
+    return handoff;
+  }
+
+  const now = new Date().toISOString();
+
+  // Update handoff
+  handoff.status = "accepted";
+  handoff.acceptedAt = now;
+  handoff.acceptedBy = options.acceptedBy || "operator";
+  
+  if (options.metadata) {
+    handoff.metadata = { ...handoff.metadata, ...options.metadata };
+  }
+
+  // Persist changes
+  await saveHandoffPackage(handoff);
+
+  // Update index
+  handoffIndex!.handoffs[handoffId].status = "accepted";
+  await saveHandoffIndex();
+
+  // Record action
+  await recordHandoffAction({
+    actionId: randomUUID(),
+    handoffId,
+    action: "accept",
+    actor: handoff.acceptedBy,
+    timestamp: now,
+  });
+
+  // Log to audit log
+  await logAudit({
+    timestamp: now,
+    eventId: `handoff-accept-${handoffId}`,
+    requestId: handoffId,
+    source: "escalation",
+    toolName: "HandoffManager",
+    action: "approved",
+    reason: `Handoff accepted: ${handoff.reason}`,
+    operatorId: handoff.acceptedBy,
+    metadata: { handoffId },
+  });
+
+  console.log(`[handoff] Accepted handoff ${handoffId} by ${handoff.acceptedBy}`);
+
+  return handoff;
+}
+
+/**
+ * Close a handoff.
+ * Marks the handoff as closed with an optional resolution.
+ * 
+ * @param handoffId - The handoff ID
+ * @param options - Close options including actor, resolution, and metadata
+ * @returns The updated handoff package or null if not found
+ */
+export async function closeHandoff(
+  handoffId: string,
+  options: CloseHandoffOptions = {}
+): Promise<HandoffPackage | null> {
+  await initHandoffManager();
+
+  const handoff = await loadHandoffPackage(handoffId);
+  if (!handoff) {
+    return null;
+  }
+
+  // Can close from any status
+  const now = new Date().toISOString();
+
+  // Update handoff
+  handoff.status = "closed";
+  handoff.closedAt = now;
+  handoff.closedBy = options.closedBy || "operator";
+  handoff.resolution = options.resolution;
+  
+  if (options.metadata) {
+    handoff.metadata = { ...handoff.metadata, ...options.metadata };
+  }
+
+  // Persist changes
+  await saveHandoffPackage(handoff);
+
+  // Update index
+  handoffIndex!.handoffs[handoffId].status = "closed";
+  handoffIndex!.handoffs[handoffId].closedAt = now;
+  await saveHandoffIndex();
+
+  // Record action
+  await recordHandoffAction({
+    actionId: randomUUID(),
+    handoffId,
+    action: "close",
+    actor: handoff.closedBy,
+    timestamp: now,
+    details: { resolution: options.resolution },
+  });
+
+  // Log to audit log
+  await logAudit({
+    timestamp: now,
+    eventId: `handoff-close-${handoffId}`,
+    requestId: handoffId,
+    source: "escalation",
+    toolName: "HandoffManager",
+    action: "allow",
+    reason: `Handoff closed: ${options.resolution || "No resolution provided"}`,
+    operatorId: handoff.closedBy,
+    metadata: { handoffId, resolution: options.resolution },
+  });
+
+  console.log(`[handoff] Closed handoff ${handoffId} by ${handoff.closedBy}`);
+
+  return handoff;
+}
+
+// ============================================================================
+// Statistics
+// ============================================================================
+
+/**
+ * Get handoff statistics.
+ */
+export async function getHandoffStats(): Promise<{
+  total: number;
+  byStatus: Record<HandoffStatus, number>;
+  bySeverity: Record<HandoffSeverity, number>;
+  openCritical: number;
+}> {
+  await initHandoffManager();
+
+  const handoffs = Object.values(handoffIndex!.handoffs);
+  
+  const byStatus: Record<HandoffStatus, number> = { open: 0, accepted: 0, closed: 0 };
+  const bySeverity: Record<HandoffSeverity, number> = { info: 0, warning: 0, critical: 0 };
+  
+  let openCritical = 0;
+
+  for (const h of handoffs) {
+    byStatus[h.status] = (byStatus[h.status] || 0) + 1;
+    bySeverity[h.severity] = (bySeverity[h.severity] || 0) + 1;
+    
+    if (h.status === "open" && h.severity === "critical") {
+      openCritical++;
+    }
+  }
+
+  return {
+    total: handoffs.length,
+    byStatus,
+    bySeverity,
+    openCritical,
+  };
+}
+
+// ============================================================================
+// Internal Functions
+// ============================================================================
+
+async function loadHandoffIndex(): Promise<HandoffIndex | null> {
+  try {
+    if (!existsSync(HANDOFF_INDEX_FILE)) {
+      return null;
+    }
+
+    const content = await readFile(HANDOFF_INDEX_FILE, "utf8");
+    const parsed = JSON.parse(content);
+
+    if (parsed.version === 1 && typeof parsed.handoffs === "object") {
+      return parsed as HandoffIndex;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveHandoffIndex(): Promise<void> {
+  if (!handoffIndex) return;
+
+  handoffIndex.updatedAt = new Date().toISOString();
+  await writeFile(HANDOFF_INDEX_FILE, JSON.stringify(handoffIndex, null, 2) + "\n", "utf8");
+}
+
+function getHandoffFilePath(handoffId: string): string {
+  return join(HANDOFFS_DIR, `${handoffId}.json`);
+}
+
+async function loadHandoffPackage(handoffId: string): Promise<HandoffPackage | null> {
+  try {
+    const filePath = getHandoffFilePath(handoffId);
+    
+    if (!existsSync(filePath)) {
+      return null;
+    }
+
+    const content = await readFile(filePath, "utf8");
+    return JSON.parse(content) as HandoffPackage;
+  } catch {
+    return null;
+  }
+}
+
+async function saveHandoffPackage(handoff: HandoffPackage): Promise<void> {
+  const filePath = getHandoffFilePath(handoff.handoffId);
+  await writeFile(filePath, JSON.stringify(handoff, null, 2) + "\n", "utf8");
+}
+
+async function recordHandoffAction(action: HandoffAction): Promise<void> {
+  const line = JSON.stringify(action) + "\n";
+  
+  let existingContent = "";
+  try {
+    if (existsSync(HANDOFF_ACTIONS_FILE)) {
+      existingContent = await readFile(HANDOFF_ACTIONS_FILE, "utf8");
+    }
+  } catch {
+    // File doesn't exist yet
+  }
+
+  await writeFile(HANDOFF_ACTIONS_FILE, existingContent + line, "utf8");
+}
+
+// ============================================================================
+// Testing Helpers
+// ============================================================================
+
+/**
+ * Reset the handoff manager (for testing only).
+ */
+export async function resetHandoffManager(): Promise<void> {
+  handoffIndex = null;
+  initializationPromise = null;
+}
+
+/**
+ * Clear the handoff manager cache without modifying state (for testing only).
+ */
+export function clearHandoffCache(): void {
+  handoffIndex = null;
+  initializationPromise = null;
+}

--- a/src/escalation/index.ts
+++ b/src/escalation/index.ts
@@ -1,0 +1,136 @@
+/**
+ * Escalation Module
+ * 
+ * Human escalation and operator intervention for ClaudeClaw.
+ * 
+ * This module provides:
+ * - Pause/resume control for system intake and scheduling
+ * - Structured handoff packages for human review
+ * - Escalation notifications with rate limiting
+ * - Trigger integration for policy, watchdog, and DLQ events
+ * - Status views for operator dashboards
+ * 
+ * @example
+ * ```typescript
+ * import { pause, resume, createHandoff, notify, handleEscalationTrigger, getEscalationStatus } from "./escalation";
+ * 
+ * // Pause the system
+ * await pause("admission_only", { reason: "Maintenance window" });
+ * 
+ * // Create a handoff for human review
+ * await createHandoff("Needs operator review", { workflowId: "wf-123" });
+ * 
+ * // Send escalation notification
+ * await notify("watchdog", "warning", "Watchdog triggered");
+ * 
+ * // Handle an escalation trigger
+ * await handleEscalationTrigger({
+ *   source: "policy_denial",
+ *   severity: "critical",
+ *   message: "Tool execution denied"
+ * });
+ * 
+ * // Get current status
+ * const status = await getEscalationStatus();
+ * ```
+ */
+
+// Pause Controller
+export {
+  initPauseController,
+  pause,
+  resume,
+  getPauseState,
+  isPaused,
+  shouldBlockAdmission,
+  shouldBlockScheduling,
+  getPauseHistory,
+  resetPauseController,
+  clearPauseCache,
+  type PauseMode,
+  type PauseState,
+  type PauseAction,
+  type PauseOptions,
+  type ResumeOptions,
+} from "./pause";
+
+// Handoff Manager
+export {
+  initHandoffManager,
+  createHandoff,
+  getHandoff,
+  listHandoffs,
+  acceptHandoff,
+  closeHandoff,
+  getHandoffStats,
+  resetHandoffManager,
+  clearHandoffCache,
+  type HandoffPackage,
+  type HandoffContext,
+  type HandoffSeverity,
+  type HandoffStatus,
+  type CreateHandoffOptions,
+  type AcceptHandoffOptions,
+  type CloseHandoffOptions,
+  type HandoffFilters,
+  type PendingEvent,
+} from "./handoff";
+
+// Notification Manager
+export {
+  initNotificationManager,
+  notify,
+  listNotifications,
+  getNotification,
+  configure,
+  getConfig,
+  retryDelivery,
+  getNotificationStats,
+  resetNotificationManager,
+  clearNotificationCache,
+  type NotificationType,
+  type NotificationSeverity,
+  type EscalationNotification,
+  type NotificationDelivery,
+  type EscalationConfig,
+  type NotificationFilters,
+} from "./notifications";
+
+// Trigger Integration
+export {
+  handleEscalationTrigger,
+  shouldPause,
+  shouldCreateHandoff,
+  shouldNotify,
+  configureEscalationPolicy,
+  getEscalationPolicy,
+  resetEscalationPolicy,
+  handlePolicyDenial,
+  handleWatchdogTrigger,
+  handleDlqOverflow,
+  handleOrchestrationFailure,
+  handleManualEscalation,
+  resetTriggerIntegration,
+  getFailureCounts,
+  clearFailureCount,
+  type TriggerSource,
+  type TriggerContext,
+  type EscalationAction,
+  type EscalationPolicy,
+} from "./triggers";
+
+// Status View
+export {
+  getEscalationStatus,
+  getEscalationSummary,
+  requiresAttention,
+  formatStatus,
+  exportStatusAsJson,
+  type EscalationStatus,
+  type PauseStatus,
+  type HandoffSummary,
+  type NotificationSummary,
+  type EscalationActionSummary,
+  type EscalationSummary,
+  type StatusFilters,
+} from "./status";

--- a/src/escalation/notifications.ts
+++ b/src/escalation/notifications.ts
@@ -1,0 +1,709 @@
+/**
+ * Notification Manager
+ * 
+ * Generate durable escalation notifications and support clean delivery abstractions.
+ * 
+ * DESIGN:
+ * - Notification records stored durably at .claude/claudeclaw/notifications/
+ * - Supports triggers: DLQ overflow, watchdog, policy denial, errors, manual escalation, pause/resume
+ * - Rate limiting and deduplication to prevent spam
+ * - Delivery abstraction supports webhook/email skeletons
+ * - Notification record is canonical; delivery is best-effort
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All notifications are persisted immediately
+ * - Delivery failure does not erase the notification record
+ * - Rate limiting state survives restart
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { log as logAudit } from "../policy/audit-log";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type NotificationType =
+  | "dlq_overflow"
+  | "watchdog"
+  | "policy_denial"
+  | "error"
+  | "manual_escalation"
+  | "pause"
+  | "resume";
+
+export type NotificationSeverity = "info" | "warning" | "critical";
+
+export interface EscalationNotification {
+  notificationId: string;
+  type: NotificationType;
+  severity: NotificationSeverity;
+  createdAt: string;
+  eventId?: string;
+  workflowId?: string;
+  sessionId?: string;
+  message: string;
+  details?: Record<string, unknown>;
+  delivery?: NotificationDelivery;
+}
+
+export interface NotificationDelivery {
+  attempted: boolean;
+  delivered?: boolean;
+  channel?: string;
+  error?: string;
+  attemptedAt?: string;
+  deliveredAt?: string;
+}
+
+export interface EscalationConfig {
+  webhookUrl?: string;
+  emailTarget?: string;
+  rateLimits?: {
+    perTypePerMinute?: number;
+    perSeverityPerMinute?: number;
+  };
+  enabledTypes?: NotificationType[];
+  minSeverity?: NotificationSeverity;
+}
+
+export interface NotificationFilters {
+  type?: NotificationType;
+  severity?: NotificationSeverity;
+  eventId?: string;
+  workflowId?: string;
+  sessionId?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  undeliveredOnly?: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const NOTIFICATIONS_DIR = join(ESCALATION_DIR, "notifications");
+const RATE_LIMIT_FILE = join(ESCALATION_DIR, "notification-rate-limits.json");
+const CONFIG_FILE = join(ESCALATION_DIR, "notification-config.json");
+
+const DEFAULT_RATE_LIMITS = {
+  perTypePerMinute: 10,
+  perSeverityPerMinute: 20,
+};
+
+const DEFAULT_CONFIG: EscalationConfig = {
+  rateLimits: DEFAULT_RATE_LIMITS,
+  enabledTypes: [
+    "dlq_overflow",
+    "watchdog",
+    "policy_denial",
+    "error",
+    "manual_escalation",
+    "pause",
+    "resume",
+  ],
+  minSeverity: "info",
+};
+
+// Rate limit tracking (in-memory, backed by file)
+interface RateLimitState {
+  typeCounts: Record<string, Array<{ timestamp: string; count: number }>>;
+  severityCounts: Record<string, Array<{ timestamp: string; count: number }>>;
+  lastDedupeKeys: Record<string, string>;
+  updatedAt: string;
+}
+
+let rateLimitState: RateLimitState | null = null;
+let config: EscalationConfig = { ...DEFAULT_CONFIG };
+let initializationPromise: Promise<void> | null = null;
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+/**
+ * Initialize the notification manager.
+ */
+export async function initNotificationManager(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directories exist
+  await mkdir(ESCALATION_DIR, { recursive: true });
+  await mkdir(NOTIFICATIONS_DIR, { recursive: true });
+
+  // Load rate limit state
+  rateLimitState = await loadRateLimitState();
+  if (!rateLimitState) {
+    rateLimitState = {
+      typeCounts: {},
+      severityCounts: {},
+      lastDedupeKeys: {},
+      updatedAt: new Date().toISOString(),
+    };
+    await saveRateLimitState();
+  }
+
+  // Load config
+  const loadedConfig = await loadConfig();
+  if (loadedConfig) {
+    config = { ...DEFAULT_CONFIG, ...loadedConfig };
+  }
+}
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Create and persist a notification.
+ * 
+ * @param type - The notification type
+ * @param severity - The notification severity
+ * @param message - The notification message
+ * @param context - Context including event/workflow/session IDs
+ * @returns The created notification or null if rate limited/deduped
+ */
+export async function notify(
+  type: NotificationType,
+  severity: NotificationSeverity,
+  message: string,
+  context?: {
+    eventId?: string;
+    workflowId?: string;
+    sessionId?: string;
+    details?: Record<string, unknown>;
+  }
+): Promise<EscalationNotification | null> {
+  await initNotificationManager();
+
+  // Check if type is enabled
+  if (config.enabledTypes && !config.enabledTypes.includes(type)) {
+    console.log(`[notification] Type ${type} is disabled, skipping`);
+    return null;
+  }
+
+  // Check minimum severity
+  const severityOrder: NotificationSeverity[] = ["info", "warning", "critical"];
+  if (config.minSeverity) {
+    const configIndex = severityOrder.indexOf(config.minSeverity);
+    const severityIndex = severityOrder.indexOf(severity);
+    if (severityIndex < configIndex) {
+      console.log(`[notification] Severity ${severity} below minimum ${config.minSeverity}, skipping`);
+      return null;
+    }
+  }
+
+  // Check deduplication
+  const dedupeKey = generateDedupeKey(type, severity, message, context);
+  if (isDuplicate(type, dedupeKey)) {
+    console.log(`[notification] Duplicate notification suppressed: ${type}`);
+    return null;
+  }
+
+  // Check rate limits
+  if (isRateLimited(type, severity)) {
+    console.warn(`[notification] Rate limited: ${type} (${severity})`);
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  const notificationId = randomUUID();
+
+  const notification: EscalationNotification = {
+    notificationId,
+    type,
+    severity,
+    createdAt: now,
+    eventId: context?.eventId,
+    workflowId: context?.workflowId,
+    sessionId: context?.sessionId,
+    message,
+    details: context?.details,
+    delivery: {
+      attempted: false,
+    },
+  };
+
+  // Persist notification
+  await saveNotification(notification);
+
+  // Update rate limits
+  recordNotification(type, severity, dedupeKey);
+
+  // Log to audit log
+  await logAudit({
+    timestamp: now,
+    eventId: `notification-${notificationId}`,
+    requestId: notificationId,
+    source: "escalation",
+    toolName: "NotificationManager",
+    action: severity === "critical" ? "require_approval" : "allow",
+    reason: `Notification: ${message}`,
+    metadata: { type, severity, eventId: context?.eventId },
+  });
+
+  // Attempt delivery if configured
+  if (config.webhookUrl || config.emailTarget) {
+    await attemptDelivery(notification);
+  }
+
+  console.log(`[notification] Created ${type} (${severity}): ${message.slice(0, 50)}...`);
+
+  return notification;
+}
+
+/**
+ * List notifications with optional filters.
+ */
+export async function listNotifications(
+  filters: NotificationFilters = {},
+  limit: number = 100
+): Promise<EscalationNotification[]> {
+  await initNotificationManager();
+
+  const notifications: EscalationNotification[] = [];
+
+  try {
+    const files = await readdir(NOTIFICATIONS_DIR);
+    const jsonFiles = files.filter(f => f.endsWith(".json"));
+
+    for (const file of jsonFiles) {
+      try {
+        const content = await readFile(join(NOTIFICATIONS_DIR, file), "utf8");
+        const notification: EscalationNotification = JSON.parse(content);
+
+        // Apply filters
+        if (filters.type && notification.type !== filters.type) continue;
+        if (filters.severity && notification.severity !== filters.severity) continue;
+        if (filters.eventId && notification.eventId !== filters.eventId) continue;
+        if (filters.workflowId && notification.workflowId !== filters.workflowId) continue;
+        if (filters.sessionId && notification.sessionId !== filters.sessionId) continue;
+        if (filters.createdAfter && notification.createdAt < filters.createdAfter) continue;
+        if (filters.createdBefore && notification.createdAt > filters.createdBefore) continue;
+        if (filters.undeliveredOnly && notification.delivery?.delivered) continue;
+
+        notifications.push(notification);
+      } catch {
+        // Skip malformed files
+        continue;
+      }
+    }
+  } catch {
+    // Directory might not exist yet
+  }
+
+  // Sort by createdAt descending (newest first)
+  notifications.sort((a, b) => 
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  return notifications.slice(0, limit);
+}
+
+/**
+ * Get a specific notification by ID.
+ */
+export async function getNotification(
+  notificationId: string
+): Promise<EscalationNotification | null> {
+  await initNotificationManager();
+
+  try {
+    const filePath = join(NOTIFICATIONS_DIR, `${notificationId}.json`);
+    if (!existsSync(filePath)) {
+      return null;
+    }
+
+    const content = await readFile(filePath, "utf8");
+    return JSON.parse(content) as EscalationNotification;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Configure the notification manager.
+ */
+export async function configure(newConfig: EscalationConfig): Promise<void> {
+  await initNotificationManager();
+
+  config = {
+    ...config,
+    ...newConfig,
+    rateLimits: {
+      ...config.rateLimits,
+      ...newConfig.rateLimits,
+    },
+  };
+
+  await saveConfig();
+  console.log("[notification] Configuration updated");
+}
+
+/**
+ * Get current configuration.
+ */
+export function getConfig(): EscalationConfig {
+  return { ...config };
+}
+
+/**
+ * Retry delivery for an undelivered notification.
+ */
+export async function retryDelivery(
+  notificationId: string
+): Promise<{ success: boolean; error?: string }> {
+  const notification = await getNotification(notificationId);
+  if (!notification) {
+    return { success: false, error: "Notification not found" };
+  }
+
+  if (notification.delivery?.delivered) {
+    return { success: true, error: "Already delivered" };
+  }
+
+  if (!config.webhookUrl && !config.emailTarget) {
+    return { success: false, error: "No delivery channels configured" };
+  }
+
+  return await attemptDelivery(notification);
+}
+
+// ============================================================================
+// Delivery Abstractions
+// ============================================================================
+
+/**
+ * Attempt to deliver a notification.
+ * This is a skeleton implementation - real delivery would integrate with
+ * actual webhook/email services.
+ */
+async function attemptDelivery(
+  notification: EscalationNotification
+): Promise<{ success: boolean; error?: string }> {
+  const now = new Date().toISOString();
+  
+  notification.delivery = {
+    ...notification.delivery,
+    attempted: true,
+    attemptedAt: now,
+  };
+
+  const results: { success: boolean; error?: string }[] = [];
+
+  // Attempt webhook delivery
+  if (config.webhookUrl) {
+    results.push(await attemptWebhookDelivery(notification));
+  }
+
+  // Attempt email delivery
+  if (config.emailTarget) {
+    results.push(await attemptEmailDelivery(notification));
+  }
+
+  // Consider successful if any channel succeeded
+  const anySuccess = results.some(r => r.success);
+  
+  if (anySuccess) {
+    notification.delivery!.delivered = true;
+    notification.delivery!.deliveredAt = now;
+  } else {
+    notification.delivery!.error = results.find(r => r.error)?.error;
+  }
+
+  // Update persisted notification
+  await saveNotification(notification);
+
+  return {
+    success: anySuccess,
+    error: anySuccess ? undefined : notification.delivery!.error,
+  };
+}
+
+/**
+ * Attempt webhook delivery (skeleton).
+ */
+async function attemptWebhookDelivery(
+  notification: EscalationNotification
+): Promise<{ success: boolean; error?: string }> {
+  if (!config.webhookUrl) {
+    return { success: false, error: "No webhook URL configured" };
+  }
+
+  // Skeleton implementation - in production, this would make an HTTP POST
+  console.log(`[notification] Would send webhook to ${config.webhookUrl}`);
+  console.log(`[notification] Payload: ${JSON.stringify(notification, null, 2).slice(0, 200)}...`);
+
+  // Simulate success for now
+  return { success: true };
+}
+
+/**
+ * Attempt email delivery (skeleton).
+ */
+async function attemptEmailDelivery(
+  notification: EscalationNotification
+): Promise<{ success: boolean; error?: string }> {
+  if (!config.emailTarget) {
+    return { success: false, error: "No email target configured" };
+  }
+
+  // Skeleton implementation - in production, this would use an email service
+  console.log(`[notification] Would send email to ${config.emailTarget}`);
+  console.log(`[notification] Subject: [${notification.severity.toUpperCase()}] ${notification.type}`);
+
+  // Simulate success for now
+  return { success: true };
+}
+
+// ============================================================================
+// Rate Limiting
+// ============================================================================
+
+function generateDedupeKey(
+  type: NotificationType,
+  severity: NotificationSeverity,
+  message: string,
+  context?: { eventId?: string }
+): string {
+  // Create a dedupe key based on type, severity, and message (first 100 chars)
+  // Include eventId if available for event-specific deduplication
+  const messageHash = message.slice(0, 100);
+  return `${type}:${severity}:${context?.eventId || "no-event"}:${messageHash}`;
+}
+
+function isDuplicate(type: NotificationType, dedupeKey: string): boolean {
+  if (!rateLimitState) return false;
+
+  const lastKey = rateLimitState.lastDedupeKeys[type];
+  if (lastKey === dedupeKey) {
+    return true;
+  }
+
+  return false;
+}
+
+function isRateLimited(type: NotificationType, severity: NotificationSeverity): boolean {
+  if (!rateLimitState) return false;
+
+  const now = new Date();
+  const oneMinuteAgo = new Date(now.getTime() - 60000).toISOString();
+
+  const limits = config.rateLimits || DEFAULT_RATE_LIMITS;
+
+  // Check per-type limit
+  if (limits.perTypePerMinute) {
+    const typeEntries = rateLimitState.typeCounts[type] || [];
+    const recentTypeEntries = typeEntries.filter(e => e.timestamp > oneMinuteAgo);
+    const typeCount = recentTypeEntries.reduce((sum, e) => sum + e.count, 0);
+    
+    if (typeCount >= limits.perTypePerMinute) {
+      return true;
+    }
+  }
+
+  // Check per-severity limit
+  if (limits.perSeverityPerMinute) {
+    const severityEntries = rateLimitState.severityCounts[severity] || [];
+    const recentSeverityEntries = severityEntries.filter(e => e.timestamp > oneMinuteAgo);
+    const severityCount = recentSeverityEntries.reduce((sum, e) => sum + e.count, 0);
+    
+    if (severityCount >= limits.perSeverityPerMinute) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function recordNotification(
+  type: NotificationType,
+  severity: NotificationSeverity,
+  dedupeKey: string
+): void {
+  if (!rateLimitState) return;
+
+  const now = new Date().toISOString();
+
+  // Update dedupe key
+  rateLimitState.lastDedupeKeys[type] = dedupeKey;
+
+  // Update type counts
+  if (!rateLimitState.typeCounts[type]) {
+    rateLimitState.typeCounts[type] = [];
+  }
+  rateLimitState.typeCounts[type].push({ timestamp: now, count: 1 });
+
+  // Update severity counts
+  if (!rateLimitState.severityCounts[severity]) {
+    rateLimitState.severityCounts[severity] = [];
+  }
+  rateLimitState.severityCounts[severity].push({ timestamp: now, count: 1 });
+
+  // Clean up old entries (older than 5 minutes)
+  const fiveMinutesAgo = new Date(Date.now() - 300000).toISOString();
+  
+  for (const t of Object.keys(rateLimitState.typeCounts)) {
+    rateLimitState.typeCounts[t] = rateLimitState.typeCounts[t].filter(
+      e => e.timestamp > fiveMinutesAgo
+    );
+  }
+
+  for (const s of Object.keys(rateLimitState.severityCounts)) {
+    rateLimitState.severityCounts[s] = rateLimitState.severityCounts[s].filter(
+      e => e.timestamp > fiveMinutesAgo
+    );
+  }
+
+  rateLimitState.updatedAt = now;
+
+  // Persist rate limit state (fire and forget)
+  saveRateLimitState().catch(() => {
+    // Ignore persistence errors
+  });
+}
+
+// ============================================================================
+// Statistics
+// ============================================================================
+
+/**
+ * Get notification statistics.
+ */
+export async function getNotificationStats(): Promise<{
+  total: number;
+  byType: Record<NotificationType, number>;
+  bySeverity: Record<NotificationSeverity, number>;
+  delivered: number;
+  undelivered: number;
+}> {
+  await initNotificationManager();
+
+  const notifications = await listNotifications({}, 10000);
+
+  const byType: Record<NotificationType, number> = {
+    dlq_overflow: 0,
+    watchdog: 0,
+    policy_denial: 0,
+    error: 0,
+    manual_escalation: 0,
+    pause: 0,
+    resume: 0,
+  };
+
+  const bySeverity: Record<NotificationSeverity, number> = {
+    info: 0,
+    warning: 0,
+    critical: 0,
+  };
+
+  let delivered = 0;
+  let undelivered = 0;
+
+  for (const n of notifications) {
+    byType[n.type] = (byType[n.type] || 0) + 1;
+    bySeverity[n.severity] = (bySeverity[n.severity] || 0) + 1;
+
+    if (n.delivery?.delivered) {
+      delivered++;
+    } else {
+      undelivered++;
+    }
+  }
+
+  return {
+    total: notifications.length,
+    byType,
+    bySeverity,
+    delivered,
+    undelivered,
+  };
+}
+
+// ============================================================================
+// Internal Functions
+// ============================================================================
+
+async function saveNotification(notification: EscalationNotification): Promise<void> {
+  const filePath = join(NOTIFICATIONS_DIR, `${notification.notificationId}.json`);
+  await writeFile(filePath, JSON.stringify(notification, null, 2) + "\n", "utf8");
+}
+
+async function loadRateLimitState(): Promise<RateLimitState | null> {
+  try {
+    if (!existsSync(RATE_LIMIT_FILE)) {
+      return null;
+    }
+
+    const content = await readFile(RATE_LIMIT_FILE, "utf8");
+    return JSON.parse(content) as RateLimitState;
+  } catch {
+    return null;
+  }
+}
+
+async function saveRateLimitState(): Promise<void> {
+  if (!rateLimitState) return;
+  await writeFile(RATE_LIMIT_FILE, JSON.stringify(rateLimitState, null, 2) + "\n", "utf8");
+}
+
+async function loadConfig(): Promise<EscalationConfig | null> {
+  try {
+    if (!existsSync(CONFIG_FILE)) {
+      return null;
+    }
+
+    const content = await readFile(CONFIG_FILE, "utf8");
+    return JSON.parse(content) as EscalationConfig;
+  } catch {
+    return null;
+  }
+}
+
+async function saveConfig(): Promise<void> {
+  await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n", "utf8");
+}
+
+// ============================================================================
+// Testing Helpers
+// ============================================================================
+
+/**
+ * Reset the notification manager (for testing only).
+ */
+export async function resetNotificationManager(): Promise<void> {
+  rateLimitState = null;
+  config = { ...DEFAULT_CONFIG };
+  initializationPromise = null;
+  
+  // Clear persisted rate limit and config files
+  try {
+    const { unlink } = await import("node:fs/promises");
+    if (existsSync(RATE_LIMIT_FILE)) {
+      await unlink(RATE_LIMIT_FILE);
+    }
+    if (existsSync(CONFIG_FILE)) {
+      await unlink(CONFIG_FILE);
+    }
+  } catch {
+    // Ignore errors during cleanup
+  }
+}
+
+/**
+ * Clear the notification manager cache without modifying state (for testing only).
+ */
+export function clearNotificationCache(): void {
+  initializationPromise = null;
+}

--- a/src/escalation/pause.ts
+++ b/src/escalation/pause.ts
@@ -1,0 +1,423 @@
+/**
+ * Pause Controller
+ * 
+ * Durable pause/resume control with explicit operating modes.
+ * 
+ * DESIGN:
+ * - Pause state stored at .claude/claudeclaw/paused.json
+ * - Supports modes: "admission_only" | "admission_and_scheduling"
+ * - Gateway and orchestrator must check pause state before processing
+ * - All pause/resume actions generate audit records
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - Pause state is persisted immediately
+ * - State survives restart and is applied during startup reconstruction
+ * - No in-memory-only pause decisions
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { log as logAudit } from "../policy/audit-log";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type PauseMode = "admission_only" | "admission_and_scheduling";
+
+export interface PauseState {
+  paused: boolean;
+  mode: PauseMode;
+  reason?: string;
+  pausedAt?: string;
+  pausedBy?: string;
+  resumeAt?: string;
+  resumedAt?: string;
+  resumedBy?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PauseAction {
+  actionId: string;
+  action: "pause" | "resume";
+  mode?: PauseMode;
+  reason: string;
+  actor: string;
+  timestamp: string;
+  previousState?: PauseState;
+  newState: PauseState;
+}
+
+export interface PauseOptions {
+  reason?: string;
+  pausedBy?: string;
+  resumeAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ResumeOptions {
+  reason?: string;
+  resumedBy?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const PAUSE_STATE_FILE = join(ESCALATION_DIR, "paused.json");
+const PAUSE_ACTIONS_FILE = join(ESCALATION_DIR, "pause-actions.jsonl");
+
+// Default empty state
+const DEFAULT_STATE: PauseState = {
+  paused: false,
+  mode: "admission_only",
+};
+
+// In-memory cache (source of truth is always the file)
+let cachedState: PauseState | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+/**
+ * Initialize the pause controller.
+ * Ensures directories exist and loads initial state.
+ */
+export async function initPauseController(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directory exists
+  await mkdir(ESCALATION_DIR, { recursive: true });
+
+  // Try to load existing state
+  cachedState = await loadPauseState();
+
+  // If no state exists, create default unpaused state
+  if (!cachedState) {
+    cachedState = { ...DEFAULT_STATE };
+    await savePauseState(cachedState);
+  }
+}
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Pause the system.
+ * 
+ * @param mode - Pause mode: "admission_only" or "admission_and_scheduling"
+ * @param options - Pause options including reason, actor, and metadata
+ * @returns The pause action record
+ * 
+ * Semantics:
+ * - "admission_only": Reject/defer new inbound work, allow running work to complete
+ * - "admission_and_scheduling": Reject/defer new work AND stop scheduling new tasks
+ */
+export async function pause(
+  mode: PauseMode,
+  options: PauseOptions = {}
+): Promise<PauseAction> {
+  await initPauseController();
+
+  const now = new Date().toISOString();
+  const previousState = { ...cachedState! };
+
+  const newState: PauseState = {
+    paused: true,
+    mode,
+    reason: options.reason,
+    pausedAt: now,
+    pausedBy: options.pausedBy || "system",
+    resumeAt: options.resumeAt,
+    resumedAt: undefined,
+    resumedBy: undefined,
+    metadata: options.metadata,
+  };
+
+  // Persist state
+  await savePauseState(newState);
+  cachedState = newState;
+
+  // Record action
+  const action: PauseAction = {
+    actionId: randomUUID(),
+    action: "pause",
+    mode,
+    reason: options.reason || "Paused by operator",
+    actor: options.pausedBy || "system",
+    timestamp: now,
+    previousState,
+    newState,
+  };
+
+  await recordPauseAction(action);
+
+  // Log to audit log
+  await logAudit({
+    timestamp: now,
+    eventId: `pause-${action.actionId}`,
+    requestId: action.actionId,
+    source: "escalation",
+    toolName: "PauseController",
+    action: "require_approval", // Using require_approval to indicate intervention
+    reason: `System paused: ${options.reason || "No reason provided"}`,
+    operatorId: options.pausedBy,
+    metadata: { mode, resumeAt: options.resumeAt },
+  });
+
+  console.log(`[pause] System paused: mode=${mode}, reason=${options.reason || "N/A"}`);
+
+  return action;
+}
+
+/**
+ * Resume the system.
+ * 
+ * @param options - Resume options including reason and actor
+ * @returns The resume action record
+ */
+export async function resume(
+  options: ResumeOptions = {}
+): Promise<PauseAction> {
+  await initPauseController();
+
+  const now = new Date().toISOString();
+  const previousState = { ...cachedState! };
+
+  // Only resume if currently paused
+  if (!previousState.paused) {
+    console.log("[pause] System is not paused, no action taken");
+    return {
+      actionId: randomUUID(),
+      action: "resume",
+      reason: options.reason || "Resume requested (system already running)",
+      actor: options.resumedBy || "system",
+      timestamp: now,
+      previousState,
+      newState: previousState,
+    };
+  }
+
+  const newState: PauseState = {
+    paused: false,
+    mode: previousState.mode, // Keep last mode for reference
+    reason: previousState.reason, // Keep reason for audit trail
+    pausedAt: previousState.pausedAt,
+    pausedBy: previousState.pausedBy,
+    resumeAt: undefined,
+    resumedAt: now,
+    resumedBy: options.resumedBy || "system",
+    metadata: { ...previousState.metadata, ...options.metadata },
+  };
+
+  // Persist state
+  await savePauseState(newState);
+  cachedState = newState;
+
+  // Record action
+  const action: PauseAction = {
+    actionId: randomUUID(),
+    action: "resume",
+    reason: options.reason || "Resumed by operator",
+    actor: options.resumedBy || "system",
+    timestamp: now,
+    previousState,
+    newState,
+  };
+
+  await recordPauseAction(action);
+
+  // Log to audit log
+  await logAudit({
+    timestamp: now,
+    eventId: `resume-${action.actionId}`,
+    requestId: action.actionId,
+    source: "escalation",
+    toolName: "PauseController",
+    action: "allow", // Using allow to indicate normal operation restored
+    reason: `System resumed: ${options.reason || "No reason provided"}`,
+    operatorId: options.resumedBy,
+    metadata: { previousPausedAt: previousState.pausedAt, previousPausedBy: previousState.pausedBy },
+  });
+
+  console.log(`[pause] System resumed: reason=${options.reason || "N/A"}`);
+
+  return action;
+}
+
+/**
+ * Get the current pause state.
+ * Always reads from disk to ensure consistency.
+ */
+export async function getPauseState(): Promise<PauseState> {
+  await initPauseController();
+
+  const state = await loadPauseState();
+  if (state) {
+    cachedState = state;
+    return state;
+  }
+
+  return { ...DEFAULT_STATE };
+}
+
+/**
+ * Check if the system is currently paused.
+ * This is a convenience method for quick checks.
+ */
+export async function isPaused(): Promise<boolean> {
+  const state = await getPauseState();
+  return state.paused;
+}
+
+/**
+ * Check if new work admission should be blocked.
+ * Returns true if paused (regardless of mode).
+ */
+export async function shouldBlockAdmission(): Promise<boolean> {
+  const state = await getPauseState();
+  return state.paused;
+}
+
+/**
+ * Check if task scheduling should be blocked.
+ * Returns true only in "admission_and_scheduling" mode.
+ */
+export async function shouldBlockScheduling(): Promise<boolean> {
+  const state = await getPauseState();
+  return state.paused && state.mode === "admission_and_scheduling";
+}
+
+// ============================================================================
+// Pause Action History
+// ============================================================================
+
+/**
+ * Get the history of pause/resume actions.
+ */
+export async function getPauseHistory(limit: number = 100): Promise<PauseAction[]> {
+  if (!existsSync(PAUSE_ACTIONS_FILE)) {
+    return [];
+  }
+
+  try {
+    const content = await readFile(PAUSE_ACTIONS_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+
+    const actions: PauseAction[] = [];
+
+    for (const line of lines) {
+      try {
+        const action: PauseAction = JSON.parse(line);
+        actions.push(action);
+      } catch {
+        // Skip malformed entries
+        continue;
+      }
+    }
+
+    // Sort by timestamp descending (newest first)
+    actions.sort((a, b) => 
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    );
+
+    return actions.slice(0, limit);
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================================
+// Internal Functions
+// ============================================================================
+
+async function loadPauseState(): Promise<PauseState | null> {
+  try {
+    if (!existsSync(PAUSE_STATE_FILE)) {
+      return null;
+    }
+
+    const content = await readFile(PAUSE_STATE_FILE, "utf8");
+    const parsed = JSON.parse(content);
+
+    // Validate required fields
+    if (typeof parsed.paused !== "boolean") {
+      return null;
+    }
+
+    return {
+      paused: parsed.paused,
+      mode: parsed.mode === "admission_and_scheduling" ? "admission_and_scheduling" : "admission_only",
+      reason: parsed.reason,
+      pausedAt: parsed.pausedAt,
+      pausedBy: parsed.pausedBy,
+      resumeAt: parsed.resumeAt,
+      resumedAt: parsed.resumedAt,
+      resumedBy: parsed.resumedBy,
+      metadata: parsed.metadata,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function savePauseState(state: PauseState): Promise<void> {
+  await writeFile(PAUSE_STATE_FILE, JSON.stringify(state, null, 2) + "\n", "utf8");
+}
+
+async function recordPauseAction(action: PauseAction): Promise<void> {
+  const line = JSON.stringify(action) + "\n";
+  
+  let existingContent = "";
+  try {
+    if (existsSync(PAUSE_ACTIONS_FILE)) {
+      existingContent = await readFile(PAUSE_ACTIONS_FILE, "utf8");
+    }
+  } catch {
+    // File doesn't exist yet
+  }
+
+  await writeFile(PAUSE_ACTIONS_FILE, existingContent + line, "utf8");
+}
+
+// ============================================================================
+// Testing Helpers
+// ============================================================================
+
+/**
+ * Reset the pause controller state (for testing only).
+ */
+export async function resetPauseController(): Promise<void> {
+  cachedState = null;
+  initializationPromise = null;
+  
+  try {
+    if (existsSync(PAUSE_STATE_FILE)) {
+      await writeFile(PAUSE_STATE_FILE, JSON.stringify(DEFAULT_STATE, null, 2) + "\n", "utf8");
+    }
+  } catch {
+    // Ignore
+  }
+}
+
+/**
+ * Clear the pause controller cache without modifying state (for testing only).
+ */
+export function clearPauseCache(): void {
+  cachedState = null;
+  initializationPromise = null;
+}

--- a/src/escalation/status.ts
+++ b/src/escalation/status.ts
@@ -1,0 +1,536 @@
+/**
+ * Escalation Status View
+ * 
+ * Provide a durable read-side view of current pause/escalation/handoff status.
+ * 
+ * DESIGN:
+ * - Status view derives from persisted escalation state
+ * - Read-only view that aggregates pause, handoff, and notification status
+ * - Provides a single source of truth for operator dashboards
+ * - No hidden state - all derived from persisted files
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import type { PauseState } from "./pause";
+import type { HandoffPackage, HandoffStatus, HandoffSeverity } from "./handoff";
+import type { EscalationNotification, NotificationType, NotificationSeverity } from "./notifications";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface EscalationStatus {
+  timestamp: string;
+  pause: PauseStatus;
+  handoffs: HandoffSummary[];
+  notifications: NotificationSummary[];
+  recentActions: EscalationActionSummary[];
+  summary: EscalationSummary;
+}
+
+export interface PauseStatus {
+  paused: boolean;
+  mode: "admission_only" | "admission_and_scheduling" | null;
+  since: string | null;
+  reason: string | null;
+  pausedBy: string | null;
+  willResumeAt: string | null;
+}
+
+export interface HandoffSummary {
+  handoffId: string;
+  createdAt: string;
+  status: HandoffStatus;
+  severity: HandoffSeverity;
+  reason: string;
+  source?: string;
+  sessionId?: string;
+  acceptedBy?: string;
+  closedBy?: string;
+}
+
+export interface NotificationSummary {
+  notificationId: string;
+  createdAt: string;
+  type: NotificationType;
+  severity: NotificationSeverity;
+  message: string;
+  delivered: boolean;
+  eventId?: string;
+  workflowId?: string;
+}
+
+export interface EscalationActionSummary {
+  actionId: string;
+  timestamp: string;
+  action: "pause" | "resume" | "handoff_created" | "handoff_accepted" | "handoff_closed" | "notification";
+  actor: string;
+  details?: Record<string, unknown>;
+}
+
+export interface EscalationSummary {
+  totalHandoffs: number;
+  openHandoffs: number;
+  criticalHandoffs: number;
+  totalNotifications24h: number;
+  undeliveredNotifications: number;
+  isPaused: boolean;
+}
+
+export interface StatusFilters {
+  includeClosedHandoffs?: boolean;
+  handoffLimit?: number;
+  notificationLimit?: number;
+  actionLimit?: number;
+  since?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const ESCALATION_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const PAUSE_STATE_FILE = join(ESCALATION_DIR, "paused.json");
+const HANDOFFS_DIR = join(ESCALATION_DIR, "handoffs");
+const NOTIFICATIONS_DIR = join(ESCALATION_DIR, "notifications");
+const PAUSE_ACTIONS_FILE = join(ESCALATION_DIR, "pause-actions.jsonl");
+const HANDOFF_ACTIONS_FILE = join(ESCALATION_DIR, "handoff-actions.jsonl");
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Get the complete escalation status.
+ * This is the main entry point for status views.
+ * 
+ * @param filters - Optional filters for the status view
+ * @returns The complete escalation status
+ */
+export async function getEscalationStatus(
+  filters: StatusFilters = {}
+): Promise<EscalationStatus> {
+  const timestamp = new Date().toISOString();
+
+  // Get all status components in parallel
+  const [pause, handoffs, notifications, recentActions] = await Promise.all([
+    getPauseStatus(),
+    getHandoffSummaries(filters),
+    getNotificationSummaries(filters),
+    getRecentActions(filters),
+  ]);
+
+  // Calculate summary
+  const summary: EscalationSummary = {
+    totalHandoffs: handoffs.length,
+    openHandoffs: handoffs.filter(h => h.status === "open").length,
+    criticalHandoffs: handoffs.filter(h => h.severity === "critical" && h.status !== "closed").length,
+    totalNotifications24h: notifications.filter(n => isWithinHours(n.createdAt, 24)).length,
+    undeliveredNotifications: notifications.filter(n => !n.delivered).length,
+    isPaused: pause.paused,
+  };
+
+  return {
+    timestamp,
+    pause,
+    handoffs,
+    notifications,
+    recentActions,
+    summary,
+  };
+}
+
+/**
+ * Get a summary of escalation status for quick checks.
+ */
+export async function getEscalationSummary(): Promise<EscalationSummary> {
+  const [pauseStatus, handoffs, notifications] = await Promise.all([
+    getPauseStatus(),
+    getHandoffSummaries({ includeClosedHandoffs: true }),
+    getNotificationSummaries({}),
+  ]);
+
+  return {
+    totalHandoffs: handoffs.length,
+    openHandoffs: handoffs.filter(h => h.status === "open").length,
+    criticalHandoffs: handoffs.filter(h => h.severity === "critical" && h.status !== "closed").length,
+    totalNotifications24h: notifications.filter(n => isWithinHours(n.createdAt, 24)).length,
+    undeliveredNotifications: notifications.filter(n => !n.delivered).length,
+    isPaused: pauseStatus.paused,
+  };
+}
+
+/**
+ * Check if the system requires operator attention.
+ */
+export async function requiresAttention(): Promise<{
+  requiresAttention: boolean;
+  reasons: string[];
+}> {
+  const status = await getEscalationStatus();
+  const reasons: string[] = [];
+
+  if (status.pause.paused) {
+    reasons.push(`System is paused (${status.pause.mode})`);
+  }
+
+  if (status.summary.criticalHandoffs > 0) {
+    reasons.push(`${status.summary.criticalHandoffs} critical handoffs require attention`);
+  }
+
+  if (status.summary.openHandoffs > 5) {
+    reasons.push(`${status.summary.openHandoffs} open handoffs`);
+  }
+
+  if (status.summary.undeliveredNotifications > 10) {
+    reasons.push(`${status.summary.undeliveredNotifications} undelivered notifications`);
+  }
+
+  return {
+    requiresAttention: reasons.length > 0,
+    reasons,
+  };
+}
+
+// ============================================================================
+// Component Status Functions
+// ============================================================================
+
+async function getPauseStatus(): Promise<PauseStatus> {
+  try {
+    if (!existsSync(PAUSE_STATE_FILE)) {
+      return {
+        paused: false,
+        mode: null,
+        since: null,
+        reason: null,
+        pausedBy: null,
+        willResumeAt: null,
+      };
+    }
+
+    const content = await readFile(PAUSE_STATE_FILE, "utf8");
+    const state: PauseState = JSON.parse(content);
+
+    return {
+      paused: state.paused,
+      mode: state.paused ? state.mode : null,
+      since: state.pausedAt || null,
+      reason: state.reason || null,
+      pausedBy: state.pausedBy || null,
+      willResumeAt: state.resumeAt || null,
+    };
+  } catch {
+    return {
+      paused: false,
+      mode: null,
+      since: null,
+      reason: null,
+      pausedBy: null,
+      willResumeAt: null,
+    };
+  }
+}
+
+async function getHandoffSummaries(filters: StatusFilters): Promise<HandoffSummary[]> {
+  const summaries: HandoffSummary[] = [];
+
+  try {
+    if (!existsSync(HANDOFFS_DIR)) {
+      return summaries;
+    }
+
+    const files = await readdir(HANDOFFS_DIR);
+    const jsonFiles = files.filter(f => f.endsWith(".json") && f !== "index.json");
+
+    for (const file of jsonFiles) {
+      try {
+        const content = await readFile(join(HANDOFFS_DIR, file), "utf8");
+        const handoff: HandoffPackage = JSON.parse(content);
+
+        // Filter out closed handoffs unless requested
+        if (!filters.includeClosedHandoffs && handoff.status === "closed") {
+          continue;
+        }
+
+        // Filter by since date
+        if (filters.since && handoff.createdAt < filters.since) {
+          continue;
+        }
+
+        summaries.push({
+          handoffId: handoff.handoffId,
+          createdAt: handoff.createdAt,
+          status: handoff.status,
+          severity: handoff.severity,
+          reason: handoff.reason,
+          source: handoff.source,
+          sessionId: handoff.sessionId,
+          acceptedBy: handoff.acceptedBy,
+          closedBy: handoff.closedBy,
+        });
+      } catch {
+        // Skip malformed files
+        continue;
+      }
+    }
+  } catch {
+    // Directory might not exist
+  }
+
+  // Sort by createdAt descending (newest first)
+  summaries.sort((a, b) => 
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  // Apply limit
+  const limit = filters.handoffLimit ?? 50;
+  return summaries.slice(0, limit);
+}
+
+async function getNotificationSummaries(
+  filters: StatusFilters
+): Promise<NotificationSummary[]> {
+  const summaries: NotificationSummary[] = [];
+
+  try {
+    if (!existsSync(NOTIFICATIONS_DIR)) {
+      return summaries;
+    }
+
+    const files = await readdir(NOTIFICATIONS_DIR);
+    const jsonFiles = files.filter(f => f.endsWith(".json"));
+
+    for (const file of jsonFiles) {
+      try {
+        const content = await readFile(join(NOTIFICATIONS_DIR, file), "utf8");
+        const notification: EscalationNotification = JSON.parse(content);
+
+        // Filter by since date
+        if (filters.since && notification.createdAt < filters.since) {
+          continue;
+        }
+
+        summaries.push({
+          notificationId: notification.notificationId,
+          createdAt: notification.createdAt,
+          type: notification.type,
+          severity: notification.severity,
+          message: notification.message,
+          delivered: notification.delivery?.delivered ?? false,
+          eventId: notification.eventId,
+          workflowId: notification.workflowId,
+        });
+      } catch {
+        // Skip malformed files
+        continue;
+      }
+    }
+  } catch {
+    // Directory might not exist
+  }
+
+  // Sort by createdAt descending (newest first)
+  summaries.sort((a, b) => 
+    new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  // Apply limit
+  const limit = filters.notificationLimit ?? 50;
+  return summaries.slice(0, limit);
+}
+
+async function getRecentActions(filters: StatusFilters): Promise<EscalationActionSummary[]> {
+  const actions: EscalationActionSummary[] = [];
+
+  // Read pause actions
+  try {
+    if (existsSync(PAUSE_ACTIONS_FILE)) {
+      const content = await readFile(PAUSE_ACTIONS_FILE, "utf8");
+      const lines = content.split("\n").filter(line => line.trim());
+
+      for (const line of lines) {
+        try {
+          const action = JSON.parse(line);
+          if (filters.since && action.timestamp < filters.since) {
+            continue;
+          }
+
+          actions.push({
+            actionId: action.actionId,
+            timestamp: action.timestamp,
+            action: action.action === "pause" ? "pause" : "resume",
+            actor: action.actor,
+            details: { mode: action.mode, reason: action.reason },
+          });
+        } catch {
+          continue;
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+
+  // Read handoff actions
+  try {
+    if (existsSync(HANDOFF_ACTIONS_FILE)) {
+      const content = await readFile(HANDOFF_ACTIONS_FILE, "utf8");
+      const lines = content.split("\n").filter(line => line.trim());
+
+      for (const line of lines) {
+        try {
+          const action = JSON.parse(line);
+          if (filters.since && action.timestamp < filters.since) {
+            continue;
+          }
+
+          let actionType: EscalationActionSummary["action"];
+          switch (action.action) {
+            case "create":
+              actionType = "handoff_created";
+              break;
+            case "accept":
+              actionType = "handoff_accepted";
+              break;
+            case "close":
+              actionType = "handoff_closed";
+              break;
+            default:
+              actionType = "handoff_created";
+          }
+
+          actions.push({
+            actionId: action.actionId,
+            timestamp: action.timestamp,
+            action: actionType,
+            actor: action.actor,
+            details: { handoffId: action.handoffId },
+          });
+        } catch {
+          continue;
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+
+  // Sort by timestamp descending (newest first)
+  actions.sort((a, b) => 
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  // Apply limit
+  const limit = filters.actionLimit ?? 50;
+  return actions.slice(0, limit);
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function isWithinHours(timestamp: string, hours: number): boolean {
+  const then = new Date(timestamp).getTime();
+  const now = Date.now();
+  const hoursInMs = hours * 60 * 60 * 1000;
+  return now - then <= hoursInMs;
+}
+
+// ============================================================================
+// Export Formatting
+// ============================================================================
+
+/**
+ * Format escalation status for human-readable display.
+ */
+export function formatStatus(status: EscalationStatus): string {
+  const lines: string[] = [];
+
+  lines.push("═".repeat(60));
+  lines.push("ESCALATION STATUS");
+  lines.push("═".repeat(60));
+  lines.push(`Generated: ${status.timestamp}`);
+  lines.push("");
+
+  // Pause status
+  lines.push("─".repeat(60));
+  lines.push("PAUSE STATUS");
+  lines.push("─".repeat(60));
+  if (status.pause.paused) {
+    lines.push(`⚠️  SYSTEM IS PAUSED`);
+    lines.push(`   Mode: ${status.pause.mode}`);
+    lines.push(`   Since: ${status.pause.since}`);
+    lines.push(`   Reason: ${status.pause.reason || "N/A"}`);
+    lines.push(`   Paused By: ${status.pause.pausedBy || "N/A"}`);
+    if (status.pause.willResumeAt) {
+      lines.push(`   Auto-resume: ${status.pause.willResumeAt}`);
+    }
+  } else {
+    lines.push("✅ System is running normally");
+  }
+  lines.push("");
+
+  // Handoffs
+  lines.push("─".repeat(60));
+  lines.push(`HANDOFFS (${status.summary.openHandoffs} open, ${status.summary.criticalHandoffs} critical)`);
+  lines.push("─".repeat(60));
+  if (status.handoffs.length === 0) {
+    lines.push("No handoffs");
+  } else {
+    for (const h of status.handoffs.slice(0, 10)) {
+      let icon = "🔵";
+      if (h.severity === "critical") {
+        icon = "🔴";
+      } else if (h.severity === "warning") {
+        icon = "🟡";
+      }
+      lines.push(`${icon} [${h.status.toUpperCase()}] ${h.reason.slice(0, 50)}${h.reason.length > 50 ? "..." : ""}`);
+      lines.push(`   ID: ${h.handoffId} | Created: ${h.createdAt}`);
+    }
+    if (status.handoffs.length > 10) {
+      lines.push(`... and ${status.handoffs.length - 10} more`);
+    }
+  }
+  lines.push("");
+
+  // Notifications
+  lines.push("─".repeat(60));
+  lines.push(`NOTIFICATIONS (${status.summary.undeliveredNotifications} undelivered)`);
+  lines.push("─".repeat(60));
+  if (status.notifications.length === 0) {
+    lines.push("No recent notifications");
+  } else {
+    for (const n of status.notifications.slice(0, 5)) {
+      const icon = n.delivered ? "✅" : "📤";
+      lines.push(`${icon} [${n.severity.toUpperCase()}] ${n.type}: ${n.message.slice(0, 40)}${n.message.length > 40 ? "..." : ""}`);
+    }
+    if (status.notifications.length > 5) {
+      lines.push(`... and ${status.notifications.length - 5} more`);
+    }
+  }
+  lines.push("");
+
+  // Summary
+  lines.push("─".repeat(60));
+  lines.push("SUMMARY");
+  lines.push("─".repeat(60));
+  lines.push(`Total Handoffs: ${status.summary.totalHandoffs}`);
+  lines.push(`Open Handoffs: ${status.summary.openHandoffs}`);
+  lines.push(`Critical Handoffs: ${status.summary.criticalHandoffs}`);
+  lines.push(`Notifications (24h): ${status.summary.totalNotifications24h}`);
+  lines.push(`Undelivered Notifications: ${status.summary.undeliveredNotifications}`);
+  lines.push("");
+  lines.push("═".repeat(60));
+
+  return lines.join("\n");
+}
+
+/**
+ * Export status as JSON for API consumption.
+ */
+export function exportStatusAsJson(status: EscalationStatus): string {
+  return JSON.stringify(status, null, 2);
+}

--- a/src/escalation/triggers.ts
+++ b/src/escalation/triggers.ts
@@ -1,0 +1,595 @@
+/**
+ * Escalation Trigger Integration
+ * 
+ * Connect existing control-plane triggers to escalation actions consistently.
+ * 
+ * DESIGN:
+ * - Integrates with policy denials, watchdog triggers, DLQ thresholds, orchestration failures
+ * - Determines when to pause, create handoffs, or send notifications
+ * - Policy-driven escalation decisions
+ * - All actions are explicit and auditable
+ * 
+ * INTEGRATION POINTS:
+ * - Phase 3 Policy Engine: policy denials, approval timeouts
+ * - Phase 4 Governance: watchdog triggers, budget blocks
+ * - Phase 1 Event Bus: DLQ threshold crossings
+ * - Phase 5 Orchestration: workflow failures
+ */
+
+import { randomUUID } from "node:crypto";
+import { log as logAudit } from "../policy/audit-log";
+import { notify, type NotificationType, type NotificationSeverity } from "./notifications";
+import { pause, type PauseMode, shouldBlockAdmission } from "./pause";
+import { createHandoff, type HandoffContext, type HandoffSeverity } from "./handoff";
+import type { WatchdogDecision } from "../governance/watchdog";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type TriggerSource = 
+  | "policy_denial"
+  | "policy_approval_timeout"
+  | "watchdog"
+  | "dlq_overflow"
+  | "orchestration_failure"
+  | "manual_escalation";
+
+export interface TriggerContext {
+  source: TriggerSource;
+  eventId?: string;
+  workflowId?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  channelId?: string;
+  threadId?: string;
+  sourceChannel?: string;
+  message?: string;
+  severity?: "info" | "warning" | "critical";
+  details?: Record<string, unknown>;
+  watchdogDecision?: WatchdogDecision;
+}
+
+export interface EscalationAction {
+  actionId: string;
+  timestamp: string;
+  pause?: boolean;
+  pauseMode?: PauseMode;
+  handoff?: boolean;
+  notification?: boolean;
+  notificationType?: NotificationType;
+  reason: string;
+}
+
+export interface EscalationPolicy {
+  // Pause thresholds
+  pauseOnCriticalPolicyDenial: boolean;
+  pauseOnWatchdogSuspend: boolean;
+  pauseOnDlqOverflow: boolean;
+  pauseOnRepeatedOrchestrationFailures: boolean;
+  
+  // Handoff thresholds
+  createHandoffOnPolicyDenial: boolean;
+  createHandoffOnWatchdogTrigger: boolean;
+  createHandoffOnManualEscalation: boolean;
+  
+  // Notification settings
+  notifyOnPolicyDenial: boolean;
+  notifyOnWatchdog: boolean;
+  notifyOnDlqOverflow: boolean;
+  notifyOnOrchestrationFailure: boolean;
+  notifyOnPauseResume: boolean;
+  
+  // Minimum severity for handoff
+  minHandoffSeverity: HandoffSeverity;
+  
+  // Repeated failure threshold for auto-pause
+  repeatedFailureThreshold: number;
+}
+
+// ============================================================================
+// Default Policy
+// ============================================================================
+
+const DEFAULT_ESCALATION_POLICY: EscalationPolicy = {
+  pauseOnCriticalPolicyDenial: true,
+  pauseOnWatchdogSuspend: true,
+  pauseOnDlqOverflow: false, // DLQ overflow usually handled by retry
+  pauseOnRepeatedOrchestrationFailures: true,
+  
+  createHandoffOnPolicyDenial: true,
+  createHandoffOnWatchdogTrigger: true,
+  createHandoffOnManualEscalation: true,
+  
+  notifyOnPolicyDenial: true,
+  notifyOnWatchdog: true,
+  notifyOnDlqOverflow: true,
+  notifyOnOrchestrationFailure: true,
+  notifyOnPauseResume: true,
+  
+  minHandoffSeverity: "warning",
+  repeatedFailureThreshold: 3,
+};
+
+// In-memory policy (can be overridden)
+let currentPolicy: EscalationPolicy = { ...DEFAULT_ESCALATION_POLICY };
+
+// Track repeated failures for auto-pause
+const failureCounts: Record<string, { count: number; lastFailure: string }> = {};
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Handle an escalation trigger.
+ * This is the main entry point for integrating triggers with escalation actions.
+ * 
+ * @param context - The trigger context
+ * @returns The escalation actions taken
+ */
+export async function handleEscalationTrigger(
+  context: TriggerContext
+): Promise<EscalationAction> {
+  const actionId = randomUUID();
+  const timestamp = new Date().toISOString();
+  
+  const action: EscalationAction = {
+    actionId,
+    timestamp,
+    pause: false,
+    handoff: false,
+    notification: false,
+    reason: `Escalation triggered by ${context.source}`,
+  };
+
+  // Determine severity
+  const severity = context.severity || "warning";
+  
+  // Determine notification type
+  const notificationType = mapSourceToNotificationType(context.source);
+
+  // Check if we should pause
+  const shouldPauseResult = shouldPause(context);
+  if (shouldPauseResult) {
+    const pauseMode = determinePauseMode(context);
+    try {
+      await pause(pauseMode, {
+        reason: `Auto-paused due to ${context.source}: ${context.message || "No details"}`,
+        pausedBy: "escalation-system",
+      });
+      action.pause = true;
+      action.pauseMode = pauseMode;
+    } catch (err) {
+      console.error(`[escalation] Failed to pause: ${err}`);
+    }
+  }
+
+  // Check if we should create handoff
+  const shouldCreateHandoffResult = shouldCreateHandoff(context);
+  if (shouldCreateHandoffResult) {
+    try {
+      const handoffSeverity = mapToHandoffSeverity(severity);
+      const handoffContext: HandoffContext = {
+        workflowIds: context.workflowId ? [context.workflowId] : undefined,
+        sessionId: context.sessionId,
+        claudeSessionId: context.claudeSessionId,
+        source: context.sourceChannel,
+        channelId: context.channelId,
+        threadId: context.threadId,
+        relatedEventIds: context.eventId ? [context.eventId] : undefined,
+      };
+      
+      await createHandoff(
+        `Escalation from ${context.source}: ${context.message || "Trigger activated"}`,
+        handoffContext,
+        {
+          severity: handoffSeverity,
+          summary: context.message || `Escalation triggered by ${context.source}`,
+          metadata: context.details,
+        }
+      );
+      action.handoff = true;
+    } catch (err) {
+      console.error(`[escalation] Failed to create handoff: ${err}`);
+    }
+  }
+
+  // Check if we should send notification
+  const shouldNotifyResult = shouldNotify(context);
+  if (shouldNotifyResult) {
+    try {
+      await notify(notificationType, severity, context.message || `Escalation: ${context.source}`, {
+        eventId: context.eventId,
+        workflowId: context.workflowId,
+        sessionId: context.sessionId,
+        details: context.details,
+      });
+      action.notification = true;
+      action.notificationType = notificationType;
+    } catch (err) {
+      console.error(`[escalation] Failed to notify: ${err}`);
+    }
+  }
+
+  // Log escalation action
+  await logAudit({
+    timestamp,
+    eventId: `escalation-${actionId}`,
+    requestId: actionId,
+    source: context.source,
+    toolName: "EscalationTrigger",
+    action: severity === "critical" ? "require_approval" : "allow",
+    reason: action.reason,
+    metadata: {
+      pause: action.pause,
+      handoff: action.handoff,
+      notification: action.notification,
+      context: {
+        eventId: context.eventId,
+        workflowId: context.workflowId,
+        sessionId: context.sessionId,
+      },
+    },
+  });
+
+  console.log(`[escalation] Handled ${context.source} trigger: pause=${action.pause}, handoff=${action.handoff}, notify=${action.notification}`);
+
+  return action;
+}
+
+/**
+ * Determine if the system should pause based on a trigger.
+ * 
+ * @param context - The trigger context
+ * @returns True if the system should pause
+ */
+export function shouldPause(context: TriggerContext): boolean {
+  const { source, severity, watchdogDecision } = context;
+
+  switch (source) {
+    case "policy_denial":
+      return currentPolicy.pauseOnCriticalPolicyDenial && severity === "critical";
+
+    case "watchdog":
+      if (!currentPolicy.pauseOnWatchdogSuspend) return false;
+      // Pause on suspend or kill states
+      return watchdogDecision?.state === "suspend" || watchdogDecision?.state === "kill";
+
+    case "dlq_overflow":
+      return currentPolicy.pauseOnDlqOverflow;
+
+    case "orchestration_failure":
+      if (!currentPolicy.pauseOnRepeatedOrchestrationFailures) return false;
+      
+      // Track repeated failures
+      const key = context.workflowId || context.sessionId || "global";
+      const now = new Date().toISOString();
+      
+      if (!failureCounts[key]) {
+        failureCounts[key] = { count: 1, lastFailure: now };
+        return false;
+      }
+      
+      // Reset count if last failure was more than 5 minutes ago
+      const lastFailure = new Date(failureCounts[key].lastFailure);
+      if (Date.now() - lastFailure.getTime() > 300000) {
+        failureCounts[key] = { count: 1, lastFailure: now };
+        return false;
+      }
+      
+      failureCounts[key].count++;
+      failureCounts[key].lastFailure = now;
+      
+      return failureCounts[key].count >= currentPolicy.repeatedFailureThreshold;
+
+    case "manual_escalation":
+      // Manual escalations don't auto-pause
+      return false;
+
+    case "policy_approval_timeout":
+      // Approval timeouts don't auto-pause
+      return false;
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Determine if a handoff should be created based on a trigger.
+ * 
+ * @param context - The trigger context
+ * @returns True if a handoff should be created
+ */
+export function shouldCreateHandoff(context: TriggerContext): boolean {
+  const { source, severity } = context;
+  
+  // Check minimum severity
+  const severityOrder: HandoffSeverity[] = ["info", "warning", "critical"];
+  const minIndex = severityOrder.indexOf(currentPolicy.minHandoffSeverity);
+  const severityIndex = severityOrder.indexOf((severity as HandoffSeverity) || "info");
+  
+  if (severityIndex < minIndex) {
+    return false;
+  }
+
+  switch (source) {
+    case "policy_denial":
+      return currentPolicy.createHandoffOnPolicyDenial;
+
+    case "watchdog":
+      return currentPolicy.createHandoffOnWatchdogTrigger;
+
+    case "manual_escalation":
+      return currentPolicy.createHandoffOnManualEscalation;
+
+    case "dlq_overflow":
+      // DLQ overflow usually handled by retry, but create handoff if critical
+      return severity === "critical";
+
+    case "orchestration_failure":
+      // Create handoff for repeated failures
+      return severity === "critical";
+
+    case "policy_approval_timeout":
+      return true;
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Determine if a notification should be sent based on a trigger.
+ * 
+ * @param context - The trigger context
+ * @returns True if a notification should be sent
+ */
+export function shouldNotify(context: TriggerContext): boolean {
+  const { source } = context;
+
+  switch (source) {
+    case "policy_denial":
+      return currentPolicy.notifyOnPolicyDenial;
+
+    case "watchdog":
+      return currentPolicy.notifyOnWatchdog;
+
+    case "dlq_overflow":
+      return currentPolicy.notifyOnDlqOverflow;
+
+    case "orchestration_failure":
+      return currentPolicy.notifyOnOrchestrationFailure;
+
+    case "manual_escalation":
+      return true;
+
+    case "policy_approval_timeout":
+      return true;
+
+    default:
+      return true;
+  }
+}
+
+// ============================================================================
+// Policy Management
+// ============================================================================
+
+/**
+ * Configure the escalation policy.
+ */
+export function configureEscalationPolicy(policy: Partial<EscalationPolicy>): void {
+  currentPolicy = {
+    ...currentPolicy,
+    ...policy,
+  };
+  console.log("[escalation] Policy updated");
+}
+
+/**
+ * Get the current escalation policy.
+ */
+export function getEscalationPolicy(): EscalationPolicy {
+  return { ...currentPolicy };
+}
+
+/**
+ * Reset the escalation policy to defaults.
+ */
+export function resetEscalationPolicy(): void {
+  currentPolicy = { ...DEFAULT_ESCALATION_POLICY };
+  // Clear failure counts
+  for (const key of Object.keys(failureCounts)) {
+    delete failureCounts[key];
+  }
+}
+
+// ============================================================================
+// Convenience Methods for Specific Triggers
+// ============================================================================
+
+/**
+ * Handle a policy denial trigger.
+ */
+export async function handlePolicyDenial(
+  eventId: string,
+  toolName: string,
+  reason: string,
+  options?: {
+    severity?: "warning" | "critical";
+    channelId?: string;
+    sessionId?: string;
+    workflowId?: string;
+  }
+): Promise<EscalationAction> {
+  return handleEscalationTrigger({
+    source: "policy_denial",
+    eventId,
+    channelId: options?.channelId,
+    sessionId: options?.sessionId,
+    workflowId: options?.workflowId,
+    severity: options?.severity || "warning",
+    message: `Policy denied ${toolName}: ${reason}`,
+    details: { toolName, reason },
+  });
+}
+
+/**
+ * Handle a watchdog trigger.
+ */
+export async function handleWatchdogTrigger(
+  decision: WatchdogDecision,
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  }
+): Promise<EscalationAction> {
+  const severity = decision.state === "kill" ? "critical" : 
+                   decision.state === "suspend" ? "warning" : "info";
+  
+  return handleEscalationTrigger({
+    source: "watchdog",
+    sessionId: context.sessionId,
+    severity,
+    message: `Watchdog ${decision.state}: ${decision.reason}`,
+    details: { decision, invocationId: context.invocationId },
+    watchdogDecision: decision,
+  });
+}
+
+/**
+ * Handle a DLQ overflow trigger.
+ */
+export async function handleDlqOverflow(
+  dlqSize: number,
+  threshold: number,
+  options?: {
+    eventId?: string;
+    workflowId?: string;
+  }
+): Promise<EscalationAction> {
+  const severity = dlqSize > threshold * 2 ? "critical" : "warning";
+  
+  return handleEscalationTrigger({
+    source: "dlq_overflow",
+    eventId: options?.eventId,
+    workflowId: options?.workflowId,
+    severity,
+    message: `DLQ overflow: ${dlqSize} items (threshold: ${threshold})`,
+    details: { dlqSize, threshold },
+  });
+}
+
+/**
+ * Handle an orchestration failure trigger.
+ */
+export async function handleOrchestrationFailure(
+  workflowId: string,
+  error: string,
+  options?: {
+    sessionId?: string;
+    eventId?: string;
+  }
+): Promise<EscalationAction> {
+  // Check if this is a repeated failure
+  const count = failureCounts[workflowId]?.count || 0;
+  const severity = count >= currentPolicy.repeatedFailureThreshold - 1 ? "critical" : "warning";
+  
+  return handleEscalationTrigger({
+    source: "orchestration_failure",
+    workflowId,
+    sessionId: options?.sessionId,
+    eventId: options?.eventId,
+    severity,
+    message: `Orchestration failure: ${error}`,
+    details: { workflowId, error, failureCount: count + 1 },
+  });
+}
+
+/**
+ * Handle a manual escalation trigger.
+ */
+export async function handleManualEscalation(
+  reason: string,
+  options?: {
+    severity?: HandoffSeverity;
+    eventId?: string;
+    workflowId?: string;
+    sessionId?: string;
+    channelId?: string;
+  }
+): Promise<EscalationAction> {
+  return handleEscalationTrigger({
+    source: "manual_escalation",
+    eventId: options?.eventId,
+    workflowId: options?.workflowId,
+    sessionId: options?.sessionId,
+    channelId: options?.channelId,
+    severity: (options?.severity as "info" | "warning" | "critical") || "warning",
+    message: `Manual escalation: ${reason}`,
+    details: { reason },
+  });
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function mapSourceToNotificationType(source: TriggerSource): NotificationType {
+  switch (source) {
+    case "policy_denial":
+    case "policy_approval_timeout":
+      return "policy_denial";
+    case "watchdog":
+      return "watchdog";
+    case "dlq_overflow":
+      return "dlq_overflow";
+    case "orchestration_failure":
+      return "error";
+    case "manual_escalation":
+      return "manual_escalation";
+    default:
+      return "error";
+  }
+}
+
+function mapToHandoffSeverity(severity: "info" | "warning" | "critical"): HandoffSeverity {
+  return severity as HandoffSeverity;
+}
+
+function determinePauseMode(context: TriggerContext): PauseMode {
+  // For critical issues, pause both admission and scheduling
+  if (context.severity === "critical" || context.watchdogDecision?.state === "kill") {
+    return "admission_and_scheduling";
+  }
+  
+  // For less severe issues, only pause admission
+  return "admission_only";
+}
+
+// ============================================================================
+// Testing Helpers
+// ============================================================================
+
+/**
+ * Reset the trigger integration (for testing only).
+ */
+export function resetTriggerIntegration(): void {
+  resetEscalationPolicy();
+}
+
+/**
+ * Get current failure counts (for testing only).
+ */
+export function getFailureCounts(): Record<string, { count: number; lastFailure: string }> {
+  return { ...failureCounts };
+}
+
+/**
+ * Clear failure count for a key (for testing only).
+ */
+export function clearFailureCount(key: string): void {
+  delete failureCounts[key];
+}

--- a/src/event-log.ts
+++ b/src/event-log.ts
@@ -1,0 +1,701 @@
+/**
+ * Durable Event Log
+ * 
+ * Segmented append-only event storage with monotonic sequence numbers.
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All writes use atomic file operations (write to temp, rename)
+ * - Segment metadata is written before data to ensure index consistency
+ * - Sequence numbers are allocated atomically with the write operation
+ * - Partial writes are detected and recovered on next startup
+ * 
+ * STORAGE MODEL:
+ * - Events stored in .claude/claudeclaw/event-log/
+ * - Segments: event-log-YYYYMMDD-HHMMSS-{seq}.jsonl
+ * - Index: segments.json (maps seq ranges to segment files)
+ * - Current segment tracked in current-segment.json
+ * - Max segment size: 10MB or daily rotation
+ * 
+ * RECOVERY:
+ * - On init, scan segments and rebuild index if corrupted
+ * - Verify segment files exist and are readable
+ * - Detect gaps in sequence numbers
+ * - Rebuild current-segment pointer from latest segment
+ */
+
+import { join } from "path";
+import { mkdir, readdir, rename, stat, unlink } from "fs/promises";
+import { existsSync } from "fs";
+import { randomUUID } from "crypto";
+
+const EVENT_LOG_DIR = join(process.cwd(), ".claude", "claudeclaw", "event-log");
+const SEGMENTS_INDEX_FILE = join(EVENT_LOG_DIR, "segments.json");
+const CURRENT_SEGMENT_FILE = join(EVENT_LOG_DIR, "current-segment.json");
+const MAX_SEGMENT_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+/**
+ * Sanitize a string for safe logging - removes control characters
+ * and limits length to prevent log injection attacks.
+ */
+function sanitizeForLog(value: unknown, maxLength = 1000): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  // Remove control characters except common whitespace
+  const sanitized = str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+  return sanitized.slice(0, maxLength);
+}
+
+export type EventStatus =
+  | "pending"
+  | "processing"
+  | "done"
+  | "retry_scheduled"
+  | "dead_lettered";
+
+export interface EventRecord {
+  id: string;
+  seq: number;
+  type: string;
+  source: string;
+  timestamp: string;
+  createdAt: string;
+  updatedAt: string;
+  status: EventStatus;
+  channelId: string;
+  threadId: string;
+  payload: unknown;
+  dedupeKey: string;
+  retryCount: number;
+  nextRetryAt: string | null;
+  correlationId: string | null;
+  causationId: string | null;
+  replayedFromEventId: string | null;
+  lastError: string | null;
+}
+
+export interface EventEntryInput {
+  type: string;
+  source: string;
+  channelId: string;
+  threadId: string;
+  payload: unknown;
+  dedupeKey: string;
+  correlationId?: string | null;
+  causationId?: string | null;
+  replayedFromEventId?: string | null;
+}
+
+interface SegmentInfo {
+  filename: string;
+  startSeq: number;
+  endSeq: number;
+  createdAt: string;
+  sizeBytes: number;
+}
+
+interface SegmentsIndex {
+  version: number;
+  segments: SegmentInfo[];
+  lastSeq: number;
+  updatedAt: string;
+}
+
+interface CurrentSegment {
+  filename: string;
+  startSeq: number;
+  nextSeq: number;
+  createdAt: string;
+  sizeBytes: number;
+}
+
+let segmentsIndex: SegmentsIndex | null = null;
+let currentSegment: CurrentSegment | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+// Write queue for serializing concurrent append operations
+let writeQueue: Promise<void> = Promise.resolve();
+let writeQueueLength = 0;
+
+/**
+ * Enqueue a write operation to ensure serial execution.
+ * This prevents race conditions in sequence number allocation.
+ */
+function enqueueWrite<T>(operation: () => Promise<T>): Promise<T> {
+  writeQueueLength++;
+  const promise = writeQueue.then(() => operation());
+  writeQueue = promise.then(
+    () => { writeQueueLength--; },
+    () => { writeQueueLength--; }
+  );
+  return promise;
+}
+
+/**
+ * Get the current length of the write queue.
+ */
+export function getWriteQueueLength(): number {
+  return writeQueueLength;
+}
+
+/**
+ * Reset the event log state (for testing).
+ * Clears all in-memory state and forces re-initialization.
+ */
+export function resetEventLog(): void {
+  segmentsIndex = null;
+  currentSegment = null;
+  initializationPromise = null;
+  writeQueue = Promise.resolve();
+  writeQueueLength = 0;
+}
+
+/**
+ * Initialize the event log system.
+ * Creates directories, loads or rebuilds index, verifies segment consistency.
+ */
+export async function initEventLog(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directory exists
+  await mkdir(EVENT_LOG_DIR, { recursive: true });
+
+  // Try to load existing state
+  segmentsIndex = await loadSegmentsIndex();
+  currentSegment = await loadCurrentSegment();
+
+  // Validate and repair if needed
+  const needsRebuild = await validateAndRepairState();
+  
+  if (needsRebuild || !segmentsIndex || !currentSegment) {
+    await rebuildStateFromDisk();
+  }
+}
+
+/**
+ * Validate segment state and detect corruption.
+ * Returns true if rebuild is needed.
+ */
+async function validateAndRepairState(): Promise<boolean> {
+  if (!segmentsIndex || !currentSegment) {
+    return true;
+  }
+
+  // Check current segment file exists
+  const currentPath = join(EVENT_LOG_DIR, currentSegment.filename);
+  if (!existsSync(currentPath)) {
+    console.warn("[event-log] Current segment file missing, rebuilding state");
+    return true;
+  }
+
+  // Verify index segments exist
+  for (const seg of segmentsIndex.segments) {
+    const segPath = join(EVENT_LOG_DIR, seg.filename);
+    if (!existsSync(segPath)) {
+      console.warn(`[event-log] Segment ${seg.filename} missing from index, rebuilding`);
+      return true;
+    }
+  }
+
+  // Check for sequence number consistency
+  const expectedNextSeq = segmentsIndex.lastSeq + 1;
+  if (currentSegment.nextSeq !== expectedNextSeq) {
+    console.warn(
+      `[event-log] Sequence mismatch: index.lastSeq=${segmentsIndex.lastSeq}, ` +
+      `current.nextSeq=${currentSegment.nextSeq}, expected=${expectedNextSeq}`
+    );
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Rebuild state by scanning disk.
+ * Used on first init or when corruption is detected.
+ */
+async function rebuildStateFromDisk(): Promise<void> {
+  console.log("[event-log] Rebuilding state from disk...");
+
+  const files = await readdir(EVENT_LOG_DIR);
+  const segmentFiles = files
+    .filter(f => f.startsWith("event-log-") && f.endsWith(".jsonl"))
+    .sort();
+
+  const segments: SegmentInfo[] = [];
+  let lastSeq = 0;
+
+  for (const filename of segmentFiles) {
+    const segPath = join(EVENT_LOG_DIR, filename);
+    const stats = await stat(segPath);
+    
+    // Parse sequence range from file content
+    const seqRange = await readSegmentSeqRange(segPath);
+    
+    if (seqRange) {
+      segments.push({
+        filename,
+        startSeq: seqRange.start,
+        endSeq: seqRange.end,
+        createdAt: stats.birthtime.toISOString(),
+        sizeBytes: stats.size,
+      });
+      lastSeq = Math.max(lastSeq, seqRange.end);
+    }
+  }
+
+  // Build new index
+  segmentsIndex = {
+    version: 1,
+    segments,
+    lastSeq,
+    updatedAt: new Date().toISOString(),
+  };
+
+  // Determine current segment
+  if (segments.length > 0) {
+    const latest = segments[segments.length - 1];
+    const latestPath = join(EVENT_LOG_DIR, latest.filename);
+    const latestStats = await stat(latestPath);
+    
+    currentSegment = {
+      filename: latest.filename,
+      startSeq: latest.startSeq,
+      nextSeq: latest.endSeq + 1,
+      createdAt: latest.createdAt,
+      sizeBytes: latestStats.size,
+    };
+  } else {
+    // No segments exist, create initial
+    await createNewSegment(1);
+  }
+
+  // Persist rebuilt state
+  await saveSegmentsIndex();
+  await saveCurrentSegment();
+
+  console.log(`[event-log] State rebuilt: ${segments.length} segments, lastSeq=${lastSeq}`);
+}
+
+/**
+ * Read sequence range from a segment file.
+ * Returns null if file is empty or corrupted.
+ */
+async function readSegmentSeqRange(filepath: string): Promise<{ start: number; end: number } | null> {
+  try {
+    const content = await Bun.file(filepath).text();
+    const lines = content.trim().split("\n").filter(l => l.trim());
+    
+    if (lines.length === 0) {
+      return null;
+    }
+
+    const first = JSON.parse(lines[0]) as EventRecord;
+    const last = JSON.parse(lines[lines.length - 1]) as EventRecord;
+
+    return { start: first.seq, end: last.seq };
+  } catch (err) {
+    console.warn(`[event-log] Failed to read segment ${filepath}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Load segments index from disk.
+ */
+async function loadSegmentsIndex(): Promise<SegmentsIndex | null> {
+  try {
+    const content = await Bun.file(SEGMENTS_INDEX_FILE).json();
+    if (content.version === 1 && Array.isArray(content.segments)) {
+      return content as SegmentsIndex;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load current segment pointer from disk.
+ */
+async function loadCurrentSegment(): Promise<CurrentSegment | null> {
+  try {
+    return await Bun.file(CURRENT_SEGMENT_FILE).json() as CurrentSegment;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save segments index atomically.
+ * CRASH-SAFE: Write directly using Bun.write which is atomic.
+ */
+async function saveSegmentsIndex(): Promise<void> {
+  if (!segmentsIndex) return;
+  
+  segmentsIndex.updatedAt = new Date().toISOString();
+  await Bun.write(SEGMENTS_INDEX_FILE, JSON.stringify(segmentsIndex, null, 2) + "\n");
+}
+
+/**
+ * Save current segment pointer atomically.
+ * CRASH-SAFE: Write directly using Bun.write which is atomic.
+ */
+async function saveCurrentSegment(): Promise<void> {
+  if (!currentSegment) return;
+  
+  await Bun.write(CURRENT_SEGMENT_FILE, JSON.stringify(currentSegment, null, 2) + "\n");
+}
+
+/**
+ * Create a new segment file.
+ */
+async function createNewSegment(startSeq: number): Promise<void> {
+  const now = new Date();
+  // Format: YYYYMMDD-HHMMSS (no colons for filesystem compatibility)
+  const timestamp = now.toISOString()
+    .replace(/[:.]/g, "-")  // Replace colons and dots
+    .replace("T", "_");      // Replace T with underscore
+  const filename = `event-log-${timestamp}-${startSeq}.jsonl`;
+  
+  currentSegment = {
+    filename,
+    startSeq,
+    nextSeq: startSeq,
+    createdAt: new Date().toISOString(),
+    sizeBytes: 0,
+  };
+
+  // Create empty segment file
+  const segPath = join(EVENT_LOG_DIR, filename);
+  await Bun.write(segPath, "");
+  
+  await saveCurrentSegment();
+}
+
+/**
+ * Check if current segment needs rotation.
+ */
+async function shouldRotateSegment(): Promise<boolean> {
+  if (!currentSegment) return true;
+
+  // Check size
+  if (currentSegment.sizeBytes >= MAX_SEGMENT_SIZE_BYTES) {
+    return true;
+  }
+
+  // Check age (daily rotation)
+  const created = new Date(currentSegment.createdAt);
+  const now = new Date();
+  const isDifferentDay = 
+    created.getUTCFullYear() !== now.getUTCFullYear() ||
+    created.getUTCMonth() !== now.getUTCMonth() ||
+    created.getUTCDate() !== now.getUTCDate();
+
+  return isDifferentDay;
+}
+
+/**
+ * Rotate to a new segment.
+ */
+async function rotateSegment(): Promise<void> {
+  if (!currentSegment || !segmentsIndex) {
+    throw new Error("Event log not initialized");
+  }
+
+  // Archive current segment in index
+  const finalSeq = currentSegment.nextSeq - 1;
+  segmentsIndex.segments.push({
+    filename: currentSegment.filename,
+    startSeq: currentSegment.startSeq,
+    endSeq: finalSeq,
+    createdAt: currentSegment.createdAt,
+    sizeBytes: currentSegment.sizeBytes,
+  });
+  segmentsIndex.lastSeq = finalSeq;
+
+  await saveSegmentsIndex();
+
+  // Create new segment
+  await createNewSegment(currentSegment.nextSeq);
+
+  console.log(
+    `[event-log] Rotated segment: ${currentSegment.filename} ` +
+    `(seq ${currentSegment.startSeq}-${finalSeq})`
+  );
+}
+
+/**
+ * Append an event to the log.
+ * CRASH-SAFE: Event is written atomically with sequence number allocation.
+ * THREAD-SAFE: Uses write queue to serialize concurrent operations.
+ */
+export async function append(entry: EventEntryInput): Promise<EventRecord> {
+  await initEventLog();
+
+  return enqueueWrite(async () => {
+    if (!currentSegment || !segmentsIndex) {
+      throw new Error("Event log not initialized");
+    }
+
+    // Check rotation
+    if (await shouldRotateSegment()) {
+      await rotateSegment();
+    }
+
+    // Allocate sequence number
+    const seq = currentSegment.nextSeq;
+    const now = new Date().toISOString();
+
+    const record: EventRecord = {
+      id: randomUUID(),
+      seq,
+      type: sanitizeForLog(entry.type),
+      source: sanitizeForLog(entry.source),
+      timestamp: now,
+      createdAt: now,
+      updatedAt: now,
+      status: "pending",
+      channelId: sanitizeForLog(entry.channelId),
+      threadId: sanitizeForLog(entry.threadId),
+      payload: entry.payload,
+      dedupeKey: sanitizeForLog(entry.dedupeKey),
+      retryCount: 0,
+      nextRetryAt: null,
+      correlationId: entry.correlationId ? sanitizeForLog(entry.correlationId) : null,
+      causationId: entry.causationId ? sanitizeForLog(entry.causationId) : null,
+      replayedFromEventId: entry.replayedFromEventId ? sanitizeForLog(entry.replayedFromEventId) : null,
+      lastError: null,
+    };
+
+    // Serialize event
+    const line = JSON.stringify(record) + "\n";
+    const lineBytes = new TextEncoder().encode(line).length;
+
+    // CRASH-SAFE WRITE:
+    // Use append mode to add to existing file atomically via Bun.write
+    // For true atomicity with Bun, we write the entire content
+    const segPath = join(EVENT_LOG_DIR, currentSegment.filename);
+
+    // Read existing content
+    let existingContent = "";
+    try {
+      existingContent = await Bun.file(segPath).text();
+    } catch {
+      // File might not exist yet, which is fine
+    }
+
+    // CRASH-SAFE: write to temp file then atomically rename
+    const tmpPath = segPath + ".tmp";
+    await Bun.write(tmpPath, existingContent + line);
+    await rename(tmpPath, segPath);
+
+    // Update in-memory state
+    currentSegment.nextSeq = seq + 1;
+    currentSegment.sizeBytes += lineBytes;
+    segmentsIndex.lastSeq = seq;
+
+    // Persist pointers
+    await saveCurrentSegment();
+    await saveSegmentsIndex();
+
+    return record;
+  });
+}
+
+/**
+ * Read events starting from a sequence number.
+ * Handles reading across segment boundaries.
+ */
+export async function* readFrom(startSeq: number): AsyncGenerator<EventRecord> {
+  await initEventLog();
+
+  if (!segmentsIndex) {
+    throw new Error("Event log not initialized");
+  }
+
+  // Find starting segment
+  let started = false;
+
+  // First, check archived segments
+  for (const seg of segmentsIndex.segments) {
+    if (seg.endSeq < startSeq) {
+      continue; // Segment is before start
+    }
+
+    const segPath = join(EVENT_LOG_DIR, seg.filename);
+    const events = await readSegmentEvents(segPath, startSeq);
+    
+    for (const event of events) {
+      yield event;
+      started = true;
+    }
+  }
+
+  // Then check current segment
+  if (currentSegment && currentSegment.startSeq <= startSeq) {
+    const segPath = join(EVENT_LOG_DIR, currentSegment.filename);
+    const events = await readSegmentEvents(segPath, startSeq);
+    
+    for (const event of events) {
+      yield event;
+    }
+  }
+}
+
+/**
+ * Read events in a sequence range.
+ */
+export async function* readRange(
+  startSeq: number,
+  endSeq: number
+): AsyncGenerator<EventRecord> {
+  for await (const event of readFrom(startSeq)) {
+    if (event.seq > endSeq) {
+      break;
+    }
+    yield event;
+  }
+}
+
+/**
+ * Read events from a segment file, filtered by start sequence.
+ */
+async function readSegmentEvents(
+  filepath: string,
+  startSeq: number
+): Promise<EventRecord[]> {
+  try {
+    const content = await Bun.file(filepath).text();
+    const lines = content.trim().split("\n").filter(l => l.trim());
+    
+    const events: EventRecord[] = [];
+    for (const line of lines) {
+      try {
+        const event = JSON.parse(line) as EventRecord;
+        if (event.seq >= startSeq) {
+          events.push(event);
+        }
+      } catch {
+        // Skip corrupted lines
+        console.warn("[event-log] Skipping corrupted line in segment");
+      }
+    }
+
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get the last assigned sequence number.
+ */
+export async function getLastSeq(): Promise<number> {
+  await initEventLog();
+  return segmentsIndex?.lastSeq ?? 0;
+}
+
+/**
+ * Get statistics about the event log.
+ */
+export async function getStats(): Promise<{
+  totalSegments: number;
+  totalEvents: number;
+  lastSeq: number;
+  currentSegmentSize: number;
+}> {
+  await initEventLog();
+
+  return {
+    totalSegments: segmentsIndex?.segments.length ?? 0,
+    totalEvents: segmentsIndex?.lastSeq ?? 0,
+    lastSeq: segmentsIndex?.lastSeq ?? 0,
+    currentSegmentSize: currentSegment?.sizeBytes ?? 0,
+  };
+}
+
+/**
+ * Update an event's status and retry information.
+ * Note: This creates a new log entry rather than modifying existing ones,
+ * preserving the append-only invariant.
+ */
+export async function appendStatusUpdate(
+  originalEventId: string,
+  updates: Partial<Pick<EventRecord, "status" | "retryCount" | "nextRetryAt" | "lastError">>
+): Promise<EventRecord> {
+  // Read the original event
+  const original = await findEventById(originalEventId);
+  if (!original) {
+    throw new Error(`Event ${originalEventId} not found`);
+  }
+
+  // Create update entry as a new event with causationId pointing to original
+  const updateEntry: EventEntryInput = {
+    type: "__status_update__",
+    source: "event-log",
+    channelId: original.channelId,
+    threadId: original.threadId,
+    payload: {
+      originalEventId: sanitizeForLog(originalEventId),
+      originalSeq: original.seq,
+      updates,
+    },
+    dedupeKey: `status-update-${sanitizeForLog(originalEventId)}-${Date.now()}`,
+    causationId: original.id,
+    correlationId: original.correlationId,
+  };
+
+  return append(updateEntry);
+}
+
+/**
+ * Find an event by ID. Searches from most recent backwards.
+ * Note: This is O(n) and should be used sparingly.
+ */
+export async function findEventById(eventId: string): Promise<EventRecord | null> {
+  // Search backwards from current segment
+  const allSegments = [...(segmentsIndex?.segments ?? [])];
+  if (currentSegment) {
+    allSegments.push({
+      filename: currentSegment.filename,
+      startSeq: currentSegment.startSeq,
+      endSeq: currentSegment.nextSeq - 1,
+      createdAt: currentSegment.createdAt,
+      sizeBytes: currentSegment.sizeBytes,
+    });
+  }
+
+  // Search in reverse order (newest first)
+  for (let i = allSegments.length - 1; i >= 0; i--) {
+    const seg = allSegments[i];
+    const segPath = join(EVENT_LOG_DIR, seg.filename);
+    
+    try {
+      const content = await Bun.file(segPath).text();
+      const lines = content.trim().split("\n").filter(l => l.trim());
+      
+      // Search backwards within segment
+      for (let j = lines.length - 1; j >= 0; j--) {
+        try {
+          const event = JSON.parse(lines[j]) as EventRecord;
+          if (event.id === eventId) {
+            return event;
+          }
+        } catch {
+          // Skip corrupted lines
+        }
+      }
+    } catch {
+      // Continue to next segment
+    }
+  }
+
+  return null;
+}

--- a/src/event-processor.ts
+++ b/src/event-processor.ts
@@ -1,0 +1,499 @@
+/**
+ * Idempotent Event Processor
+ * 
+ * Processes events from the durable event log with deduplication support.
+ * 
+ * DEDUPLICATION STRATEGY:
+ * - Uses dedupeKey from event record (prefer upstream event IDs when available)
+ * - Falls back to canonical key: hash(source + type + channelId + threadId + normalizedPayload)
+ * - Persists dedupe state to disk with retention policy
+ * - Dedupe state is replay-safe and survives restarts
+ * 
+ * RETENTION:
+ * - Default retention: 7 days
+ * - Configurable via config
+ * - Cleanup runs periodically
+ * 
+ * PROCESSING:
+ * - Phase 1: Serial processing for correctness
+ * - Design supports future partitioned concurrency
+ * - Events processed in sequence order
+ */
+
+import { join } from "path";
+import { mkdir } from "fs/promises";
+import { createHash } from "crypto";
+import {
+  initEventLog,
+  readFrom,
+  appendStatusUpdate,
+  getLastSeq,
+  findEventById,
+  type EventRecord,
+  type EventStatus,
+} from "./event-log";
+import { list as listDLQ } from "./dead-letter-queue";
+import { handleDlqOverflow } from "./escalation";
+
+const DEDUPE_DIR = join(process.cwd(), ".claude", "claudeclaw", "dedupe");
+const DEDUPE_STATE_FILE = join(DEDUPE_DIR, "state.json");
+const DEFAULT_RETENTION_DAYS = 7;
+
+interface DedupeEntry {
+  key: string;
+  eventId: string;
+  eventSeq: number;
+  timestamp: string;
+  processedAt: string;
+}
+
+interface DedupeState {
+  version: number;
+  entries: DedupeEntry[];
+  lastCleanupAt: string;
+}
+
+interface ProcessorConfig {
+  retentionDays: number;
+  onEvent: (event: EventRecord) => Promise<ProcessingResult>;
+}
+
+export interface ProcessingResult {
+  success: boolean;
+  error?: string;
+  shouldRetry?: boolean;
+}
+
+let dedupeState: DedupeState | null = null;
+let processorConfig: ProcessorConfig | null = null;
+let isProcessing = false;
+let lastProcessedSeq = 0;
+
+/**
+ * Initialize the event processor.
+ * Loads or creates dedupe state.
+ */
+export async function initProcessor(config: ProcessorConfig): Promise<void> {
+  await initEventLog();
+  await mkdir(DEDUPE_DIR, { recursive: true });
+
+  processorConfig = config;
+  lastProcessedSeq = 0; // Always start fresh
+
+  // Load or create dedupe state
+  dedupeState = await loadDedupeState();
+  if (!dedupeState) {
+    dedupeState = {
+      version: 1,
+      entries: [],
+      lastCleanupAt: new Date().toISOString(),
+    };
+    await saveDedupeState();
+  }
+
+  // Run cleanup if needed
+  await maybeCleanup();
+}
+
+/**
+ * Load dedupe state from disk.
+ */
+async function loadDedupeState(): Promise<DedupeState | null> {
+  try {
+    const content = await Bun.file(DEDUPE_STATE_FILE).json();
+    if (content.version === 1 && Array.isArray(content.entries)) {
+      return content as DedupeState;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save dedupe state atomically.
+ */
+async function saveDedupeState(): Promise<void> {
+  if (!dedupeState) return;
+  await Bun.write(DEDUPE_STATE_FILE, JSON.stringify(dedupeState, null, 2) + "\n");
+}
+
+/**
+ * Generate a canonical dedupe key for an event.
+ * Used when upstream doesn't provide a dedupeKey.
+ */
+function generateDedupeKey(event: EventRecord): string {
+  // Normalize payload for consistent hashing
+  const normalizedPayload = JSON.stringify(event.payload, Object.keys(event.payload || {}).sort());
+  
+  const keyData = `${event.source}:${event.type}:${event.channelId}:${event.threadId}:${normalizedPayload}`;
+  return createHash("sha256").update(keyData).digest("hex");
+}
+
+/**
+ * Get the effective dedupe key for an event.
+ * Prefers upstream dedupeKey, falls back to canonical key.
+ */
+function getDedupeKey(event: EventRecord): string {
+  // If upstream provided a dedupeKey, use it
+  if (event.dedupeKey && event.dedupeKey.length > 0) {
+    return event.dedupeKey;
+  }
+  
+  // Otherwise generate canonical key
+  return generateDedupeKey(event);
+}
+
+/**
+ * Check if an event is a duplicate.
+ */
+function isDuplicate(key: string): boolean {
+  if (!dedupeState) return false;
+  return dedupeState.entries.some(e => e.key === key);
+}
+
+/**
+ * Record an event as processed for deduplication.
+ */
+async function recordProcessed(event: EventRecord, key: string): Promise<void> {
+  if (!dedupeState) return;
+
+  const entry: DedupeEntry = {
+    key,
+    eventId: event.id,
+    eventSeq: event.seq,
+    timestamp: event.timestamp,
+    processedAt: new Date().toISOString(),
+  };
+
+  dedupeState.entries.push(entry);
+  await saveDedupeState();
+}
+
+/**
+ * Clean up old dedupe entries based on retention policy.
+ */
+async function cleanupOldEntries(): Promise<void> {
+  if (!dedupeState || !processorConfig) return;
+
+  const retentionDays = processorConfig.retentionDays ?? DEFAULT_RETENTION_DAYS;
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+  const cutoffISO = cutoffDate.toISOString();
+
+  const beforeCount = dedupeState.entries.length;
+  dedupeState.entries = dedupeState.entries.filter(e => e.timestamp >= cutoffISO);
+  dedupeState.lastCleanupAt = new Date().toISOString();
+
+  const removedCount = beforeCount - dedupeState.entries.length;
+  if (removedCount > 0) {
+    console.log(`[processor] Cleaned up ${removedCount} old dedupe entries`);
+    await saveDedupeState();
+  }
+}
+
+/**
+ * Run cleanup if it's been a while since the last one.
+ */
+async function maybeCleanup(): Promise<void> {
+  if (!dedupeState) return;
+
+  const lastCleanup = new Date(dedupeState.lastCleanupAt);
+  const now = new Date();
+  const hoursSinceCleanup = (now.getTime() - lastCleanup.getTime()) / (1000 * 60 * 60);
+
+  // Cleanup daily
+  if (hoursSinceCleanup >= 24) {
+    await cleanupOldEntries();
+  }
+}
+
+/**
+ * Process the next pending event.
+ * Returns true if an event was processed, false if no pending events.
+ */
+export async function processNext(): Promise<boolean> {
+  if (!processorConfig) {
+    throw new Error("Processor not initialized. Call initProcessor() first.");
+  }
+
+  if (isProcessing) {
+    return false; // Already processing
+  }
+
+  isProcessing = true;
+
+  try {
+    // Find next pending event
+    let nextEvent: EventRecord | null = null;
+    
+    for await (const event of readFrom(lastProcessedSeq + 1)) {
+      // Skip non-pending events and internal events (like status updates)
+      if (event.status !== "pending" || event.type.startsWith("__")) {
+        lastProcessedSeq = Math.max(lastProcessedSeq, event.seq);
+        continue;
+      }
+      // Skip events already processed (deduplication check against append-only log)
+      const eventDedupeKey = getDedupeKey(event);
+      if (isDuplicate(eventDedupeKey)) {
+        lastProcessedSeq = Math.max(lastProcessedSeq, event.seq);
+        continue;
+      }
+      nextEvent = event;
+      break;
+    }
+
+    if (!nextEvent) {
+      return false; // No pending events
+    }
+
+    // Process the event
+    console.log(`[processor] Processing event ${nextEvent.id} (seq ${nextEvent.seq}, type: ${nextEvent.type})`);
+    
+    let result: ProcessingResult;
+    try {
+      result = await processorConfig.onEvent(nextEvent);
+    } catch (err) {
+      result = {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+        shouldRetry: true,
+      };
+    }
+
+    if (result.success) {
+      // Mark as done
+      await appendStatusUpdate(nextEvent.id, {
+        status: "done",
+      });
+      
+      // Record for deduplication
+      await recordProcessed(nextEvent, dedupeKey);
+      
+      lastProcessedSeq = nextEvent.seq;
+      console.log(`[processor] Successfully processed event ${nextEvent.id}`);
+    } else {
+      // Handle failure
+      if (result.shouldRetry) {
+        // Mark for retry - retry scheduler will handle this
+        await appendStatusUpdate(nextEvent.id, {
+          status: "retry_scheduled",
+          lastError: result.error ?? null,
+        });
+        console.log(`[processor] Event ${nextEvent.id} failed, scheduled for retry: ${result.error}`);
+      } else {
+        // Permanent failure - will go to DLQ
+        await appendStatusUpdate(nextEvent.id, {
+          status: "dead_lettered",
+          lastError: result.error ?? null,
+        });
+        console.log(`[processor] Event ${nextEvent.id} permanently failed: ${result.error}`);
+
+        // Check DLQ overflow threshold and trigger escalation if needed
+        const DLQ_THRESHOLD = 100;
+        const dlqSize = listDLQ().length;
+        if (dlqSize > DLQ_THRESHOLD) {
+          await handleDlqOverflow(dlqSize, DLQ_THRESHOLD, { eventId: nextEvent.id });
+        }
+      }
+    }
+
+    return true;
+  } finally {
+    isProcessing = false;
+  }
+}
+
+/**
+ * Process a specific persisted event by ID.
+ * Used by the gateway to process inbound events.
+ */
+export async function processPersistedEvent(eventId: string): Promise<ProcessingResult> {
+  if (!processorConfig) {
+    return { success: false, error: "Processor not initialized. Call initProcessor() first." };
+  }
+
+  // Find the event
+  const event = await findEventById(eventId);
+  if (!event) {
+    return { success: false, error: `Event ${eventId} not found` };
+  }
+
+  // Check for duplicates
+  const dedupeKey = getDedupeKey(event);
+  if (isDuplicate(dedupeKey)) {
+    console.log(`[processor] Skipping duplicate event ${event.id} (seq ${event.seq})`);
+    return { success: true }; // Already processed
+  }
+
+  // Process the event
+  console.log(`[processor] Processing persisted event ${event.id} (seq ${event.seq}, type: ${event.type})`);
+
+  let result: ProcessingResult;
+  try {
+    result = await processorConfig.onEvent(event);
+  } catch (err) {
+    result = {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+      shouldRetry: true,
+    };
+  }
+
+  if (result.success) {
+    // Mark as done
+    await appendStatusUpdate(event.id, { status: "done" });
+    // Record for deduplication
+    await recordProcessed(event, dedupeKey);
+    console.log(`[processor] Successfully processed persisted event ${event.id}`);
+  } else {
+    // Handle failure
+    if (result.shouldRetry) {
+      await appendStatusUpdate(event.id, {
+        status: "retry_scheduled",
+        lastError: result.error ?? null,
+      });
+    } else {
+      await appendStatusUpdate(event.id, {
+        status: "dead_lettered",
+        lastError: result.error ?? null,
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Process all pending events sequentially.
+ * Returns the number of events processed.
+ */
+export async function processPending(): Promise<number> {
+  let count = 0;
+  
+  while (await processNext()) {
+    count++;
+  }
+  
+  return count;
+}
+
+/**
+ * Get the count of pending events.
+ */
+export async function getPendingCount(): Promise<number> {
+  let count = 0;
+
+  for await (const event of readFrom(lastProcessedSeq + 1)) {
+    // Only count non-internal pending events
+    if (event.status === "pending" && !event.type.startsWith("__")) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Get the last processed sequence number.
+ */
+export function getLastProcessedSeq(): number {
+  return lastProcessedSeq;
+}
+
+/**
+ * Reset the processor state (for testing).
+ */
+export async function resetProcessor(): Promise<void> {
+  dedupeState = {
+    version: 1,
+    entries: [],
+    lastCleanupAt: new Date().toISOString(),
+  };
+  await saveDedupeState();
+  lastProcessedSeq = 0;
+  isProcessing = false;
+}
+
+/**
+ * Get dedupe statistics.
+ */
+export function getDedupeStats(): {
+  totalEntries: number;
+  lastCleanupAt: string;
+  retentionDays: number;
+} {
+  return {
+    totalEntries: dedupeState?.entries.length ?? 0,
+    lastCleanupAt: dedupeState?.lastCleanupAt ?? new Date().toISOString(),
+    retentionDays: processorConfig?.retentionDays ?? DEFAULT_RETENTION_DAYS,
+  };
+}
+
+/**
+ * Check if a specific dedupe key exists.
+ * Useful for testing and debugging.
+ */
+export function hasDedupeKey(key: string): boolean {
+  return isDuplicate(key);
+}
+
+// --- Gateway wiring ---
+
+let gatewayProcessFn: ((eventId: string) => Promise<ProcessingResult>) | null = null;
+
+/**
+ * Initialize the event processor for use with the gateway.
+ * This must be called before processing Discord/Telegram events through the gateway.
+ * 
+ * @param processFn - The function to call for each persisted event.
+ *                     For Discord/Telegram, this should call runUserMessage.
+ */
+export async function initGatewayProcessor(
+  processFn: (source: string, prompt: string) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+): Promise<void> {
+  await initProcessor({
+    retentionDays: 7,
+    onEvent: async (event) => {
+      try {
+        const normalizedEvent = (event.payload as any)?.normalizedEvent;
+        if (!normalizedEvent) {
+          return { success: false, error: "No normalizedEvent in payload" };
+        }
+
+        // Get prompt from metadata if already built, otherwise use text
+        const prompt = (normalizedEvent.metadata as any)?.prompt || normalizedEvent.text;
+        if (!prompt) {
+          return { success: false, error: "No prompt in event" };
+        }
+
+        const source = event.source || normalizedEvent.channel;
+        const result = await processFn(source, prompt);
+
+        return {
+          success: result.exitCode === 0,
+          error: result.exitCode !== 0 ? result.stderr : undefined,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          shouldRetry: true,
+        };
+      }
+    },
+  });
+
+  // Create the processPersistedEvent wrapper for the gateway
+  gatewayProcessFn = async (eventId: string): Promise<ProcessingResult> => {
+    return processPersistedEvent(eventId);
+  };
+}
+
+/**
+ * Get the gateway processor function.
+ * Returns null if initGatewayProcessor hasn't been called.
+ */
+export function getGatewayProcessor(): ((eventId: string) => Promise<ProcessingResult>) | null {
+  return gatewayProcessFn;
+}

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,0 +1,603 @@
+/**
+ * Gateway Orchestrator — single entry point for all inbound normalized events.
+ * 
+ * CONTROL FLOW:
+ *   Adapter -> Normalizer -> Gateway -> Event Log -> Processor
+ * 
+ * CRITICAL DESIGN CONSTRAINTS:
+ * - Gateway is the single entry point for all inbound events
+ * - Sequence numbers are assigned by the event log, NOT by getLastSeq() + 1 in gateway
+ * - Gateway coordinates, it does NOT duplicate processor responsibilities
+ * - Channel adapters do NOT call runner.ts directly
+ * 
+ * DEPENDENCY INJECTION:
+ * - Uses injected dependencies via GatewayDependencies interface
+ * - Falls back to module globals for backward compatibility
+ */
+
+import { append as eventLogAppend, type EventRecord, type EventEntryInput } from "../event-log";
+import type { ProcessingResult } from "../event-processor";
+import type { NormalizedEvent } from "./normalizer";
+import {
+  getOrCreateSessionMapping,
+  getResumeArgsForEvent,
+  updateSessionAfterProcessing,
+  recordClaudeSessionId,
+  type ResumeArgs,
+} from "./resume";
+import { shouldBlockAdmission, handlePolicyDenial } from "../escalation";
+import { evaluate, type ToolRequestContext, type PolicyDecision } from "../policy/engine";
+import { enqueue } from "../policy/approval-queue";
+import { getGovernanceClient } from "../governance/client";
+
+// --- Gateway Configuration ---
+
+export interface GatewayConfig {
+  /** Feature flag: enable gateway processing */
+  enabled?: boolean;
+  /** Fallback to legacy handler when gateway is disabled */
+  useLegacyFallback?: boolean;
+}
+
+// --- Gateway Dependencies ---
+
+export interface GatewayDependencies {
+  /** Event log append function */
+  eventLog: {
+    append: (entry: EventEntryInput) => Promise<EventRecord>;
+  };
+  /** Processor function for persisted events */
+  processor: {
+    processPersistedEvent: (eventId: string) => Promise<ProcessorResult>;
+  };
+  /** Resume module functions */
+  resume: {
+    getOrCreateSessionMapping: typeof getOrCreateSessionMapping;
+    getResumeArgsForEvent: typeof getResumeArgsForEvent;
+    updateSessionAfterProcessing: typeof updateSessionAfterProcessing;
+    recordClaudeSessionId?: typeof recordClaudeSessionId;
+  };
+}
+
+// --- Default Dependencies (module globals) ---
+
+// Import the event processor's gateway function
+import { getGatewayProcessor } from "../event-processor";
+
+function createDefaultDependencies(): GatewayDependencies {
+  // Try to get the event processor from event-processor module
+  const eventProcessorFn = getGatewayProcessor();
+
+  return {
+    eventLog: {
+      append: eventLogAppend,
+    },
+    processor: {
+      processPersistedEvent: eventProcessorFn
+        ? eventProcessorFn
+        : async (_eventId: string): Promise<ProcessorResult> => {
+            // Default: processor not available in this context
+            // Actual implementation should use initGatewayProcessor from event-processor.ts
+            return { success: false, error: "Processor not configured" };
+          },
+    },
+    resume: {
+      getOrCreateSessionMapping,
+      getResumeArgsForEvent,
+      updateSessionAfterProcessing,
+      recordClaudeSessionId,
+    },
+  };
+}
+
+// --- Gateway Class ---
+
+let globalGateway: Gateway | null = null;
+
+export class Gateway {
+  private config: GatewayConfig;
+  private deps: GatewayDependencies;
+  private running = false;
+
+  constructor(config: GatewayConfig = {}, deps?: GatewayDependencies) {
+    this.config = config;
+    this.deps = deps ?? createDefaultDependencies();
+    this.running = true;
+  }
+
+  /**
+   * Check if gateway is running
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Start the gateway (no-op in current implementation, reserved for future use)
+   */
+  async start(): Promise<void> {
+    this.running = true;
+    console.log("[gateway] Gateway started");
+  }
+
+  /**
+   * Stop the gateway (no-op in current implementation, reserved for future use)
+   */
+  async stop(): Promise<void> {
+    this.running = false;
+    console.log("[gateway] Gateway stopped");
+  }
+
+  /**
+   * Evaluate a tool request against policy rules.
+   */
+  private evaluatePolicy(event: NormalizedEvent, toolName: string, toolArgs?: Record<string, unknown>): PolicyDecision {
+    const gc = getGovernanceClient();
+    const request: ToolRequestContext = {
+      eventId: event.id || crypto.randomUUID(),
+      source: event.channel,
+      channelId: event.channelId,
+      threadId: event.threadId,
+      userId: event.userId,
+      toolName,
+      toolArgs,
+      timestamp: new Date(event.timestamp).toISOString(),
+      metadata: event.metadata,
+    };
+    return gc.evaluateToolRequest(request);
+  }
+
+  /**
+   * Check if approval is required and enqueue if so.
+   * Returns true if the request was enqueued for approval.
+   */
+  private async checkToolApproval(
+    event: NormalizedEvent, 
+    decision: PolicyDecision
+  ): Promise<{ needsApproval: boolean; approvalId?: string }> {
+    if (decision.action !== "require_approval") {
+      return { needsApproval: false };
+    }
+    
+    const gc = getGovernanceClient();
+    const request: ToolRequestContext = {
+      eventId: event.id || crypto.randomUUID(),
+      source: event.channel,
+      channelId: event.channelId,
+      threadId: event.threadId,
+      userId: event.userId,
+      toolName: decision.matchedRuleId || "unknown",
+      timestamp: new Date(event.timestamp).toISOString(),
+    };
+    
+    const entry = await gc.requestApproval(request, decision);
+    if (entry) {
+      return { needsApproval: true, approvalId: entry.id };
+    }
+    return { needsApproval: false };
+  }
+
+  /**
+   * Process an inbound normalized event.
+   * 
+   * Flow:
+   * 1. Validate normalized input
+   * 2. Resolve or create session mapping
+   * 3. Append event to event log (event log assigns sequence number)
+   * 4. Trigger processor on persisted event record
+   * 5. Update mapping metadata after success
+   * 6. Record real Claude session ID if available
+   * 
+   * @param event - NormalizedEvent from adapter/normalizer
+   * @returns Processing result with event record and session info
+   */
+  async processInboundEvent(event: NormalizedEvent): Promise<{
+    success: boolean;
+    eventRecord?: EventRecord;
+    resumeArgs?: ResumeArgs;
+    error?: string;
+  }> {
+    if (!this.running) {
+      return { success: false, error: "Gateway is not running" };
+    }
+
+    // Step 1: Validate the normalized event
+    if (!this.validateEvent(event)) {
+      return { success: false, error: "Invalid normalized event" };
+    }
+
+    // Step 1b: Check if system is paused - reject new events when paused
+    if (await shouldBlockAdmission()) {
+      return { success: false, error: "System is paused - new events are not being admitted" };
+    }
+
+    try {
+      // Step 2: Resolve or create session mapping
+      const sessionEntry = await this.deps.resume.getOrCreateSessionMapping(
+        event.channelId,
+        event.threadId
+      );
+
+      // Step 2b: Evaluate policy for inbound event
+      // This evaluates the incoming message as a "tool" request
+      const policyDecision = this.evaluatePolicy(event, "InboundMessage", {
+        messageLength: event.text?.length ?? 0,
+        hasAttachments: (event.attachments ?? []).length > 0,
+      });
+
+      // Check if approval is required
+      const { needsApproval, approvalId } = await this.checkToolApproval(event, policyDecision);
+      if (needsApproval) {
+        return { 
+          success: false, 
+          error: `Request requires approval (ID: ${approvalId}). Please wait for operator approval.`,
+        };
+      }
+
+      // If denied, reject the request
+      if (policyDecision.action === "deny") {
+        // Trigger escalation for policy denial
+        await handlePolicyDenial(event.id, "InboundMessage", policyDecision.reason || "Policy denied request", {
+          severity: "warning",
+          channelId: event.channelId,
+          sessionId: sessionEntry.sessionId,
+        });
+        return { 
+          success: false, 
+          error: `Request denied: ${policyDecision.reason}`,
+        };
+      }
+
+      // Step 3: Append event to event log (sequence number assigned by event log)
+      const eventRecord = await this.deps.eventLog.append({
+        type: `inbound:${event.channel}`,
+        source: event.channel,
+        channelId: event.channelId,
+        threadId: event.threadId,
+        payload: {
+          normalizedEvent: event,
+          sessionMappingId: sessionEntry.mappingId,
+        },
+        dedupeKey: event.sourceEventId 
+          ? `${event.channel}:${event.sourceEventId}` 
+          : `${event.channelId}:${event.threadId}:${event.timestamp}`,
+        correlationId: undefined,
+        causationId: undefined,
+      });
+
+      // Step 4: Trigger processor on the persisted event record
+      // The processor handles the actual Claude CLI execution
+      let processorResult: ProcessingResult;
+      try {
+        processorResult = await this.deps.processor.processPersistedEvent(eventRecord.id);
+      } catch (err) {
+        processorResult = {
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // Step 5: Update mapping metadata after successful processing
+      if (processorResult.success) {
+        await this.deps.resume.updateSessionAfterProcessing(
+          event.channelId,
+          event.threadId,
+          eventRecord.seq,
+          { turnCountIncrement: 1 }
+        );
+      }
+
+      // Step 6: Record real Claude session ID if available in processor result
+      // This is transitional - the processor should expose a seam for session ID extraction
+      if (processorResult.success && processorResult.claudeSessionId) {
+        if (this.deps.resume.recordClaudeSessionId) {
+          await this.deps.resume.recordClaudeSessionId(
+            event.channelId,
+            event.threadId,
+            processorResult.claudeSessionId
+          );
+        }
+      }
+
+      // Get resume args for response
+      const resumeArgs = await this.deps.resume.getResumeArgsForEvent(event);
+
+      return {
+        success: processorResult.success,
+        eventRecord,
+        resumeArgs,
+        error: processorResult.error,
+      };
+    } catch (err) {
+      console.error("[gateway] Error processing inbound event:", err);
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Validate a normalized event
+   */
+  private validateEvent(event: NormalizedEvent): boolean {
+    if (!event) return false;
+    if (!event.channelId) return false;
+    if (!event.threadId) return false;
+    if (!event.channel) return false;
+    return true;
+  }
+}
+
+// --- Factory Functions ---
+
+/**
+ * Create a new Gateway instance with optional config and dependencies
+ */
+export function createGateway(config?: GatewayConfig, deps?: GatewayDependencies): Gateway {
+  return new Gateway(config, deps);
+}
+
+/**
+ * Get the global gateway instance (singleton)
+ */
+export function getGateway(): Gateway | null {
+  return globalGateway;
+}
+
+/**
+ * Set the global gateway instance
+ */
+export function setGateway(gateway: Gateway): void {
+  globalGateway = gateway;
+}
+
+// --- Standalone Process Function ---
+
+/**
+ * Process an inbound event using the global gateway or create a new one.
+ * This is the main entry point for the gateway orchestrator.
+ */
+export async function processInboundEvent(event: NormalizedEvent): Promise<{
+  success: boolean;
+  eventRecord?: EventRecord;
+  resumeArgs?: ResumeArgs;
+  error?: string;
+}> {
+  // Check if system is paused before creating gateway
+  if (await shouldBlockAdmission()) {
+    return { success: false, error: "System is paused - new events are not being admitted" };
+  }
+
+  // Get or create gateway
+  let gateway = getGateway();
+  if (!gateway) {
+    // Check feature flag
+    const useGateway = process.env.USE_GATEWAY === "true" || isGatewayEnabled();
+    if (!useGateway) {
+      return { success: false, error: "Gateway is disabled" };
+    }
+    gateway = createGateway();
+    setGateway(gateway);
+  }
+
+  return gateway.processInboundEvent(event);
+}
+
+// --- Feature Flag ---
+
+let cachedGatewayEnabled: boolean | null = null;
+
+/**
+ * Check if the gateway is enabled via environment variable or settings
+ */
+export function isGatewayEnabled(): boolean {
+  if (cachedGatewayEnabled !== null) {
+    return cachedGatewayEnabled;
+  }
+
+  // Check environment variable
+  const envValue = process.env.USE_GATEWAY;
+  if (envValue !== undefined) {
+    cachedGatewayEnabled = envValue === "true";
+    return cachedGatewayEnabled;
+  }
+
+  // Default to false for conservative migration
+  cachedGatewayEnabled = false;
+  return cachedGatewayEnabled;
+}
+
+/**
+ * Clear the cached gateway enabled state (useful for testing)
+ */
+export function clearGatewayEnabledCache(): void {
+  cachedGatewayEnabled = null;
+}
+
+/**
+ * Set gateway enabled state (useful for testing)
+ */
+export function setGatewayEnabled(enabled: boolean): void {
+  cachedGatewayEnabled = enabled;
+}
+
+// --- Extended Processor Result ---
+
+export interface ProcessorResult extends ProcessingResult {
+  /** Real Claude session ID if available (extracted from first successful run) */
+  claudeSessionId?: string;
+}
+
+// Re-export ProcessingResult from event-processor for convenience
+export type { ProcessingResult } from "../event-processor";
+
+// --- Event Processing with Fallback ---
+
+export interface ProcessEventOptions {
+  /** Legacy handler to call when gateway is disabled */
+  legacyHandler?: () => Promise<LegacyResult>;
+  /** Options to pass to the legacy handler */
+  legacyOptions?: Record<string, unknown>;
+}
+
+export interface LegacyResult {
+  success: boolean;
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  error?: string;
+}
+
+/**
+ * Process an event with automatic fallback to legacy handler.
+ * 
+ * Migration pattern:
+ * - When gateway is enabled: routes through gateway orchestrator
+ * - When gateway is disabled: calls legacy handler (e.g., runUserMessage)
+ * 
+ * @param event - NormalizedEvent to process
+ * @param options - Options including legacy handler for fallback
+ * @returns Result with source information
+ */
+export async function processEventWithFallback(
+  event: NormalizedEvent,
+  options: ProcessEventOptions = {}
+): Promise<{
+  success: boolean;
+  source: "gateway" | "legacy";
+  eventRecord?: EventRecord;
+  resumeArgs?: ResumeArgs;
+  error?: string;
+  legacyResult?: LegacyResult;
+}> {
+  // Check if system is paused before routing
+  if (await shouldBlockAdmission()) {
+    return {
+      success: false,
+      source: "gateway",
+      error: "System is paused - new events are not being admitted",
+    };
+  }
+
+  // Check if gateway is enabled
+  const gatewayEnabled = isGatewayEnabled();
+
+  if (gatewayEnabled) {
+    // Use gateway path
+    let gateway = getGateway();
+    if (!gateway) {
+      gateway = createGateway({ enabled: true });
+      setGateway(gateway);
+    }
+
+    const result = await gateway.processInboundEvent(event);
+    return {
+      success: result.success,
+      source: "gateway",
+      eventRecord: result.eventRecord,
+      resumeArgs: result.resumeArgs,
+      error: result.error,
+    };
+  } else {
+    // Use legacy path
+    if (options.legacyHandler) {
+      try {
+        const legacyResult = await options.legacyHandler();
+        return {
+          success: legacyResult.exitCode === 0,
+          source: "legacy",
+          error: legacyResult.error ?? legacyResult.stderr ?? undefined,
+          legacyResult,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          source: "legacy",
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+
+    // No legacy handler available
+    return {
+      success: false,
+      source: "legacy",
+      error: "Gateway disabled and no legacy handler provided",
+    };
+  }
+}
+
+// --- Adapter Helpers ---
+
+/**
+ * Normalize and process a Telegram message through the gateway.
+ * 
+ * Usage in telegram.ts migration:
+ *   // Before (legacy):
+ *   const result = await runUserMessage("telegram", prompt);
+ *   
+ *   // After (with gateway):
+ *   const normalized = normalizeTelegramMessage(message);
+ *   const result = await submitTelegramToGateway(normalized);
+ */
+export async function submitTelegramToGateway(
+  message: import("./normalizer").TelegramMessage
+): Promise<{
+  success: boolean;
+  source: "gateway" | "legacy";
+  error?: string;
+}> {
+  const { normalizeTelegramMessage } = await import("./normalizer");
+  const normalized = normalizeTelegramMessage(message);
+
+  const result = await processEventWithFallback(normalized, {
+    legacyHandler: async () => {
+      // Legacy handler is not called from here - adapters should
+      // pass their own legacy handler if they want fallback
+      return { success: false, error: "Legacy fallback not configured" };
+    },
+  });
+
+  return {
+    success: result.success,
+    source: result.source,
+    error: result.error,
+  };
+}
+
+/**
+ * Normalize and process a Discord message through the gateway.
+ * 
+ * Usage in discord.ts migration:
+ *   // Before (legacy):
+ *   const result = await runUserMessage("discord", prompt);
+ *   
+ *   // After (with gateway):
+ *   const normalized = normalizeDiscordMessage(message);
+ *   const result = await submitDiscordToGateway(normalized);
+ */
+export async function submitDiscordToGateway(
+  message: import("./normalizer").DiscordMessage
+): Promise<{
+  success: boolean;
+  source: "gateway" | "legacy";
+  error?: string;
+}> {
+  const { normalizeDiscordMessage } = await import("./normalizer");
+  const normalized = normalizeDiscordMessage(message);
+
+  const result = await processEventWithFallback(normalized, {
+    legacyHandler: async () => {
+      // Legacy handler is not called from here - adapters should
+      // pass their own legacy handler if they want fallback
+      return { success: false, error: "Legacy fallback not configured" };
+    },
+  });
+
+  return {
+    success: result.success,
+    source: result.source,
+    error: result.error,
+  };
+}

--- a/src/gateway/normalizer.ts
+++ b/src/gateway/normalizer.ts
@@ -1,0 +1,451 @@
+/**
+ * Gateway Normalizer — transforms platform-specific events into a unified schema.
+ *
+ * Design principles:
+ * - `id` is always local (assigned by event log, not by normalizer)
+ * - `sourceEventId` captures the upstream message/event ID when available
+ * - No `seq` field — sequence numbers belong to the event log, not normalization
+ * - Normalization preserves provenance needed for dedupe and replay
+ * - Adapters only need to normalize and submit events
+ *
+ * Supported channels: telegram, discord, cron, webhook
+ */
+
+// --- Core types ---
+
+export type Channel = "telegram" | "discord" | "cron" | "webhook";
+
+export interface Attachment {
+  type: "image" | "voice" | "document";
+  url?: string;
+  localPath?: string;
+  mimeType?: string;
+  filename?: string;
+  sizeBytes?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedEvent {
+  id: string; // local event UUID (assigned by event log, not here)
+  channel: Channel;
+  sourceEventId?: string; // upstream message/event ID if available
+  channelId: string;
+  threadId: string;
+  userId: string;
+  text: string;
+  attachments: Attachment[];
+  timestamp: number; // source timestamp if available, else now
+  metadata: {
+    replyTo?: string;
+    command?: string;
+    entities?: unknown[];
+    rawType?: string | number;
+    [key: string]: unknown;
+  };
+}
+
+// --- Source platform types (minimal, for normalization only) ---
+
+// Telegram types (from telegram.ts)
+export interface TelegramMessage {
+  message_id: number;
+  from?: { id: number; first_name: string; username?: string };
+  reply_to_message?: { message_id?: number; from?: { id: number } };
+  chat: { id: number; type: string };
+  message_thread_id?: number;
+  text?: string;
+  caption?: string;
+  photo?: TelegramPhotoSize[];
+  document?: TelegramDocument;
+  voice?: TelegramVoice;
+  audio?: TelegramAudio;
+  entities?: TelegramEntity[];
+  caption_entities?: TelegramEntity[];
+}
+
+export interface TelegramPhotoSize {
+  file_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+export interface TelegramDocument {
+  file_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
+export interface TelegramVoice {
+  file_id: string;
+  mime_type?: string;
+  duration?: number;
+  file_size?: number;
+}
+
+export interface TelegramAudio {
+  file_id: string;
+  mime_type?: string;
+  duration?: number;
+  file_name?: string;
+  file_size?: number;
+}
+
+export interface TelegramEntity {
+  type: "mention" | "bot_command" | string;
+  offset: number;
+  length: number;
+}
+
+// Discord types (from discord.ts)
+export interface DiscordMessage {
+  id: string;
+  channel_id: string;
+  guild_id?: string;
+  author: DiscordUser;
+  content: string;
+  attachments: DiscordAttachment[];
+  mentions: DiscordUser[];
+  referenced_message?: DiscordMessage | null;
+  flags?: number;
+  type: number;
+}
+
+export interface DiscordUser {
+  id: string;
+  username: string;
+  discriminator: string;
+  bot?: boolean;
+}
+
+export interface DiscordAttachment {
+  id: string;
+  filename: string;
+  content_type?: string;
+  url: string;
+  proxy_url: string;
+  size: number;
+  flags?: number;
+}
+
+// Cron/Webhook types
+export interface CronEvent {
+  timestamp?: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface WebhookEvent {
+  headers?: Record<string, string>;
+  body?: unknown;
+  path?: string;
+  timestamp?: number;
+}
+
+// --- Type guards ---
+
+/**
+ * Check if a value is a valid Channel string
+ */
+export function isValidChannel(value: unknown): value is Channel {
+  return typeof value === "string" && ["telegram", "discord", "cron", "webhook"].includes(value);
+}
+
+/**
+ * Check if an object conforms to the NormalizedEvent schema
+ */
+export function isNormalizedEvent(obj: unknown): obj is NormalizedEvent {
+  if (!obj || typeof obj !== "object") return false;
+  const o = obj as Record<string, unknown>;
+
+  // Check required primitive fields
+  if (typeof o.id !== "string") return false;
+  if (!isValidChannel(o.channel)) return false;
+  if (typeof o.channelId !== "string") return false;
+  if (typeof o.threadId !== "string") return false;
+  if (typeof o.userId !== "string") return false;
+  if (typeof o.text !== "string") return false;
+  if (typeof o.timestamp !== "number") return false;
+
+  // Check optional sourceEventId
+  if (o.sourceEventId !== undefined && typeof o.sourceEventId !== "string") return false;
+
+  // Check attachments is an array
+  if (!Array.isArray(o.attachments)) return false;
+  for (const att of o.attachments) {
+    if (!isAttachment(att)) return false;
+  }
+
+  // Check metadata is a plain object
+  if (!o.metadata || typeof o.metadata !== "object" || Array.isArray(o.metadata)) return false;
+
+  return true;
+}
+
+function isAttachment(obj: unknown): obj is Attachment {
+  if (!obj || typeof obj !== "object") return false;
+  const o = obj as Record<string, unknown>;
+  if (!["image", "voice", "document"].includes(o.type as string)) return false;
+  return true;
+}
+
+// --- Telegram normalizer ---
+
+/**
+ * Normalize a Telegram message into the unified schema.
+ * Preserves source provenance (message_id, chat.id, user.id) for dedupe/replay.
+ */
+export function normalizeTelegramMessage(message: TelegramMessage): NormalizedEvent {
+  // Extract text from either text or caption field
+  const text = message.text ?? message.caption ?? "";
+
+  // Build attachments from photo, voice, audio, document
+  const attachments: Attachment[] = [];
+
+  // Photo attachments
+  if (message.photo && message.photo.length > 0) {
+    // Pick largest photo (best quality)
+    const largest = [...message.photo].sort((a, b) => {
+      const sizeA = a.file_size ?? a.width * a.height;
+      const sizeB = b.file_size ?? b.width * b.height;
+      return sizeB - sizeA;
+    })[0];
+    attachments.push({
+      type: "image",
+      url: undefined, // URL requires file_id → getFile → download (deferred to fetcher)
+      filename: undefined,
+      sizeBytes: largest.file_size,
+      metadata: { file_id: largest.file_id, width: largest.width, height: largest.height },
+    });
+  }
+
+  // Voice/audio attachments
+  if (message.voice) {
+    attachments.push({
+      type: "voice",
+      mimeType: message.voice.mime_type,
+      sizeBytes: message.voice.file_size,
+      metadata: { file_id: message.voice.file_id, duration: message.voice.duration },
+    });
+  }
+
+  if (message.audio) {
+    attachments.push({
+      type: "voice", // audio files treated as voice (speech/audio content)
+      mimeType: message.audio.mime_type,
+      filename: message.audio.file_name,
+      sizeBytes: message.audio.file_size,
+      metadata: { file_id: message.audio.file_id, duration: message.audio.duration },
+    });
+  }
+
+  // Document attachments (images via document are handled separately)
+  if (message.document) {
+    const isImage = message.document.mime_type?.startsWith("image/");
+    const isAudio = message.document.mime_type?.startsWith("audio/");
+    let attachmentType: "image" | "voice" | "document" = "document";
+    if (isImage) {
+      attachmentType = "image";
+    } else if (isAudio) {
+      attachmentType = "voice";
+    }
+    attachments.push({
+      type: attachmentType,
+      mimeType: message.document.mime_type,
+      filename: message.document.file_name,
+      sizeBytes: message.document.file_size,
+      metadata: { file_id: message.document.file_id },
+    });
+  }
+
+  // Build metadata
+  const metadata: NormalizedEvent["metadata"] = {};
+
+  // Reply metadata
+  if (message.reply_to_message?.message_id) {
+    metadata.replyTo = String(message.reply_to_message.message_id);
+  }
+
+  // Entity metadata (mentions, bot commands, etc.)
+  const entities = message.entities ?? message.caption_entities;
+  if (entities && entities.length > 0) {
+    metadata.entities = entities;
+
+    // Extract bot command if present
+    const cmd = entities.find((e) => e.type === "bot_command");
+    if (cmd) {
+      const rawCmd = text.slice(cmd.offset, cmd.offset + cmd.length);
+      metadata.command = rawCmd.split("@")[0].toLowerCase(); // strip @botname
+    }
+  }
+
+  // Raw type preservation (e.g., "message", "edited_message", "channel_post")
+  if (message.entities) {
+    metadata.rawType = "message";
+  } else if (message.caption_entities) {
+    metadata.rawType = "caption";
+  }
+
+  return {
+    id: "", // assigned by event log
+    channel: "telegram",
+    sourceEventId: message.message_id ? String(message.message_id) : undefined,
+    channelId: `telegram:${message.chat.id}`,
+    threadId: message.message_thread_id ? String(message.message_thread_id) : "default",
+    userId: message.from?.id ? String(message.from.id) : "unknown",
+    text,
+    attachments,
+    timestamp: Date.now(), // Telegram doesn't provide source timestamp, use arrival time
+    metadata,
+  };
+}
+
+// --- Discord normalizer ---
+
+/**
+ * Normalize a Discord message into the unified schema.
+ * Preserves source provenance (id, channel_id, author.id) for dedupe/replay.
+ */
+export function normalizeDiscordMessage(message: DiscordMessage): NormalizedEvent {
+  // Trim content
+  const text = message.content.trim();
+
+  // Build attachments
+  const attachments: Attachment[] = message.attachments.map((att) => {
+    const isImage = att.content_type?.startsWith("image/");
+    const isVoice =
+      (att.flags ?? 0) & (1 << 13) || att.content_type?.startsWith("audio/");
+
+    let attachmentType: "image" | "voice" | "document" = "document";
+    if (isImage) {
+      attachmentType = "image";
+    } else if (isVoice) {
+      attachmentType = "voice";
+    }
+    return {
+      type: attachmentType,
+      url: att.url,
+      filename: att.filename,
+      sizeBytes: att.size,
+      mimeType: att.content_type,
+      metadata: { id: att.id, proxy_url: att.proxy_url },
+    };
+  });
+
+  // Build metadata
+  const metadata: NormalizedEvent["metadata"] = {};
+
+  // Reply/reference metadata
+  if (message.referenced_message) {
+    metadata.replyTo = message.referenced_message.id;
+  }
+
+  // Channel and thread context
+  // Discord exposes guild_id and channel_id separately
+  // threadId: Discord uses parent channel_id + optional thread id in message
+  // We preserve the full channel context by including guild_id in channelId
+  const channelId = message.guild_id
+    ? `discord:guild:${message.guild_id}:${message.channel_id}`
+    : `discord:dm:${message.channel_id}`;
+
+  // Discord message type (e.g., 0=DEFAULT, 19=REPLY, 20=CHANNEL_PINNED_MESSAGE)
+  metadata.rawType = message.type;
+
+  // Detect bot command from content (slash commands start with /)
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("/")) {
+    const cmdPart = trimmed.slice(1).split(/\s+/)[0];
+    if (cmdPart) metadata.command = cmdPart.toLowerCase();
+  }
+
+  // Mention entities for reference
+  if (message.mentions && message.mentions.length > 0) {
+    metadata.entities = message.mentions.map((m) => ({ id: m.id, username: m.username }));
+  }
+
+  return {
+    id: "", // assigned by event log
+    channel: "discord",
+    sourceEventId: message.id,
+    channelId,
+    threadId: message.channel_id, // Discord thread id embedded in channel_id if needed
+    userId: message.author.id,
+    text,
+    attachments,
+    timestamp: Date.now(), // Discord doesn't provide source timestamp in message create
+    metadata,
+  };
+}
+
+// --- Cron normalizer ---
+
+/**
+ * Normalize a Cron event into the unified schema.
+ * Uses "system" as a stable synthetic userId.
+ */
+export function normalizeCronEvent(event: CronEvent): NormalizedEvent {
+  const metadata: NormalizedEvent["metadata"] = {};
+
+  // Preserve payload data
+  if (event.payload) {
+    metadata.payload = event.payload;
+  }
+
+  return {
+    id: "", // assigned by event log
+    channel: "cron",
+    channelId: "cron:system",
+    threadId: "default",
+    userId: "system", // stable synthetic actor
+    text: "",
+    attachments: [],
+    timestamp: event.timestamp ?? Date.now(),
+    metadata,
+  };
+}
+
+// --- Webhook normalizer ---
+
+/**
+ * Normalize a Webhook event into the unified schema.
+ * Preserves headers, body, and path for inspection/replay.
+ * Uses "system" as a stable synthetic userId.
+ */
+export function normalizeWebhookEvent(event: WebhookEvent): NormalizedEvent {
+  const metadata: NormalizedEvent["metadata"] = {};
+
+  // Preserve headers (sans sensitive values)
+  if (event.headers) {
+    const safeHeaders: Record<string, string> = {};
+    for (const [k, v] of Object.entries(event.headers)) {
+      const lower = k.toLowerCase();
+      // Strip potentially sensitive headers
+      if (!["authorization", "cookie", "x-api-key", "x-auth"].includes(lower)) {
+        safeHeaders[k] = v;
+      }
+    }
+    metadata.headers = safeHeaders;
+  }
+
+  // Preserve body
+  if (event.body !== undefined) {
+    metadata.body = event.body;
+  }
+
+  // Preserve path
+  if (event.path) {
+    metadata.path = event.path;
+  }
+
+  return {
+    id: "", // assigned by event log
+    channel: "webhook",
+    channelId: "webhook:receiver",
+    threadId: "default",
+    userId: "system", // stable synthetic actor
+    text: "", // webhook events may not have text content
+    attachments: [],
+    timestamp: event.timestamp ?? Date.now(),
+    metadata,
+  };
+}

--- a/src/gateway/resume.ts
+++ b/src/gateway/resume.ts
@@ -1,0 +1,321 @@
+/**
+ * Resume Logic Module
+ * 
+ * Bridges normalized inbound events, session mappings, and real Claude CLI session resumption.
+ * Enables deterministic session resumption per conversation thread using the ACTUAL
+ * Claude session ID once one has been created by the runner.
+ * 
+ * CRITICAL DESIGN CONSTRAINTS:
+ * - Do NOT generate random UUIDs and treat them as Claude session IDs
+ * - local mapping identity may be generated locally
+ * - Claude session identity must come from runner / Claude output
+ * - `--resume` must only be emitted when a real `claudeSessionId` exists
+ */
+
+import { 
+  get, 
+  set, 
+  remove,
+  getOrCreateMapping as sessionMapGetOrCreate,
+  attachClaudeSessionId as sessionMapAttachClaudeSessionId,
+  update as sessionMapUpdate,
+  type SessionEntry,
+  type SessionStatus
+} from "./session-map";
+import type { NormalizedEvent } from "./normalizer";
+
+// --- Core types ---
+
+export interface ResumeArgs {
+  mappingId: string;
+  claudeSessionId: string | null;
+  args: string[];
+  isNewMapping: boolean;
+  canResume: boolean;
+}
+
+export interface UpdateSessionOptions {
+  turnCountIncrement?: number;
+  status?: SessionStatus;
+}
+
+export interface SessionStats {
+  mappingId: string;
+  claudeSessionId: string | null;
+  lastSeq: number;
+  turnCount: number;
+  status: SessionStatus;
+  lastActiveAt: string;
+  createdAt: string;
+  isStale: boolean;
+  canResume: boolean;
+}
+
+// Default threshold for stale detection (24 hours in ms)
+const DEFAULT_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+// Threshold for compact warning (1 hour in ms)
+const COMPACT_WARNING_THRESHOLD_MS = 60 * 60 * 1000;
+
+// --- Task 1: Core lookup and resume argument logic ---
+
+/**
+ * Get an existing session mapping or create a new one.
+ * New mappings start with claudeSessionId = null (waiting for real session ID from runner).
+ * 
+ * @param channelId - The channel identifier (e.g., "telegram:123")
+ * @param threadId - The thread/conversation identifier (defaults to "default")
+ * @returns The session entry (existing or newly created)
+ */
+export async function getOrCreateSessionMapping(
+  channelId: string,
+  threadId: string = "default"
+): Promise<SessionEntry> {
+  return sessionMapGetOrCreate(channelId, threadId);
+}
+
+/**
+ * Get resume arguments for a channel+thread combination.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier (defaults to "default")
+ * @returns ResumeArgs object containing:
+ *   - mappingId: The session mapping identifier
+ *   - claudeSessionId: Real Claude session ID or null
+ *   - args: CLI arguments (--resume with session ID if canResume)
+ *   - isNewMapping: Whether this was a newly created mapping
+ *   - canResume: Whether this session can be resumed (has real Claude session ID)
+ */
+export async function getResumeArgs(
+  channelId: string,
+  threadId: string = "default"
+): Promise<ResumeArgs> {
+  const entry = await get(channelId, threadId);
+  
+  if (!entry) {
+    // No mapping exists - create one
+    const newEntry = await getOrCreateSessionMapping(channelId, threadId);
+    return {
+      mappingId: newEntry.mappingId,
+      claudeSessionId: null,
+      args: [],
+      isNewMapping: true,
+      canResume: false,
+    };
+  }
+  
+  const canResume = entry.claudeSessionId !== null;
+  
+  return {
+    mappingId: entry.mappingId,
+    claudeSessionId: entry.claudeSessionId,
+    args: canResume ? ["--resume", entry.claudeSessionId] : [],
+    isNewMapping: false,
+    canResume,
+  };
+}
+
+/**
+ * Get resume arguments from a normalized event.
+ * Convenience wrapper around getResumeArgs using event's channelId and threadId.
+ * 
+ * @param event - A NormalizedEvent
+ * @returns ResumeArgs for the event's channel+thread
+ */
+export async function getResumeArgsForEvent(event: NormalizedEvent): Promise<ResumeArgs> {
+  return getResumeArgs(event.channelId, event.threadId);
+}
+
+// --- Task 2: Post-processing metadata updates ---
+
+/**
+ * Record the real Claude session ID after first successful runner execution.
+ * This should be called once the runner returns the actual Claude session ID.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier
+ * @param claudeSessionId - The real Claude session ID from the runner
+ */
+export async function recordClaudeSessionId(
+  channelId: string,
+  threadId: string,
+  claudeSessionId: string
+): Promise<void> {
+  // Only attach if we have a real session ID (not null/empty)
+  if (!claudeSessionId || claudeSessionId.trim() === "") {
+    console.warn(
+      `[resume] Not recording empty claudeSessionId for channel=${channelId}, thread=${threadId}`
+    );
+    return;
+  }
+  
+  await sessionMapAttachClaudeSessionId(channelId, threadId, claudeSessionId);
+}
+
+/**
+ * Update session metadata after successful processing.
+ * Updates lastSeq, turnCount, lastActiveAt, and optionally status.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier
+ * @param seq - The sequence number to record
+ * @param options - Optional updates (turnCountIncrement, status)
+ */
+export async function updateSessionAfterProcessing(
+  channelId: string,
+  threadId: string,
+  seq: number,
+  options?: UpdateSessionOptions
+): Promise<void> {
+  const existing = await get(channelId, threadId);
+  if (!existing) {
+    console.warn(
+      `[resume] No mapping found for channel=${channelId}, thread=${threadId} during updateSessionAfterProcessing`
+    );
+    return;
+  }
+  
+  const now = new Date().toISOString();
+  const patch: Partial<SessionEntry> = {
+    lastSeq: seq,
+    lastActiveAt: now,
+    updatedAt: now,
+  };
+  
+  // Handle turn count increment
+  if (options?.turnCountIncrement !== undefined) {
+    patch.turnCount = existing.turnCount + options.turnCountIncrement;
+  } else {
+    // Default: increment by 1 for each processing
+    patch.turnCount = existing.turnCount + 1;
+  }
+  
+  // Handle status update
+  if (options?.status) {
+    patch.status = options.status;
+  } else if (existing.status === "pending") {
+    // Upgrade pending to active on first successful processing
+    patch.status = "active";
+  }
+  
+  await sessionMapUpdate(channelId, threadId, patch);
+}
+
+/**
+ * Get statistics for a session mapping.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier
+ * @returns SessionStats or null if no mapping exists
+ */
+export async function getSessionStats(
+  channelId: string,
+  threadId: string
+): Promise<SessionStats | null> {
+  const entry = await get(channelId, threadId);
+  
+  if (!entry) {
+    return null;
+  }
+  
+  const now = new Date().getTime();
+  const lastActive = new Date(entry.lastActiveAt).getTime();
+  const isStale = (now - lastActive) > DEFAULT_STALE_THRESHOLD_MS;
+  
+  return {
+    mappingId: entry.mappingId,
+    claudeSessionId: entry.claudeSessionId,
+    lastSeq: entry.lastSeq,
+    turnCount: entry.turnCount,
+    status: entry.status,
+    lastActiveAt: entry.lastActiveAt,
+    createdAt: entry.createdAt,
+    isStale,
+    canResume: entry.claudeSessionId !== null,
+  };
+}
+
+// --- Task 3: Lifecycle helpers ---
+
+/**
+ * Reset a session mapping.
+ * Marks it as reset and removes it from storage.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier
+ */
+export async function resetSession(
+  channelId: string,
+  threadId: string
+): Promise<void> {
+  const existing = await get(channelId, threadId);
+  if (!existing) {
+    console.debug(
+      `[resume] No mapping found to reset for channel=${channelId}, thread=${threadId}`
+    );
+    return;
+  }
+  
+  // Mark as reset first (helps with cleanup tracking)
+  await sessionMapUpdate(channelId, threadId, { status: "reset" });
+  
+  // Then remove the entry
+  await remove(channelId, threadId);
+}
+
+/**
+ * Check if a session is stale based on lastActiveAt.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier
+ * @param thresholdMs - Stale threshold in milliseconds (defaults to 24 hours)
+ * @returns true if the session is stale, false otherwise
+ */
+export async function isSessionStale(
+  channelId: string,
+  threadId: string,
+  thresholdMs: number = DEFAULT_STALE_THRESHOLD_MS
+): Promise<boolean> {
+  const entry = await get(channelId, threadId);
+  
+  if (!entry) {
+    return true; // No mapping = considered stale
+  }
+  
+  const now = new Date().getTime();
+  const lastActive = new Date(entry.lastActiveAt).getTime();
+  
+  return (now - lastActive) > thresholdMs;
+}
+
+/**
+ * Check if a session should trigger a compaction warning.
+ * Sessions that have been active for an extended period may benefit from compaction.
+ * 
+ * @param channelId - The channel identifier
+ * @param threadId - The thread/conversation identifier
+ * @returns true if compaction warning should be shown
+ */
+export async function shouldWarnCompact(
+  channelId: string,
+  threadId: string
+): Promise<boolean> {
+  const entry = await get(channelId, threadId);
+  
+  if (!entry) {
+    return false;
+  }
+  
+  const now = new Date().getTime();
+  const lastActive = new Date(entry.lastActiveAt).getTime();
+  
+  // Warn if session has been continuously active for > 1 hour
+  // and has accumulated significant turn count
+  return (
+    (now - lastActive) < COMPACT_WARNING_THRESHOLD_MS &&
+    entry.turnCount > 50
+  );
+}
+
+// Re-export constants for external use
+export { DEFAULT_STALE_THRESHOLD_MS, COMPACT_WARNING_THRESHOLD_MS };

--- a/src/gateway/session-map.ts
+++ b/src/gateway/session-map.ts
@@ -1,0 +1,437 @@
+/**
+ * Session Map Store
+ * 
+ * Hierarchical per-channel+thread mapping state management.
+ * Each channelId + threadId combination has its own isolated mapping entry.
+ * 
+ * PERSISTENCE MODEL:
+ * - Data stored at .claude/claudeclaw/session-map.json
+ * - Source of truth is the persisted file
+ * - Write queue pattern serializes concurrent write operations
+ * - Reads may be optimistic, writes are serialized
+ * 
+ * DESIGN CONSTRAINTS:
+ * - Do NOT invent a Claude CLI session ID - store as null until real ID is returned
+ * - Cleanup must not remove entries merely because they are old if still active
+ * - Storage-focused module - do not fold resume logic into it
+ */
+
+import { join } from "path";
+import { randomUUID } from "crypto";
+
+const SESSION_MAP_FILE = join(process.cwd(), ".claude", "claudeclaw", "session-map.json");
+const DEFAULT_THREAD_ID = "default";
+const DEFAULT_TTL_DAYS = 30; // Entries older than this with no activity are cleanup candidates
+
+export type SessionStatus = "pending" | "active" | "stale" | "reset";
+
+export interface SessionEntry {
+  mappingId: string;
+  claudeSessionId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+  lastSeq: number;
+  turnCount: number;
+  status: SessionStatus;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SessionMap {
+  [channelId: string]: {
+    [threadId: string]: SessionEntry;
+  };
+}
+
+// In-memory cache
+let sessionMap: SessionMap | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+// Write queue for serializing concurrent write operations
+let writeQueue: Promise<void> = Promise.resolve();
+let writeQueueLength = 0;
+
+/**
+ * Enqueue a write operation to ensure serial execution.
+ * All writes to the session map must go through this queue.
+ */
+function enqueueWrite<T>(operation: () => Promise<T>): Promise<T> {
+  writeQueueLength++;
+  const promise = writeQueue.then(() => operation());
+  writeQueue = promise.then(
+    () => { writeQueueLength--; },
+    () => { writeQueueLength--; }
+  );
+  return promise;
+}
+
+/**
+ * Get the current length of the write queue (for testing/debugging).
+ */
+export function getWriteQueueLength(): number {
+  return writeQueueLength;
+}
+
+/**
+ * Reset session map state (for testing).
+ * Clears in-memory cache and forces re-initialization.
+ */
+export function resetSessionMap(): void {
+  sessionMap = null;
+  initializationPromise = null;
+  writeQueue = Promise.resolve();
+  writeQueueLength = 0;
+}
+
+/**
+ * Initialize the session map by loading from disk.
+ */
+async function initSessionMap(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  sessionMap = await loadMap();
+}
+
+/**
+ * Load the session map from disk.
+ * Missing or malformed files return empty map.
+ */
+async function loadMap(): Promise<SessionMap> {
+  try {
+    const content = await Bun.file(SESSION_MAP_FILE).text();
+    const parsed = JSON.parse(content);
+    
+    // Validate structure
+    if (typeof parsed === "object" && parsed !== null) {
+      return parsed as SessionMap;
+    }
+    
+    console.warn("[session-map] Invalid session map structure, starting fresh");
+    return {};
+  } catch {
+    // File doesn't exist or is malformed - return empty map
+    return {};
+  }
+}
+
+/**
+ * Save the session map to disk atomically.
+ * Uses Bun.write which is atomic for the write operation.
+ */
+async function saveMap(map: SessionMap): Promise<void> {
+  await Bun.write(SESSION_MAP_FILE, JSON.stringify(map, null, 2) + "\n");
+}
+
+/**
+ * Get a mapping entry for a channel+thread.
+ * Returns null if no mapping exists.
+ */
+export async function get(
+  channelId: string,
+  threadId: string = DEFAULT_THREAD_ID
+): Promise<SessionEntry | null> {
+  await initSessionMap();
+  
+  if (!sessionMap) {
+    return null;
+  }
+  
+  return sessionMap[channelId]?.[threadId] ?? null;
+}
+
+/**
+ * Set a mapping entry for a channel+thread.
+ * Overwrites any existing entry.
+ */
+export async function set(
+  channelId: string,
+  threadId: string,
+  entry: SessionEntry
+): Promise<void> {
+  await initSessionMap();
+  
+  await enqueueWrite(async () => {
+    if (!sessionMap) {
+      sessionMap = {};
+    }
+    
+    if (!sessionMap[channelId]) {
+      sessionMap[channelId] = {};
+    }
+    
+    sessionMap[channelId][threadId] = entry;
+    await saveMap(sessionMap);
+  });
+}
+
+/**
+ * Delete a mapping entry for a channel+thread.
+ * Only removes the specific thread within the channel.
+ */
+export async function remove(
+  channelId: string,
+  threadId: string = DEFAULT_THREAD_ID
+): Promise<void> {
+  await initSessionMap();
+  
+  await enqueueWrite(async () => {
+    if (!sessionMap || !sessionMap[channelId]) {
+      return;
+    }
+    
+    delete sessionMap[channelId][threadId];
+    
+    // Remove empty channel buckets
+    if (Object.keys(sessionMap[channelId]).length === 0) {
+      delete sessionMap[channelId];
+    }
+    
+    await saveMap(sessionMap);
+  });
+}
+
+/**
+ * Update specific fields of a mapping entry.
+ */
+export async function update(
+  channelId: string,
+  threadId: string,
+  patch: Partial<SessionEntry>
+): Promise<void> {
+  await initSessionMap();
+
+  await enqueueWrite(async () => {
+    const existing = sessionMap?.[channelId]?.[threadId] ?? null;
+    if (!existing) {
+      throw new Error(`No mapping found for channel=${channelId}, thread=${threadId}`);
+    }
+
+    const updated: SessionEntry = {
+      ...existing,
+      ...patch,
+      mappingId: existing.mappingId, // Prevent overwriting identity
+      updatedAt: new Date().toISOString(),
+    };
+
+    if (!sessionMap) sessionMap = {};
+    if (!sessionMap[channelId]) sessionMap[channelId] = {};
+    sessionMap[channelId][threadId] = updated;
+    await saveMap(sessionMap);
+  });
+}
+
+/**
+ * Update the lastSeq for a channel+thread.
+ */
+export async function updateLastSeq(
+  channelId: string,
+  threadId: string,
+  seq: number
+): Promise<void> {
+  await update(channelId, threadId, { lastSeq: seq });
+}
+
+/**
+ * Increment the turn count for a channel+thread.
+ */
+export async function incrementTurnCount(
+  channelId: string,
+  threadId: string
+): Promise<void> {
+  await initSessionMap();
+
+  await enqueueWrite(async () => {
+    const existing = sessionMap?.[channelId]?.[threadId] ?? null;
+    if (!existing) {
+      throw new Error(`No mapping found for channel=${channelId}, thread=${threadId}`);
+    }
+
+    existing.turnCount += 1;
+    existing.updatedAt = new Date().toISOString();
+    await saveMap(sessionMap!);
+  });
+}
+
+/**
+ * Attach a real Claude session ID to a mapping.
+ * Will not overwrite an existing non-null Claude session ID unless forced.
+ */
+export async function attachClaudeSessionId(
+  channelId: string,
+  threadId: string,
+  claudeSessionId: string,
+  force: boolean = false
+): Promise<void> {
+  await initSessionMap();
+
+  await enqueueWrite(async () => {
+    const existing = sessionMap?.[channelId]?.[threadId] ?? null;
+    if (!existing) {
+      throw new Error(`No mapping found for channel=${channelId}, thread=${threadId}`);
+    }
+
+    if (existing.claudeSessionId !== null && !force) {
+      console.warn(
+        `[session-map] Not overwriting existing claudeSessionId for channel=${channelId}, thread=${threadId}`
+      );
+      return;
+    }
+
+    existing.claudeSessionId = claudeSessionId;
+    existing.status = "active";
+    existing.updatedAt = new Date().toISOString();
+    await saveMap(sessionMap!);
+  });
+}
+
+/**
+ * Get an existing mapping or create a new one.
+ * New mappings start with claudeSessionId = null.
+ */
+export async function getOrCreateMapping(
+  channelId: string,
+  threadId: string = DEFAULT_THREAD_ID
+): Promise<SessionEntry> {
+  await initSessionMap();
+
+  return enqueueWrite(async () => {
+    const existing = sessionMap?.[channelId]?.[threadId] ?? null;
+
+    if (existing) {
+      // Update lastActiveAt inside the write lock
+      existing.lastActiveAt = new Date().toISOString();
+      existing.updatedAt = new Date().toISOString();
+      if (!sessionMap) sessionMap = {};
+      if (!sessionMap[channelId]) sessionMap[channelId] = {};
+      sessionMap[channelId][threadId] = existing;
+      await saveMap(sessionMap);
+      return existing;
+    }
+
+    // Create new entry
+    const now = new Date().toISOString();
+    const newEntry: SessionEntry = {
+      mappingId: randomUUID(),
+      claudeSessionId: null,
+      createdAt: now,
+      updatedAt: now,
+      lastActiveAt: now,
+      lastSeq: 0,
+      turnCount: 0,
+      status: "pending",
+    };
+
+    if (!sessionMap) sessionMap = {};
+    if (!sessionMap[channelId]) sessionMap[channelId] = {};
+    sessionMap[channelId][threadId] = newEntry;
+    await saveMap(sessionMap);
+    return newEntry;
+  });
+}
+
+/**
+ * List all channel IDs that have mappings.
+ */
+export async function listChannels(): Promise<string[]> {
+  await initSessionMap();
+  return Object.keys(sessionMap ?? {});
+}
+
+/**
+ * List all thread IDs for a given channel.
+ */
+export async function listThreads(channelId: string): Promise<string[]> {
+  await initSessionMap();
+  return Object.keys(sessionMap?.[channelId] ?? {});
+}
+
+/**
+ * Mark a mapping as stale.
+ */
+export async function markStale(
+  channelId: string,
+  threadId: string
+): Promise<void> {
+  await update(channelId, threadId, { status: "stale" });
+}
+
+/**
+ * Conservative cleanup of old entries.
+ * Removes entries that are:
+ * - Explicitly reset
+ * - Past TTL AND have no activity AND no Claude session attached
+ * 
+ * IMPORTANT: Does NOT auto-delete active mappings during ordinary get() calls.
+ * Cleanup should be explicit or tightly controlled.
+ */
+export async function cleanup(maxAgeDays: number = DEFAULT_TTL_DAYS): Promise<number> {
+  await initSessionMap();
+  
+  if (!sessionMap) {
+    return 0;
+  }
+  
+  let removedCount = 0;
+  const now = new Date();
+  const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+  
+  await enqueueWrite(async () => {
+    for (const channelId of Object.keys(sessionMap!)) {
+      const channelEntries = sessionMap![channelId];
+      const threadsToDelete: string[] = [];
+      
+      for (const threadId of Object.keys(channelEntries)) {
+        const entry = channelEntries[threadId];
+        
+        // Check if entry is past TTL
+        const lastActive = new Date(entry.lastActiveAt);
+        const ageMs = now.getTime() - lastActive.getTime();
+        
+        // Cleanup candidates:
+        // 1. Reset entries (explicitly marked for cleanup)
+        // 2. Entries past TTL with no activity and no Claude session attached
+        const isReset = entry.status === "reset";
+        const isOldWithNoSession = ageMs > maxAgeMs && entry.claudeSessionId === null;
+        const updatedAt = new Date(entry.updatedAt);
+        const updateAgeMs = now.getTime() - updatedAt.getTime();
+        const isOldWithNoRecentUpdate = updateAgeMs > maxAgeMs;
+        
+        if (isReset || (isOldWithNoSession && isOldWithNoRecentUpdate)) {
+          threadsToDelete.push(threadId);
+          removedCount++;
+          console.debug(
+            `[session-map] Cleanup removing: channel=${channelId}, thread=${threadId}, ` +
+            `reason=${isReset ? "reset" : "old"}, age=${Math.round(ageMs / (24 * 60 * 60 * 1000))} days`
+          );
+        }
+      }
+      
+      // Remove marked threads
+      for (const threadId of threadsToDelete) {
+        delete channelEntries[threadId];
+      }
+      
+      // Remove empty channel buckets
+      if (Object.keys(channelEntries).length === 0) {
+        delete sessionMap![channelId];
+      }
+    }
+    
+    if (removedCount > 0) {
+      await saveMap(sessionMap!);
+      console.log(`[session-map] Cleanup removed ${removedCount} entries`);
+    }
+  });
+  
+  return removedCount;
+}
+
+// Re-export for convenience
+export { DEFAULT_THREAD_ID, DEFAULT_TTL_DAYS };

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -1,0 +1,655 @@
+/**
+ * Pricing & Budget Engine
+ * 
+ * Evaluates spend/usage against configured budget policies and returns governance actions.
+ * 
+ * BUDGET MODEL:
+ * - Budgets are scoped (session, daily, monthly)
+ * - Thresholds: warn, degrade, reroute, block
+ * - Actions are policy-driven, not hard-coded
+ * - Cost is always labeled as ESTIMATED
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { randomUUID } from "crypto";
+import { 
+  getAggregates, 
+  getSessionUsage, 
+  type UsageFilters 
+} from "./usage-tracker";
+
+const CLAUDECLAW_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const BUDGET_POLICIES_FILE = join(CLAUDECLAW_DIR, "budget-policies.json");
+const PRICING_FILE = join(CLAUDECLAW_DIR, "pricing.json");
+
+export type BudgetPeriod = "session" | "daily" | "monthly";
+export type BudgetState = "healthy" | "warn" | "degrade" | "reroute" | "block";
+
+export interface BudgetThreshold {
+  warnAt?: number;
+  degradeAt?: number;
+  rerouteAt?: number;
+  blockAt?: number;
+}
+
+export interface BudgetActionDefaults {
+  degradeToModel?: string;
+  rerouteToProvider?: string;
+}
+
+export interface BudgetScope {
+  source?: string | string[];
+  channelId?: string | string[];
+  userId?: string | string[];
+  sessionId?: string | string[];
+  model?: string | string[];
+  provider?: string | string[];
+}
+
+export interface BudgetPolicy {
+  id: string;
+  name: string;
+  scope: BudgetScope;
+  thresholds: BudgetThreshold;
+  period: BudgetPeriod;
+  currency: string;
+  actionDefaults?: BudgetActionDefaults;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PricingTier {
+  provider: string;
+  model: string;
+  inputCostPerMillion: number;
+  outputCostPerMillion: number;
+  cacheReadCostPerMillion?: number;
+  cacheCreationCostPerMillion?: number;
+  currency: string;
+}
+
+export interface PricingConfig {
+  version: string;
+  updatedAt: string;
+  tiers: PricingTier[];
+}
+
+export interface BudgetEvaluation {
+  policyId: string;
+  policyName: string;
+  state: BudgetState;
+  currentSpend: number;
+  threshold: number | null;
+  percentage: number;
+  period: BudgetPeriod;
+  currency: string;
+  actions: {
+    shouldWarn: boolean;
+    shouldDegrade: boolean;
+    shouldReroute: boolean;
+    shouldBlock: boolean;
+    degradeToModel?: string;
+    rerouteToProvider?: string;
+  };
+  evaluatedAt: string;
+}
+
+export interface BudgetStateSummary {
+  policyId: string;
+  policyName: string;
+  state: BudgetState;
+  currentSpend: number;
+  threshold: number | null;
+  percentage: number;
+  period: BudgetPeriod;
+  currency: string;
+}
+
+// In-memory cache
+let budgetPolicies: BudgetPolicy[] | null = null;
+let pricingConfig: PricingConfig | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+export function resetBudgetEngine(): void {
+  budgetPolicies = null;
+  pricingConfig = null;
+  initializationPromise = null;
+}
+
+/**
+ * Initialize the budget engine.
+ */
+export async function initBudgetEngine(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  await loadBudgetPolicies();
+  await loadPricing();
+}
+
+async function loadBudgetPolicies(): Promise<BudgetPolicy[]> {
+  if (budgetPolicies !== null) {
+    return budgetPolicies;
+  }
+
+  try {
+    if (existsSync(BUDGET_POLICIES_FILE)) {
+      const data = await Bun.file(BUDGET_POLICIES_FILE).json();
+      if (Array.isArray(data.policies)) {
+        budgetPolicies = data.policies;
+        return budgetPolicies;
+      }
+    }
+  } catch {
+    // Fall through to defaults
+  }
+
+  // Default empty policies
+  budgetPolicies = [];
+  return budgetPolicies;
+}
+
+async function loadPricing(): Promise<PricingConfig> {
+  if (pricingConfig !== null) {
+    return pricingConfig;
+  }
+
+  try {
+    if (existsSync(PRICING_FILE)) {
+      const data = await Bun.file(PRICING_FILE).json();
+      if (data.version && Array.isArray(data.tiers)) {
+        pricingConfig = data;
+        return pricingConfig;
+      }
+    }
+  } catch {
+    // Fall through to defaults
+  }
+
+  // Default pricing (Anthropic-focused, others can be added)
+  pricingConfig = {
+    version: "1.0.0",
+    updatedAt: new Date().toISOString(),
+    tiers: [
+      {
+        provider: "anthropic",
+        model: "claude-3-5-sonnet",
+        inputCostPerMillion: 3.0,
+        outputCostPerMillion: 15.0,
+        cacheReadCostPerMillion: 0.3,
+        cacheCreationCostPerMillion: 3.75,
+        currency: "USD",
+      },
+      {
+        provider: "anthropic",
+        model: "claude-3-haiku",
+        inputCostPerMillion: 0.25,
+        outputCostPerMillion: 1.25,
+        cacheReadCostPerMillion: 0.03,
+        cacheCreationCostPerMillion: 0.03,
+        currency: "USD",
+      },
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        inputCostPerMillion: 5.0,
+        outputCostPerMillion: 15.0,
+        currency: "USD",
+      },
+      {
+        provider: "openai",
+        model: "gpt-4o-mini",
+        inputCostPerMillion: 0.15,
+        outputCostPerMillion: 0.6,
+        currency: "USD",
+      },
+      {
+        provider: "google",
+        model: "glm-4",
+        inputCostPerMillion: 0.27,
+        outputCostPerMillion: 1.07,
+        currency: "USD",
+      },
+    ],
+  };
+
+  await savePricing();
+  return pricingConfig;
+}
+
+async function savePricing(): Promise<void> {
+  if (!pricingConfig) return;
+  pricingConfig.updatedAt = new Date().toISOString();
+  await Bun.write(PRICING_FILE, JSON.stringify(pricingConfig, null, 2) + "\n");
+}
+
+async function saveBudgetPolicies(): Promise<void> {
+  if (!budgetPolicies) return;
+  await Bun.write(
+    BUDGET_POLICIES_FILE,
+    JSON.stringify({ policies: budgetPolicies, updatedAt: new Date().toISOString() }, null, 2) + "\n"
+  );
+}
+
+/**
+ * Load pricing configuration.
+ */
+export async function loadPricingConfig(): Promise<PricingConfig> {
+  await initBudgetEngine();
+  return pricingConfig!;
+}
+
+/**
+ * Load budget policies.
+ */
+export async function loadPolicies(): Promise<BudgetPolicy[]> {
+  await initBudgetEngine();
+  return budgetPolicies!;
+}
+
+/**
+ * Add or update a budget policy.
+ */
+export async function upsertBudgetPolicy(
+  policyData: Omit<BudgetPolicy, "id" | "createdAt" | "updatedAt"> & { id?: string }
+): Promise<BudgetPolicy> {
+  await initBudgetEngine();
+
+  const now = new Date().toISOString();
+  const policyId = policyData.id;
+  
+  if (policyId) {
+    // Update existing
+    const index = budgetPolicies!.findIndex(p => p.id === policyId);
+    if (index >= 0) {
+      budgetPolicies![index] = {
+        ...budgetPolicies![index],
+        ...policyData,
+        id: policyId,
+        updatedAt: now,
+      };
+      await saveBudgetPolicies();
+      return budgetPolicies![index];
+    }
+  }
+
+  // Create new
+  const newPolicy: BudgetPolicy = {
+    ...policyData,
+    id: policyId || randomUUID(),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  budgetPolicies!.push(newPolicy);
+  await saveBudgetPolicies();
+  return newPolicy;
+}
+
+/**
+ * Delete a budget policy.
+ */
+export async function deleteBudgetPolicy(policyId: string): Promise<boolean> {
+  await initBudgetEngine();
+
+  const index = budgetPolicies!.findIndex(p => p.id === policyId);
+  if (index < 0) {
+    return false;
+  }
+
+  budgetPolicies!.splice(index, 1);
+  await saveBudgetPolicies();
+  return true;
+}
+
+/**
+ * Calculate estimated cost from usage metrics.
+ */
+export function calculateEstimatedCost(
+  usage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheCreationInputTokens?: number;
+    cacheReadInputTokens?: number;
+  },
+  provider: string,
+  model: string
+): { totalCost: number; breakdown: { inputCost: number; outputCost: number; cacheCost: number } } | null {
+  if (!pricingConfig) {
+    return null;
+  }
+
+  const tier = pricingConfig.tiers.find(t => t.provider === provider && t.model === model);
+  if (!tier) {
+    // Try just provider-level default
+    const providerTier = pricingConfig.tiers.find(t => t.provider === provider);
+    if (!providerTier) {
+      return null;
+    }
+  }
+
+  const selectedTier = tier || pricingConfig.tiers.find(t => t.provider === provider)!;
+
+  const inputCost = ((usage.inputTokens ?? 0) / 1_000_000) * selectedTier.inputCostPerMillion;
+  const outputCost = ((usage.outputTokens ?? 0) / 1_000_000) * selectedTier.outputCostPerMillion;
+  
+  let cacheCost = 0;
+  if (selectedTier.cacheCreationCostPerMillion && usage.cacheCreationInputTokens) {
+    cacheCost += (usage.cacheCreationInputTokens / 1_000_000) * selectedTier.cacheCreationCostPerMillion;
+  }
+  if (selectedTier.cacheReadCostPerMillion && usage.cacheReadInputTokens) {
+    cacheCost += (usage.cacheReadInputTokens / 1_000_000) * selectedTier.cacheReadCostPerMillion;
+  }
+
+  const totalCost = inputCost + outputCost + cacheCost;
+
+  return {
+    totalCost,
+    breakdown: {
+      inputCost,
+      outputCost,
+      cacheCost,
+    },
+  };
+}
+
+function matchesScope(record: { source?: string; channelId?: string; sessionId?: string; provider?: string; model?: string }, scope: BudgetScope): boolean {
+  // Check source
+  if (scope.source) {
+    const sources = Array.isArray(scope.source) ? scope.source : [scope.source];
+    if (record.source && !sources.includes(record.source)) {
+      return false;
+    }
+  }
+
+  // Check channelId
+  if (scope.channelId) {
+    const channels = Array.isArray(scope.channelId) ? scope.channelId : [scope.channelId];
+    if (record.channelId && !channels.includes(record.channelId)) {
+      return false;
+    }
+  }
+
+  // Check sessionId
+  if (scope.sessionId) {
+    const sessions = Array.isArray(scope.sessionId) ? scope.sessionId : [scope.sessionId];
+    if (record.sessionId && !sessions.includes(record.sessionId)) {
+      return false;
+    }
+  }
+
+  // Check provider
+  if (scope.provider) {
+    const providers = Array.isArray(scope.provider) ? scope.provider : [scope.provider];
+    if (record.provider && !providers.includes(record.provider)) {
+      return false;
+    }
+  }
+
+  // Check model
+  if (scope.model) {
+    const models = Array.isArray(scope.model) ? scope.model : [scope.model];
+    if (record.model && !models.includes(record.model)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getPeriodBounds(period: BudgetPeriod): { startDate: string; endDate: string } {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const day = now.getUTCDate();
+
+  let startDate: string;
+  let endDate: string;
+
+  switch (period) {
+    case "session":
+      // Session is unbounded in time - use all records
+      startDate = "1970-01-01T00:00:00Z";
+      endDate = "2099-12-31T23:59:59Z";
+      break;
+
+    case "daily":
+      startDate = new Date(year, month, day, 0, 0, 0, 0).toISOString();
+      endDate = new Date(year, month, day, 23, 59, 59, 999).toISOString();
+      break;
+
+    case "monthly":
+      startDate = new Date(year, month, 1, 0, 0, 0, 0).toISOString();
+      // Last day of month
+      const lastDay = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString();
+      endDate = lastDay;
+      break;
+  }
+
+  return { startDate, endDate };
+}
+
+/**
+ * Evaluate budget for a given context.
+ */
+export async function evaluateBudget(
+  context: {
+    sessionId?: string;
+    channelId?: string;
+    source?: string;
+    userId?: string;
+    provider?: string;
+    model?: string;
+  }
+): Promise<BudgetEvaluation[]> {
+  await initBudgetEngine();
+
+  const evaluations: BudgetEvaluation[] = [];
+
+  for (const policy of budgetPolicies!) {
+    if (!policy.enabled) {
+      continue;
+    }
+
+    // Check if context matches policy scope
+    if (!matchesScope(context, policy.scope)) {
+      continue;
+    }
+
+    // Get period bounds
+    const { startDate, endDate } = getPeriodBounds(policy.period);
+
+    // Get usage for the period
+    const filters: UsageFilters = {
+      startDate,
+      endDate,
+      sessionId: policy.period === "session" ? context.sessionId : undefined,
+      channelId: context.channelId,
+      source: context.source,
+      provider: context.provider,
+      model: context.model,
+    };
+
+    const aggregates = await getAggregates(filters);
+
+    const currentSpend = aggregates.totalEstimatedCost;
+    const { thresholds } = policy;
+
+    // Determine state
+    let state: BudgetState = "healthy";
+    let threshold: number | null = null;
+    let percentage = 0;
+
+    if (thresholds.blockAt !== undefined && currentSpend >= thresholds.blockAt) {
+      state = "block";
+      threshold = thresholds.blockAt;
+      percentage = (currentSpend / thresholds.blockAt) * 100;
+    } else if (thresholds.rerouteAt !== undefined && currentSpend >= thresholds.rerouteAt) {
+      state = "reroute";
+      threshold = thresholds.rerouteAt;
+      percentage = (currentSpend / thresholds.rerouteAt) * 100;
+    } else if (thresholds.degradeAt !== undefined && currentSpend >= thresholds.degradeAt) {
+      state = "degrade";
+      threshold = thresholds.degradeAt;
+      percentage = (currentSpend / thresholds.degradeAt) * 100;
+    } else if (thresholds.warnAt !== undefined && currentSpend >= thresholds.warnAt) {
+      state = "warn";
+      threshold = thresholds.warnAt;
+      percentage = (currentSpend / thresholds.warnAt) * 100;
+    }
+
+    // Determine actions
+    const actions = {
+      shouldWarn: state !== "healthy",
+      shouldDegrade: state === "degrade" || state === "reroute" || state === "block",
+      shouldReroute: state === "reroute" || state === "block",
+      shouldBlock: state === "block",
+      degradeToModel: policy.actionDefaults?.degradeToModel,
+      rerouteToProvider: policy.actionDefaults?.rerouteToProvider,
+    };
+
+    evaluations.push({
+      policyId: policy.id,
+      policyName: policy.name,
+      state,
+      currentSpend,
+      threshold,
+      percentage,
+      period: policy.period,
+      currency: policy.currency,
+      actions,
+      evaluatedAt: new Date().toISOString(),
+    });
+  }
+
+  return evaluations;
+}
+
+/**
+ * Get current budget state for a scope.
+ */
+export async function getBudgetState(
+  scope: BudgetScope
+): Promise<BudgetStateSummary[]> {
+  await initBudgetEngine();
+
+  const summaries: BudgetStateSummary[] = [];
+
+  for (const policy of budgetPolicies!) {
+    if (!policy.enabled) {
+      continue;
+    }
+
+    // Check if policy matches the requested scope
+    if (!matchesScope(scope as { source?: string; channelId?: string; sessionId?: string; provider?: string; model?: string }, policy.scope)) {
+      continue;
+    }
+
+    // Get period bounds
+    const { startDate, endDate } = getPeriodBounds(policy.period);
+
+    // Get usage for the period
+    const filters: UsageFilters = {
+      startDate,
+      endDate,
+    };
+
+    const aggregates = await getAggregates(filters);
+    const currentSpend = aggregates.totalEstimatedCost;
+
+    // Determine state
+    let state: BudgetState = "healthy";
+    let threshold: number | null = null;
+    let percentage = 0;
+
+    const { thresholds } = policy;
+
+    if (thresholds.blockAt !== undefined && currentSpend >= thresholds.blockAt) {
+      state = "block";
+      threshold = thresholds.blockAt;
+      percentage = (currentSpend / thresholds.blockAt) * 100;
+    } else if (thresholds.rerouteAt !== undefined && currentSpend >= thresholds.rerouteAt) {
+      state = "reroute";
+      threshold = thresholds.rerouteAt;
+      percentage = (currentSpend / thresholds.rerouteAt) * 100;
+    } else if (thresholds.degradeAt !== undefined && currentSpend >= thresholds.degradeAt) {
+      state = "degrade";
+      threshold = thresholds.degradeAt;
+      percentage = (currentSpend / thresholds.degradeAt) * 100;
+    } else if (thresholds.warnAt !== undefined && currentSpend >= thresholds.warnAt) {
+      state = "warn";
+      threshold = thresholds.warnAt;
+      percentage = (currentSpend / thresholds.warnAt) * 100;
+    }
+
+    summaries.push({
+      policyId: policy.id,
+      policyName: policy.name,
+      state,
+      currentSpend,
+      threshold,
+      percentage,
+      period: policy.period,
+      currency: policy.currency,
+    });
+  }
+
+  return summaries;
+}
+
+/**
+ * Create default budget policies for a channel.
+ */
+export async function createDefaultPoliciesForChannel(
+  channelId: string,
+  options: {
+    dailyLimit?: number;
+    monthlyLimit?: number;
+  } = {}
+): Promise<BudgetPolicy[]> {
+  const policies: BudgetPolicy[] = [];
+
+  if (options.dailyLimit) {
+    const dailyPolicy = await upsertBudgetPolicy({
+      id: randomUUID(),
+      name: `Daily budget for ${channelId}`,
+      scope: { channelId },
+      thresholds: {
+        warnAt: options.dailyLimit! * 0.7,
+        degradeAt: options.dailyLimit! * 0.85,
+        blockAt: options.dailyLimit!,
+      },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+    policies.push(dailyPolicy);
+  }
+
+  if (options.monthlyLimit) {
+    const monthlyPolicy = await upsertBudgetPolicy({
+      id: randomUUID(),
+      name: `Monthly budget for ${channelId}`,
+      scope: { channelId },
+      thresholds: {
+        warnAt: options.monthlyLimit! * 0.7,
+        degradeAt: options.monthlyLimit! * 0.85,
+        blockAt: options.monthlyLimit!,
+      },
+      period: "monthly",
+      currency: "USD",
+      enabled: true,
+    });
+    policies.push(monthlyPolicy);
+  }
+
+  return policies;
+}

--- a/src/governance/client.ts
+++ b/src/governance/client.ts
@@ -1,0 +1,163 @@
+/**
+ * GovernanceClient - Unified interface to governance operations
+ * 
+ * Provides a single entry point for policy evaluation, approval management,
+ * and governance telemetry across the codebase.
+ */
+
+import { evaluate, loadRules, type ToolRequestContext, type PolicyDecision } from "../policy/engine";
+import { enqueue, listPending, findByEventId, findById, loadState as loadApprovalState, type ApprovalEntry } from "../policy/approval-queue";
+import { logPolicyDecision } from "../policy/audit-log";
+import * as governance from "./index";
+
+export interface GovernanceClientConfig {
+  policyEnabled?: boolean;
+  approvalEnabled?: boolean;
+}
+
+export class GovernanceClient {
+  private config: GovernanceClientConfig;
+
+  constructor(config: GovernanceClientConfig = {}) {
+    this.config = {
+      policyEnabled: config.policyEnabled ?? true,
+      approvalEnabled: config.approvalEnabled ?? true,
+    };
+  }
+
+  // --- Policy Engine ---
+  
+  /**
+   * Evaluate a tool request against policy rules.
+   */
+  evaluateToolRequest(request: ToolRequestContext): PolicyDecision {
+    if (!this.config.policyEnabled) {
+      const decision = {
+        requestId: crypto.randomUUID(),
+        action: "allow",
+        reason: "Policy engine disabled",
+        evaluatedAt: new Date().toISOString(),
+        cacheable: false,
+      };
+      return decision;
+    }
+    const decision = evaluate(request);
+
+    // Log every policy decision to audit trail (fire-and-forget)
+    logPolicyDecision(
+      request.eventId,
+      decision.requestId,
+      request.source,
+      request.toolName,
+      decision.action,
+      decision.reason,
+      {
+        channelId: request.channelId,
+        threadId: request.threadId,
+        userId: request.userId,
+        skillName: request.skillName,
+        matchedRuleId: decision.matchedRuleId,
+      }
+    ).catch(err => {
+      console.error("[governance] Failed to write audit log:", err);
+    });
+
+    return decision;
+  }
+
+  /**
+   * Load/reload policy rules from disk.
+   */
+  async reloadPolicies(): Promise<void> {
+    await loadRules();
+  }
+
+  // --- Approval Queue ---
+  
+  /**
+   * Request approval for a tool execution.
+   * Returns the approval entry if decision is require_approval.
+   */
+  async requestApproval(request: ToolRequestContext, decision: PolicyDecision): Promise<ApprovalEntry | null> {
+    if (!this.config.approvalEnabled || decision.action !== "require_approval") {
+      return null;
+    }
+    return enqueue(request, decision);
+  }
+
+  /**
+   * Get all pending approvals.
+   */
+  getPendingApprovals(): ApprovalEntry[] {
+    return listPending();
+  }
+
+  /**
+   * Find approval by event ID.
+   */
+  async findApprovalByEvent(eventId: string): Promise<ApprovalEntry | null> {
+    return findByEventId(eventId);
+  }
+
+  /**
+   * Find approval by approval ID.
+   */
+  getApprovalById(id: string): ApprovalEntry | null {
+    return findById(id);
+  }
+
+  // --- Governance Telemetry ---
+  
+  /**
+   * Get governance telemetry summary.
+   */
+  async getTelemetry() {
+    return governance.getTelemetry({});
+  }
+
+  /**
+   * Get usage stats.
+   */
+  async getUsageStats() {
+    return governance.getUsageStats();
+  }
+
+  /**
+   * Get budget state.
+   */
+  async getBudgetState(channelId?: string) {
+    return governance.getBudgetState(channelId);
+  }
+
+  /**
+   * Check if a tool is allowed (shortcut for allow action).
+   */
+  isToolAllowed(request: ToolRequestContext): boolean {
+    const decision = this.evaluateToolRequest(request);
+    return decision.action === "allow";
+  }
+
+  /**
+   * Check if a tool requires approval (shortcut for require_approval action).
+   */
+  requiresApproval(request: ToolRequestContext): boolean {
+    const decision = this.evaluateToolRequest(request);
+    return decision.action === "require_approval";
+  }
+}
+
+// --- Singleton Instance ---
+
+let governanceClientInstance: GovernanceClient | null = null;
+
+export function getGovernanceClient(): GovernanceClient {
+  if (!governanceClientInstance) {
+    governanceClientInstance = new GovernanceClient();
+  }
+  return governanceClientInstance;
+}
+
+export function initGovernanceClient(config?: GovernanceClientConfig): GovernanceClient {
+  governanceClientInstance = new GovernanceClient(config);
+  return governanceClientInstance;
+}

--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -1,0 +1,104 @@
+/**
+ * Governance Module Index
+ * 
+ * Exposes all governance modules from a single entry point.
+ */
+
+// Usage Tracker
+export {
+  initUsageTracker,
+  recordInvocationStart,
+  recordInvocationCompletion,
+  recordInvocationFailure,
+  recordInvocationKilled,
+  getInvocation,
+  getSessionUsage,
+  getChannelUsage,
+  getAggregates,
+  getUsageStats,
+  getAllUsageRecords,
+  resetUsageTracker,
+  type InvocationStatus,
+  type UsageMetrics,
+  type EstimatedCost,
+  type InvocationUsageRecord,
+  type InvocationContext,
+  type UsageFilters,
+} from "./usage-tracker";
+
+// Budget Engine
+export {
+  initBudgetEngine,
+  evaluateBudget,
+  getBudgetState,
+  upsertBudgetPolicy,
+  deleteBudgetPolicy,
+  loadPricingConfig,
+  loadPolicies,
+  calculateEstimatedCost,
+  createDefaultPoliciesForChannel,
+  resetBudgetEngine,
+  type BudgetPeriod,
+  type BudgetState,
+  type BudgetThreshold,
+  type BudgetActionDefaults,
+  type BudgetScope,
+  type BudgetPolicy,
+  type PricingTier,
+  type PricingConfig,
+  type BudgetEvaluation,
+  type BudgetStateSummary,
+} from "./budget-engine";
+
+// Model Router
+export {
+  selectModel,
+  getFallbackChain,
+  isModelAllowed,
+  configureRouter,
+  getRouterConfig,
+  type ModelRoutingDecision,
+  type ModelRequestContext,
+} from "./model-router";
+
+// Watchdog
+export {
+  initWatchdog,
+  recordExecutionMetric,
+  incrementToolCall,
+  incrementTurnCount,
+  checkLimits,
+  handleTrigger,
+  getActiveInvocation,
+  getSessionActiveInvocations,
+  clearInvocation,
+  getWatchdogStats,
+  configureWatchdog,
+  getWatchdogConfig,
+  resetWatchdog,
+  type WatchdogState,
+  type WatchdogLimits,
+  type ExecutionMetrics,
+  type WatchdogDecision,
+  type WatchdogConfig,
+} from "./watchdog";
+
+// Telemetry
+export {
+  getTelemetry,
+  getTelemetrySummary,
+  getProviderBreakdown,
+  getModelBreakdown,
+  getChannelBreakdown,
+  getBudgetHealth,
+  type GovernanceTelemetry,
+  type TelemetryFilters,
+} from "./telemetry";
+
+// GovernanceClient
+export {
+  GovernanceClient,
+  getGovernanceClient,
+  initGovernanceClient,
+  type GovernanceClientConfig,
+} from "./client";

--- a/src/governance/model-router.ts
+++ b/src/governance/model-router.ts
@@ -1,0 +1,358 @@
+/**
+ * Governance-Aware Model Router
+ * 
+ * Selects provider/model combinations using policy, task context, capability requirements,
+ * and budget state. Replaces the naive keyword-based router with an auditable,
+ * policy-driven approach.
+ */
+
+import { randomUUID } from "crypto";
+import { evaluateBudget, type BudgetEvaluation, type BudgetState } from "./budget-engine";
+import { classifyTask, selectModel as legacySelectModel } from "../model-router";
+import type { AgenticMode } from "../config";
+
+export type { BudgetState };
+
+export interface ModelRoutingDecision {
+  requestId: string;
+  selectedProvider: string;
+  selectedModel: string;
+  reason: string;
+  matchedPolicyId?: string;
+  budgetState?: BudgetState;
+  fallbackChain?: Array<{ provider: string; model: string }>;
+  decidedAt: string;
+}
+
+export interface ModelRequestContext {
+  prompt?: string;
+  taskType?: string;
+  capability?: string;
+  preferredProvider?: string;
+  preferredModel?: string;
+  explicitOverride?: {
+    provider?: string;
+    model?: string;
+    allowed: boolean;
+  };
+  sessionId?: string;
+  channelId?: string;
+  source?: string;
+  userId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface RouterConfig {
+  defaultProvider: string;
+  defaultModel: string;
+  modes?: AgenticMode[];
+  defaultMode?: string;
+  fallbackChain: Array<{ provider: string; model: string }>;
+  degradeToModel?: string;
+  rerouteToProvider?: string;
+}
+
+// Configuration for the router
+let routerConfig: RouterConfig = {
+  defaultProvider: "anthropic",
+  defaultModel: "claude-3-5-sonnet",
+  fallbackChain: [
+    { provider: "anthropic", model: "claude-3-5-sonnet" },
+    { provider: "anthropic", model: "claude-3-haiku" },
+    { provider: "openai", model: "gpt-4o-mini" },
+  ],
+};
+
+/**
+ * Configure the model router.
+ */
+export function configureRouter(config: Partial<RouterConfig>): void {
+  routerConfig = {
+    ...routerConfig,
+    ...config,
+    fallbackChain: config.fallbackChain || routerConfig.fallbackChain,
+  };
+}
+
+/**
+ * Get current router configuration.
+ */
+export function getRouterConfig(): RouterConfig {
+  return { ...routerConfig };
+}
+
+function determineBudgetState(evaluations: BudgetEvaluation[]): BudgetState {
+  if (evaluations.length === 0) {
+    return "healthy";
+  }
+
+  // Use the worst state across all applicable policies
+  const statePriority: Record<BudgetState, number> = {
+    healthy: 0,
+    warn: 1,
+    degrade: 2,
+    reroute: 3,
+    block: 4,
+  };
+
+  let worstState: BudgetState = "healthy";
+  let highestPriority = 0;
+
+  for (const eval_ of evaluations) {
+    const priority = statePriority[eval_.state];
+    if (priority > highestPriority) {
+      highestPriority = priority;
+      worstState = eval_.state;
+    }
+  }
+
+  return worstState;
+}
+
+function findCheaperAlternative(
+  currentProvider: string,
+  currentModel: string
+): { provider: string; model: string } | null {
+  // Define cheaper alternatives per provider
+  const cheaperAlternatives: Record<string, Record<string, { provider: string; model: string }>> = {
+    "anthropic": {
+      "claude-3-5-sonnet": { provider: "anthropic", model: "claude-3-haiku" },
+      "claude-3-opus": { provider: "anthropic", model: "claude-3-5-sonnet" },
+    },
+    "openai": {
+      "gpt-4o": { provider: "openai", model: "gpt-4o-mini" },
+      "gpt-4": { provider: "openai", model: "gpt-4o-mini" },
+    },
+  };
+
+  const providerAlternatives = cheaperAlternatives[currentProvider];
+  if (!providerAlternatives) {
+    return null;
+  }
+
+  return providerAlternatives[currentModel] || null;
+}
+
+function findRerouteAlternative(
+  currentProvider: string,
+  rerouteToProvider?: string
+): { provider: string; model: string } | null {
+  // Provider-level reroute mapping
+  const providerDefaults: Record<string, { provider: string; model: string }> = {
+    "anthropic": { provider: "anthropic", model: "claude-3-haiku" },
+    "openai": { provider: "openai", model: "gpt-4o-mini" },
+    "google": { provider: "google", model: "glm-4" },
+  };
+
+  if (rerouteToProvider && providerDefaults[rerouteToProvider]) {
+    return providerDefaults[rerouteToProvider];
+  }
+
+  // Fall back to finding any cheaper provider
+  for (const [provider, defaultModel] of Object.entries(providerDefaults)) {
+    if (provider !== currentProvider) {
+      return defaultModel;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Select a model based on request context and budget state.
+ */
+export async function selectModel(requestContext: ModelRequestContext): Promise<ModelRoutingDecision> {
+  const requestId = randomUUID();
+  const now = new Date().toISOString();
+
+  // Evaluate budget first
+  const budgetEvaluations = await evaluateBudget({
+    sessionId: requestContext.sessionId,
+    channelId: requestContext.channelId,
+    source: requestContext.source,
+    userId: requestContext.userId,
+    provider: requestContext.preferredProvider,
+    model: requestContext.preferredModel,
+  });
+
+  const budgetState = determineBudgetState(budgetEvaluations);
+  const worstEvaluation = budgetEvaluations[0]; // First is typically the most relevant
+
+  // Check for explicit override
+  if (requestContext.explicitOverride?.allowed && 
+      (requestContext.explicitOverride.provider || requestContext.explicitOverride.model)) {
+    // Override is allowed - use it but still consider budget state
+    if (budgetState === "block") {
+      return {
+        requestId,
+        selectedProvider: "",
+        selectedModel: "",
+        reason: "Execution blocked: budget limit exceeded",
+        budgetState,
+        fallbackChain: routerConfig.fallbackChain,
+        decidedAt: now,
+      };
+    }
+
+    return {
+      requestId,
+      selectedProvider: requestContext.explicitOverride.provider || routerConfig.defaultProvider,
+      selectedModel: requestContext.explicitOverride.model || routerConfig.defaultModel,
+      reason: "Explicit override applied (allowed by policy)",
+      matchedPolicyId: worstEvaluation?.policyId,
+      budgetState,
+      fallbackChain: routerConfig.fallbackChain,
+      decidedAt: now,
+    };
+  }
+
+  // Determine base model selection
+  let selectedProvider = routerConfig.defaultProvider;
+  let selectedModel = routerConfig.defaultModel;
+  let reason = "Default model selection";
+  let finalBudgetState: BudgetState = budgetState;
+
+  // If blocked, return early
+  if (budgetState === "block") {
+    finalBudgetState = "block";
+    return {
+      requestId,
+      selectedProvider: "",
+      selectedModel: "",
+      reason: "Execution blocked: budget limit exceeded",
+      budgetState: finalBudgetState,
+      matchedPolicyId: worstEvaluation?.policyId,
+      fallbackChain: routerConfig.fallbackChain,
+      decidedAt: now,
+    };
+  }
+
+  // Use task type / capability if provided
+  if (requestContext.taskType && routerConfig.modes && routerConfig.modes.length > 0) {
+    // Use legacy classification for task type
+    if (requestContext.prompt && routerConfig.defaultMode) {
+      const legacyResult = legacySelectModel(
+        requestContext.prompt,
+        routerConfig.modes,
+        routerConfig.defaultMode
+      );
+      selectedModel = legacyResult.model;
+      reason = `Task classified as "${legacyResult.taskType}": ${legacyResult.reasoning}`;
+    }
+  } else if (requestContext.capability) {
+    // Map capability to model
+    const capabilityModelMap: Record<string, { provider: string; model: string }> = {
+      "coding": { provider: "anthropic", model: "claude-3-5-sonnet" },
+      "analysis": { provider: "anthropic", model: "claude-3-5-sonnet" },
+      "creative": { provider: "anthropic", model: "claude-3-5-sonnet" },
+      "fast": { provider: "anthropic", model: "claude-3-haiku" },
+      "simple": { provider: "anthropic", model: "claude-3-haiku" },
+    };
+    const mapped = capabilityModelMap[requestContext.capability.toLowerCase()];
+    if (mapped) {
+      selectedProvider = mapped.provider;
+      selectedModel = mapped.model;
+      reason = `Capability "${requestContext.capability}" mapped to ${mapped.provider}/${mapped.model}`;
+    }
+  }
+
+  // Apply preferred provider/model if set
+  if (requestContext.preferredProvider) {
+    selectedProvider = requestContext.preferredProvider;
+  }
+  if (requestContext.preferredModel) {
+    selectedModel = requestContext.preferredModel;
+  }
+
+  // Apply budget-aware modifications
+  // Note: "block" is handled earlier with early return, so remaining states are "healthy"|"warn"|"degrade"|"reroute"
+  const currentBudgetState = budgetState as "healthy" | "warn" | "degrade" | "reroute";
+  if (currentBudgetState === "degrade" && worstEvaluation?.actions.degradeToModel) {
+    const degradeParts = worstEvaluation.actions.degradeToModel.split("/");
+    if (degradeParts.length === 2) {
+      selectedProvider = degradeParts[0];
+      selectedModel = degradeParts[1];
+    } else {
+      selectedModel = worstEvaluation.actions.degradeToModel;
+    }
+    reason = `Budget degrade: switched to ${selectedProvider}/${selectedModel}`;
+  } else if (currentBudgetState === "reroute" && worstEvaluation?.actions.rerouteToProvider) {
+    const reroute = findRerouteAlternative(selectedProvider, worstEvaluation.actions.rerouteToProvider);
+    if (reroute) {
+      selectedProvider = reroute.provider;
+      selectedModel = reroute.model;
+      reason = `Budget reroute: switched to ${selectedProvider}/${selectedModel}`;
+    } else if (routerConfig.rerouteToProvider) {
+      const fallback = findRerouteAlternative(selectedProvider, routerConfig.rerouteToProvider);
+      if (fallback) {
+        selectedProvider = fallback.provider;
+        selectedModel = fallback.model;
+        reason = `Budget reroute: switched to ${selectedProvider}/${selectedModel}`;
+      }
+    }
+  } else if (currentBudgetState === "warn") {
+    reason += ` (budget warning: ${worstEvaluation?.percentage.toFixed(1)}% of threshold)`;
+  }
+  // "healthy" state requires no special action
+
+  // Build fallback chain based on budget state (block case handled earlier)
+  let fallbackChain = routerConfig.fallbackChain;
+  if (currentBudgetState === "degrade" || currentBudgetState === "reroute") {
+    // Filter fallback chain to cheaper options
+    fallbackChain = routerConfig.fallbackChain.filter(
+      (f) => f.provider !== selectedProvider || f.model !== selectedModel
+    );
+  }
+
+  return {
+    requestId,
+    selectedProvider,
+    selectedModel,
+    reason,
+    matchedPolicyId: worstEvaluation?.policyId,
+    budgetState,
+    fallbackChain,
+    decidedAt: now,
+  };
+}
+
+/**
+ * Get the fallback chain for a request context.
+ */
+export async function getFallbackChain(requestContext: ModelRequestContext): Promise<Array<{ provider: string; model: string }>> {
+  const decision = await selectModel(requestContext);
+  return decision.fallbackChain || routerConfig.fallbackChain;
+}
+
+/**
+ * Check if a specific model selection is allowed given the context.
+ */
+export async function isModelAllowed(
+  provider: string,
+  model: string,
+  context: ModelRequestContext
+): Promise<{ allowed: boolean; reason: string }> {
+  // Evaluate budget
+  const evaluations = await evaluateBudget({
+    sessionId: context.sessionId,
+    channelId: context.channelId,
+    source: context.source,
+    userId: context.userId,
+    provider,
+    model,
+  });
+
+  const budgetState = determineBudgetState(evaluations);
+
+  if (budgetState === "block") {
+    return {
+      allowed: false,
+      reason: `Model ${provider}/${model} blocked: budget limit exceeded`,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: "Model selection allowed",
+  };
+}

--- a/src/governance/telemetry.ts
+++ b/src/governance/telemetry.ts
@@ -1,0 +1,306 @@
+/**
+ * Governance Telemetry
+ * 
+ * Exposes persisted governance state and derived aggregates to API/dashboard consumers.
+ * 
+ * PRINCIPLES:
+ * - Telemetry is read-side only
+ * - Telemetry derives from persisted usage/governance records
+ * - Cached aggregates may exist, but persisted records remain canonical
+ * - Real-time updates are optional and only added if architecture supports them
+ */
+
+import { getAggregates, type UsageFilters } from "./usage-tracker";
+import { getBudgetState, type BudgetScope } from "./budget-engine";
+
+export interface GovernanceTelemetry {
+  // Session stats
+  totalSessions: number;
+  activeSessions: number;
+  
+  // Cost stats
+  estimatedTotalCost: number;
+  currency: string;
+  
+  // Channel stats
+  channelStats: Record<string, {
+    sessions: number;
+    estimatedCost: number;
+    tokens: number;
+    invocations: number;
+  }>;
+  
+  // Provider stats
+  providerStats: Record<string, {
+    calls: number;
+    tokens: number;
+    estimatedCost: number;
+  }>;
+  
+  // Model stats
+  modelStats: Record<string, {
+    calls: number;
+    tokens: number;
+    estimatedCost: number;
+  }>;
+  
+  // Budget states
+  budgetStates: Record<string, {
+    status: string;
+    scope: string;
+    currentSpend?: number;
+    threshold?: number;
+  }>;
+  
+  // Watchdog stats
+  watchdog: {
+    triggered: number;
+    warned: number;
+    killed: number;
+    suspended: number;
+  };
+  
+  // Invocation stats
+  invocationStats: {
+    total: number;
+    completed: number;
+    failed: number;
+    killed: number;
+    byProvider: Record<string, number>;
+    byModel: Record<string, number>;
+  };
+}
+
+export interface TelemetryFilters {
+  startDate?: string;
+  endDate?: string;
+  channelId?: string;
+  source?: string;
+  provider?: string;
+  model?: string;
+}
+
+/**
+ * Get comprehensive governance telemetry.
+ */
+export async function getTelemetry(filters: TelemetryFilters = {}): Promise<GovernanceTelemetry> {
+  // Get usage aggregates
+  const usageFilters: UsageFilters = {
+    startDate: filters.startDate,
+    endDate: filters.endDate,
+    channelId: filters.channelId,
+    source: filters.source,
+    provider: filters.provider,
+    model: filters.model,
+  };
+
+  const aggregates = await getAggregates(usageFilters);
+
+  // Get budget states
+  const budgetScope: BudgetScope = {};
+  if (filters.channelId) {
+    budgetScope.channelId = filters.channelId;
+  }
+  const budgetStates = await getBudgetState(budgetScope);
+
+  // Build telemetry response
+  const telemetry: GovernanceTelemetry = {
+    // Session stats (derived from usage records)
+    totalSessions: new Set(
+      Object.values(aggregates.byChannel).map(() => "")
+    ).size || Object.keys(aggregates.byChannel).length,
+    activeSessions: 0, // Would need active session tracking
+
+    // Cost stats
+    estimatedTotalCost: aggregates.totalEstimatedCost,
+    currency: "USD", // Default currency
+
+    // Channel stats
+    channelStats: Object.fromEntries(
+      Object.entries(aggregates.byChannel).map(([channelId, stats]) => [
+        channelId,
+        {
+          sessions: 0, // Would need session-level tracking
+          estimatedCost: stats.cost,
+          tokens: stats.tokens,
+          invocations: stats.count,
+        },
+      ])
+    ),
+
+    // Provider stats
+    providerStats: Object.fromEntries(
+      Object.entries(aggregates.byProvider).map(([provider, stats]) => [
+        provider,
+        {
+          calls: stats.count,
+          tokens: stats.tokens,
+          estimatedCost: stats.cost,
+        },
+      ])
+    ),
+
+    // Model stats
+    modelStats: Object.fromEntries(
+      Object.entries(aggregates.byModel).map(([model, stats]) => [
+        model,
+        {
+          calls: stats.count,
+          tokens: stats.tokens,
+          estimatedCost: stats.cost,
+        },
+      ])
+    ),
+
+    // Budget states
+    budgetStates: Object.fromEntries(
+      budgetStates.map((bs) => [
+        bs.policyId,
+        {
+          status: bs.state,
+          scope: JSON.stringify(bs),
+          currentSpend: bs.currentSpend,
+          threshold: bs.threshold ?? undefined,
+        },
+      ])
+    ),
+
+    // Watchdog stats (placeholder - would need watchdog event tracking)
+    watchdog: {
+      triggered: 0,
+      warned: 0,
+      killed: aggregates.killedInvocations,
+      suspended: 0,
+    },
+
+    // Invocation stats
+    invocationStats: {
+      total: aggregates.totalInvocations,
+      completed: aggregates.completedInvocations,
+      failed: aggregates.failedInvocations,
+      killed: aggregates.killedInvocations,
+      byProvider: Object.fromEntries(
+        Object.entries(aggregates.byProvider).map(([p, v]) => [p, v.count])
+      ),
+      byModel: Object.fromEntries(
+        Object.entries(aggregates.byModel).map(([m, v]) => [m, v.count])
+      ),
+    },
+  };
+
+  return telemetry;
+}
+
+/**
+ * Get lightweight summary for quick overview.
+ */
+export async function getTelemetrySummary(): Promise<{
+  totalInvocations: number;
+  estimatedTotalCost: number;
+  activeBudgets: number;
+  blockedBudgets: number;
+}> {
+  const aggregates = await getAggregates({});
+  const budgetStates = await getBudgetState({});
+
+  return {
+    totalInvocations: aggregates.totalInvocations,
+    estimatedTotalCost: aggregates.totalEstimatedCost,
+    activeBudgets: budgetStates.filter((b) => b.state !== "healthy").length,
+    blockedBudgets: budgetStates.filter((b) => b.state === "block").length,
+  };
+}
+
+/**
+ * Get provider breakdown.
+ */
+export async function getProviderBreakdown(): Promise<Array<{
+  provider: string;
+  calls: number;
+  tokens: number;
+  estimatedCost: number;
+  avgCostPerCall: number;
+}>> {
+  const aggregates = await getAggregates({});
+
+  return Object.entries(aggregates.byProvider).map(([provider, stats]) => ({
+    provider,
+    calls: stats.count,
+    tokens: stats.tokens,
+    estimatedCost: stats.cost,
+    avgCostPerCall: stats.count > 0 ? stats.cost / stats.count : 0,
+  }));
+}
+
+/**
+ * Get model breakdown.
+ */
+export async function getModelBreakdown(): Promise<Array<{
+  model: string;
+  provider: string;
+  calls: number;
+  tokens: number;
+  estimatedCost: number;
+  avgCostPerCall: number;
+}>> {
+  const aggregates = await getAggregates({});
+
+  return Object.entries(aggregates.byModel).map(([model, stats]) => {
+    // Extract provider from model name (heuristic)
+    const provider = model.includes("-") ? model.split("-")[0] : "unknown";
+    return {
+      model,
+      provider,
+      calls: stats.count,
+      tokens: stats.tokens,
+      estimatedCost: stats.cost,
+      avgCostPerCall: stats.count > 0 ? stats.cost / stats.count : 0,
+    };
+  });
+}
+
+/**
+ * Get channel breakdown.
+ */
+export async function getChannelBreakdown(): Promise<Array<{
+  channelId: string;
+  sessions: number;
+  invocations: number;
+  tokens: number;
+  estimatedCost: number;
+}>> {
+  const aggregates = await getAggregates({});
+
+  return Object.entries(aggregates.byChannel).map(([channelId, stats]) => ({
+    channelId,
+    sessions: 0, // Would need session tracking per channel
+    invocations: stats.count,
+    tokens: stats.tokens,
+    estimatedCost: stats.cost,
+  }));
+}
+
+/**
+ * Get budget health summary.
+ */
+export async function getBudgetHealth(): Promise<Array<{
+  policyId: string;
+  policyName: string;
+  state: string;
+  currentSpend: number;
+  threshold: number | null;
+  percentage: number;
+  currency: string;
+}>> {
+  const budgetStates = await getBudgetState({});
+
+  return budgetStates.map((bs) => ({
+    policyId: bs.policyId,
+    policyName: bs.policyName,
+    state: bs.state,
+    currentSpend: bs.currentSpend,
+    threshold: bs.threshold,
+    percentage: bs.percentage,
+    currency: bs.currency,
+  }));
+}

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -1,0 +1,630 @@
+/**
+ * Durable Usage Tracker
+ * 
+ * Persisted per-invocation usage/accounting records with aggregate queries.
+ * 
+ * STORAGE MODEL:
+ * - Records stored in .claude/claudeclaw/usage/
+ * - Per-invocation: usage-{invocationId}.json
+ * - Index: usage-index.json (maps invocationId to file)
+ * - Usage logs: usage-{YYYYMMDD}.jsonl (daily rotation)
+ * 
+ * COST CALCULATION:
+ * - Cost is ESTIMATED based on configurable pricing metadata
+ * - Cost is NEVER presented as exact provider billing
+ * - Pricing is versioned for auditability
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { randomUUID } from "crypto";
+
+const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
+const USAGE_INDEX_FILE = join(USAGE_DIR, "usage-index.json");
+const MAX_INDEX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+export type InvocationStatus = "started" | "completed" | "failed" | "killed";
+
+export interface UsageMetrics {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
+export interface EstimatedCost {
+  currency: string;
+  inputCost?: number;
+  outputCost?: number;
+  cacheCost?: number;
+  totalCost?: number;
+  pricingVersion?: string;
+}
+
+export interface InvocationUsageRecord {
+  invocationId: string;
+  eventId?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  source?: string;
+  channelId?: string;
+  threadId?: string;
+  provider: string;
+  model: string;
+  startedAt: string;
+  completedAt?: string;
+  status: InvocationStatus;
+  usage?: UsageMetrics;
+  estimatedCost?: EstimatedCost;
+  metadata?: Record<string, unknown>;
+  error?: {
+    type?: string;
+    message: string;
+  };
+}
+
+export interface InvocationContext {
+  eventId?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+  source?: string;
+  channelId?: string;
+  threadId?: string;
+  provider: string;
+  model: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface UsageIndex {
+  version: number;
+  records: Record<string, string>; // invocationId -> filename
+  updatedAt: string;
+}
+
+interface DailyUsageLog {
+  date: string;
+  records: string[];
+}
+
+// In-memory cache for performance
+let usageIndex: UsageIndex | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+// Write queue for serializing concurrent operations
+let writeQueue: Promise<void> = Promise.resolve();
+let writeQueueLength = 0;
+
+function enqueueWrite<T>(operation: () => Promise<T>): Promise<T> {
+  writeQueueLength++;
+  const promise = writeQueue.then(() => operation());
+  writeQueue = promise.then(
+    () => { writeQueueLength--; },
+    () => { writeQueueLength--; }
+  );
+  return promise;
+}
+
+export function getWriteQueueLength(): number {
+  return writeQueueLength;
+}
+
+export function resetUsageTracker(): void {
+  usageIndex = null;
+  initializationPromise = null;
+  writeQueue = Promise.resolve();
+  writeQueueLength = 0;
+}
+
+/**
+ * Initialize the usage tracker system.
+ */
+export async function initUsageTracker(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directory exists
+  await Bun.write(join(USAGE_DIR, ".gitkeep"), "");
+
+  // Try to load existing index
+  usageIndex = await loadUsageIndex();
+
+  if (!usageIndex) {
+    usageIndex = {
+      version: 1,
+      records: {},
+      updatedAt: new Date().toISOString(),
+    };
+    await saveUsageIndex();
+  }
+}
+
+async function loadUsageIndex(): Promise<UsageIndex | null> {
+  try {
+    if (!existsSync(USAGE_INDEX_FILE)) {
+      return null;
+    }
+    const content = await Bun.file(USAGE_INDEX_FILE).json();
+    if (content.version === 1 && typeof content.records === "object") {
+      return content as UsageIndex;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveUsageIndex(): Promise<void> {
+  if (!usageIndex) return;
+
+  usageIndex.updatedAt = new Date().toISOString();
+  await Bun.write(USAGE_INDEX_FILE, JSON.stringify(usageIndex, null, 2) + "\n");
+}
+
+function getInvocationFilePath(invocationId: string): string {
+  return join(USAGE_DIR, `usage-${invocationId}.json`);
+}
+
+function getDailyLogFilePath(date: string): string {
+  return join(USAGE_DIR, `usage-${date}.jsonl`);
+}
+
+function getTodayDate(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+/**
+ * Record the start of an invocation.
+ */
+export async function recordInvocationStart(context: InvocationContext): Promise<InvocationUsageRecord> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const now = new Date().toISOString();
+    const record: InvocationUsageRecord = {
+      invocationId: randomUUID(),
+      eventId: context.eventId,
+      sessionId: context.sessionId,
+      claudeSessionId: context.claudeSessionId ?? null,
+      source: context.source,
+      channelId: context.channelId,
+      threadId: context.threadId,
+      provider: context.provider,
+      model: context.model,
+      startedAt: now,
+      status: "started",
+      metadata: context.metadata,
+    };
+
+    // Save record
+    const filePath = getInvocationFilePath(record.invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Update index
+    if (usageIndex) {
+      usageIndex.records[record.invocationId] = filePath;
+      await saveUsageIndex();
+    }
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "start",
+    }) + "\n";
+    
+    const existingContent = existsSync(dailyLogPath) 
+      ? await Bun.file(dailyLogPath).text() 
+      : "";
+    await Bun.write(dailyLogPath, existingContent + logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Record the completion of an invocation with usage metrics.
+ */
+export async function recordInvocationCompletion(
+  invocationId: string,
+  usage?: UsageMetrics,
+  estimatedCost?: EstimatedCost
+): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const record = await loadInvocationRecord(invocationId);
+    if (!record) {
+      console.warn(`[usage-tracker] Invocation ${invocationId} not found for completion`);
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    record.status = "completed";
+    record.completedAt = now;
+    record.usage = usage;
+    record.estimatedCost = estimatedCost;
+
+    // Save updated record
+    const filePath = getInvocationFilePath(invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "completion",
+      usage,
+      estimatedCost,
+    }) + "\n";
+    
+    const existingContent = existsSync(dailyLogPath) 
+      ? await Bun.file(dailyLogPath).text() 
+      : "";
+    await Bun.write(dailyLogPath, existingContent + logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Record the failure of an invocation.
+ */
+export async function recordInvocationFailure(
+  invocationId: string,
+  error: { type?: string; message: string }
+): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const record = await loadInvocationRecord(invocationId);
+    if (!record) {
+      console.warn(`[usage-tracker] Invocation ${invocationId} not found for failure`);
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    record.status = "failed";
+    record.completedAt = now;
+    record.error = error;
+
+    // Save updated record
+    const filePath = getInvocationFilePath(invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "failure",
+      error,
+    }) + "\n";
+    
+    const existingContent = existsSync(dailyLogPath) 
+      ? await Bun.file(dailyLogPath).text() 
+      : "";
+    await Bun.write(dailyLogPath, existingContent + logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Record invocation killed by watchdog.
+ */
+export async function recordInvocationKilled(
+  invocationId: string,
+  reason: string
+): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+
+  return enqueueWrite(async () => {
+    const record = await loadInvocationRecord(invocationId);
+    if (!record) {
+      console.warn(`[usage-tracker] Invocation ${invocationId} not found for kill`);
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    record.status = "killed";
+    record.completedAt = now;
+    record.error = { type: "watchdog", message: reason };
+
+    // Save updated record
+    const filePath = getInvocationFilePath(invocationId);
+    await Bun.write(filePath, JSON.stringify(record, null, 2) + "\n");
+
+    // Append to daily log
+    const today = getTodayDate();
+    const dailyLogPath = getDailyLogFilePath(today);
+    const logEntry = JSON.stringify({
+      invocationId: record.invocationId,
+      timestamp: now,
+      type: "killed",
+      reason,
+    }) + "\n";
+    
+    const existingContent = existsSync(dailyLogPath) 
+      ? await Bun.file(dailyLogPath).text() 
+      : "";
+    await Bun.write(dailyLogPath, existingContent + logEntry);
+
+    return record;
+  });
+}
+
+/**
+ * Load an invocation record by ID.
+ */
+export async function getInvocation(invocationId: string): Promise<InvocationUsageRecord | null> {
+  await initUsageTracker();
+  return loadInvocationRecord(invocationId);
+}
+
+async function loadInvocationRecord(invocationId: string): Promise<InvocationUsageRecord | null> {
+  const filePath = getInvocationFilePath(invocationId);
+  
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    return await Bun.file(filePath).json() as InvocationUsageRecord;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get usage for a specific session.
+ */
+export async function getSessionUsage(sessionId: string): Promise<InvocationUsageRecord[]> {
+  await initUsageTracker();
+
+  const records: InvocationUsageRecord[] = [];
+
+  if (!usageIndex) {
+    return records;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+      if (record.sessionId === sessionId) {
+        records.push(record);
+      }
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get usage for a specific channel.
+ */
+export async function getChannelUsage(channelId: string): Promise<InvocationUsageRecord[]> {
+  await initUsageTracker();
+
+  const records: InvocationUsageRecord[] = [];
+
+  if (!usageIndex) {
+    return records;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+      if (record.channelId === channelId) {
+        records.push(record);
+      }
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get usage filtered by various criteria.
+ */
+export interface UsageFilters {
+  sessionId?: string;
+  channelId?: string;
+  source?: string;
+  provider?: string;
+  model?: string;
+  status?: InvocationStatus;
+  startDate?: string;
+  endDate?: string;
+}
+
+export async function getAggregates(filters: UsageFilters = {}): Promise<{
+  totalInvocations: number;
+  completedInvocations: number;
+  failedInvocations: number;
+  killedInvocations: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
+  totalEstimatedCost: number;
+  byProvider: Record<string, { count: number; tokens: number; cost: number }>;
+  byModel: Record<string, { count: number; tokens: number; cost: number }>;
+  byChannel: Record<string, { count: number; tokens: number; cost: number }>;
+  bySource: Record<string, { count: number; tokens: number; cost: number }>;
+}> {
+  await initUsageTracker();
+
+  const result = {
+    totalInvocations: 0,
+    completedInvocations: 0,
+    failedInvocations: 0,
+    killedInvocations: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalEstimatedCost: 0,
+    byProvider: {} as Record<string, { count: number; tokens: number; cost: number }>,
+    byModel: {} as Record<string, { count: number; tokens: number; cost: number }>,
+    byChannel: {} as Record<string, { count: number; tokens: number; cost: number }>,
+    bySource: {} as Record<string, { count: number; tokens: number; cost: number }>,
+  };
+
+  if (!usageIndex) {
+    return result;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+
+      // Apply filters
+      if (filters.sessionId && record.sessionId !== filters.sessionId) continue;
+      if (filters.channelId && record.channelId !== filters.channelId) continue;
+      if (filters.source && record.source !== filters.source) continue;
+      if (filters.provider && record.provider !== filters.provider) continue;
+      if (filters.model && record.model !== filters.model) continue;
+      if (filters.status && record.status !== filters.status) continue;
+      if (filters.startDate && record.startedAt < filters.startDate) continue;
+      if (filters.endDate && record.startedAt > filters.endDate) continue;
+
+      // Count
+      result.totalInvocations++;
+
+      if (record.status === "completed") {
+        result.completedInvocations++;
+      } else if (record.status === "failed") {
+        result.failedInvocations++;
+      } else if (record.status === "killed") {
+        result.killedInvocations++;
+      }
+
+      // Tokens
+      const inputTokens = record.usage?.inputTokens ?? 0;
+      const outputTokens = record.usage?.outputTokens ?? 0;
+      const cacheCreationTokens = record.usage?.cacheCreationInputTokens ?? 0;
+      const cacheReadTokens = record.usage?.cacheReadInputTokens ?? 0;
+
+      result.totalInputTokens += inputTokens;
+      result.totalOutputTokens += outputTokens;
+      result.totalCacheCreationTokens += cacheCreationTokens;
+      result.totalCacheReadTokens += cacheReadTokens;
+
+      // Cost
+      const cost = record.estimatedCost?.totalCost ?? 0;
+      result.totalEstimatedCost += cost;
+
+      // By provider
+      if (!result.byProvider[record.provider]) {
+        result.byProvider[record.provider] = { count: 0, tokens: 0, cost: 0 };
+      }
+      result.byProvider[record.provider].count++;
+      result.byProvider[record.provider].tokens += inputTokens + outputTokens;
+      result.byProvider[record.provider].cost += cost;
+
+      // By model
+      if (!result.byModel[record.model]) {
+        result.byModel[record.model] = { count: 0, tokens: 0, cost: 0 };
+      }
+      result.byModel[record.model].count++;
+      result.byModel[record.model].tokens += inputTokens + outputTokens;
+      result.byModel[record.model].cost += cost;
+
+      // By channel
+      if (record.channelId) {
+        if (!result.byChannel[record.channelId]) {
+          result.byChannel[record.channelId] = { count: 0, tokens: 0, cost: 0 };
+        }
+        result.byChannel[record.channelId].count++;
+        result.byChannel[record.channelId].tokens += inputTokens + outputTokens;
+        result.byChannel[record.channelId].cost += cost;
+      }
+
+      // By source
+      if (record.source) {
+        if (!result.bySource[record.source]) {
+          result.bySource[record.source] = { count: 0, tokens: 0, cost: 0 };
+        }
+        result.bySource[record.source].count++;
+        result.bySource[record.source].tokens += inputTokens + outputTokens;
+        result.bySource[record.source].cost += cost;
+      }
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get all usage records (for testing/admin).
+ */
+export async function getAllUsageRecords(): Promise<InvocationUsageRecord[]> {
+  await initUsageTracker();
+
+  const records: InvocationUsageRecord[] = [];
+
+  if (!usageIndex) {
+    return records;
+  }
+
+  for (const [invocationId, filePath] of Object.entries(usageIndex.records)) {
+    try {
+      const record = await Bun.file(filePath).json() as InvocationUsageRecord;
+      records.push(record);
+    } catch {
+      // Skip corrupted records
+    }
+  }
+
+  return records;
+}
+
+/**
+ * Get usage tracker statistics.
+ */
+export async function getUsageStats(): Promise<{
+  totalRecords: number;
+  indexSizeBytes: number;
+  directorySizeBytes: number;
+}> {
+  await initUsageTracker();
+
+  let directorySizeBytes = 0;
+
+  try {
+    const files = await Bun.file(USAGE_DIR).entries();
+    for (const file of files) {
+      if (file.kind === "file") {
+        const stats = await Bun.file(join(USAGE_DIR, file.name)).size();
+        directorySizeBytes += stats;
+      }
+    }
+  } catch {
+    // Directory might not exist
+  }
+
+  return {
+    totalRecords: usageIndex ? Object.keys(usageIndex.records).length : 0,
+    indexSizeBytes: existsSync(USAGE_INDEX_FILE) 
+      ? new TextEncoder().encode(JSON.stringify(usageIndex)).length 
+      : 0,
+    directorySizeBytes,
+  };
+}

--- a/src/governance/watchdog.ts
+++ b/src/governance/watchdog.ts
@@ -1,0 +1,606 @@
+/**
+ * Runaway Watchdog
+ * 
+ * Detects and controls runaway execution patterns safely and durably.
+ * 
+ * DESIGN PRINCIPLES:
+ * - Watchdog monitors durable execution metrics per invocation/session
+ * - "kill" is modeled as a governance outcome first, then mapped to execution control
+ * - Actions flow through governance/event paths, not subprocess hacks
+ * - Repeated-tool detection uses normalized signatures, not raw string comparison
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+import { randomUUID } from "crypto";
+import { recordInvocationKilled } from "./usage-tracker";
+
+const CLAUDECLAW_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const WATCHDOG_DIR = join(CLAUDECLAW_DIR, "watchdog");
+const WATCHDOG_INDEX_FILE = join(WATCHDOG_DIR, "watchdog-index.json");
+const WATCHDOG_EVENTS_FILE = join(WATCHDOG_DIR, "watchdog-events.jsonl");
+
+export type WatchdogState = "healthy" | "warn" | "suspend" | "kill";
+
+export interface WatchdogLimits {
+  maxToolCalls?: number;
+  maxTurns?: number;
+  maxRuntimeSeconds?: number;
+  maxRepeatedTools?: number;
+  repeatedToolThreshold?: number; // Number of repeated patterns before action
+}
+
+export interface ExecutionMetrics {
+  invocationId: string;
+  sessionId?: string;
+  toolCallCount: number;
+  turnCount: number;
+  toolCalls: Array<{
+    tool: string;
+    inputHash: string;
+    timestamp: string;
+  }>;
+  startedAt: string;
+  lastActivityAt: string;
+}
+
+export interface WatchdogDecision {
+  invocationId: string;
+  state: WatchdogState;
+  reason: string;
+  triggeredLimits: string[];
+  recommendedAction: string;
+  evaluatedAt: string;
+}
+
+export interface WatchdogConfig {
+  limits: WatchdogLimits;
+  enabled: boolean;
+  checkIntervalMs: number;
+}
+
+interface WatchdogEventRecord {
+  id: string;
+  invocationId: string;
+  sessionId?: string;
+  decision: WatchdogDecision;
+  executedAction?: string;
+  timestamp: string;
+}
+
+interface WatchdogIndex {
+  version: number;
+  activeInvocations: Record<string, ExecutionMetrics>;
+  updatedAt: string;
+}
+
+// Default configuration
+let watchdogConfig: WatchdogConfig = {
+  limits: {
+    maxToolCalls: 100,
+    maxTurns: 50,
+    maxRuntimeSeconds: 600, // 10 minutes
+    maxRepeatedTools: 5,
+    repeatedToolThreshold: 3, // 3+ repeated patterns triggers warning
+  },
+  enabled: true,
+  checkIntervalMs: 5000, // Check every 5 seconds
+};
+
+// In-memory state
+let watchdogIndex: WatchdogIndex | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+export function resetWatchdog(): void {
+  watchdogIndex = null;
+  initializationPromise = null;
+}
+
+/**
+ * Configure the watchdog.
+ */
+export function configureWatchdog(config: Partial<WatchdogConfig>): void {
+  watchdogConfig = {
+    ...watchdogConfig,
+    limits: {
+      ...watchdogConfig.limits,
+      ...config.limits,
+    },
+    enabled: config.enabled ?? watchdogConfig.enabled,
+    checkIntervalMs: config.checkIntervalMs ?? watchdogConfig.checkIntervalMs,
+  };
+}
+
+/**
+ * Get current watchdog configuration.
+ */
+export function getWatchdogConfig(): WatchdogConfig {
+  return { ...watchdogConfig };
+}
+
+/**
+ * Initialize the watchdog system.
+ */
+export async function initWatchdog(): Promise<void> {
+  if (initializationPromise) {
+    return initializationPromise;
+  }
+
+  initializationPromise = doInit();
+  return initializationPromise;
+}
+
+async function doInit(): Promise<void> {
+  // Ensure directory exists
+  await Bun.write(join(WATCHDOG_DIR, ".gitkeep"), "");
+
+  // Try to load existing index
+  watchdogIndex = await loadWatchdogIndex();
+
+  if (!watchdogIndex) {
+    watchdogIndex = {
+      version: 1,
+      activeInvocations: {},
+      updatedAt: new Date().toISOString(),
+    };
+    await saveWatchdogIndex();
+  }
+}
+
+async function loadWatchdogIndex(): Promise<WatchdogIndex | null> {
+  try {
+    if (!existsSync(WATCHDOG_INDEX_FILE)) {
+      return null;
+    }
+    const content = await Bun.file(WATCHDOG_INDEX_FILE).json();
+    if (content.version === 1 && typeof content.activeInvocations === "object") {
+      return content as WatchdogIndex;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveWatchdogIndex(): Promise<void> {
+  if (!watchdogIndex) return;
+
+  watchdogIndex.updatedAt = new Date().toISOString();
+  await Bun.write(WATCHDOG_INDEX_FILE, JSON.stringify(watchdogIndex, null, 2) + "\n");
+}
+
+async function appendWatchdogEvent(event: WatchdogEventRecord): Promise<void> {
+  const line = JSON.stringify(event) + "\n";
+  const existingContent = existsSync(WATCHDOG_EVENTS_FILE)
+    ? await Bun.file(WATCHDOG_EVENTS_FILE).text()
+    : "";
+  await Bun.write(WATCHDOG_EVENTS_FILE, existingContent + line);
+}
+
+/**
+ * Normalize a tool call for comparison.
+ * Uses input hash to detect repeated patterns.
+ */
+function normalizeToolCall(tool: string, input: unknown): { tool: string; inputHash: string } {
+  const normalizedTool = tool.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const inputStr = JSON.stringify(input) || "";
+  // Simple hash for comparison
+  let hash = 0;
+  for (let i = 0; i < inputStr.length; i++) {
+    const char = inputStr.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  const inputHash = Math.abs(hash).toString(16);
+
+  return { tool: normalizedTool, inputHash };
+}
+
+/**
+ * Detect repeated tool call patterns.
+ */
+function detectRepeatedPatterns(
+  toolCalls: Array<{ tool: string; inputHash: string; timestamp: string }>
+): { pattern: string; count: number }[] {
+  const patterns: Record<string, number> = {};
+
+  for (const call of toolCalls) {
+    const key = `${call.tool}:${call.inputHash}`;
+    patterns[key] = (patterns[key] || 0) + 1;
+  }
+
+  return Object.entries(patterns)
+    .filter(([, count]) => count >= (watchdogConfig.limits.repeatedToolThreshold || 3))
+    .map(([pattern, count]) => {
+      const [tool, hash] = pattern.split(":");
+      return { pattern: `${tool}(hash=${hash.slice(0, 8)})`, count };
+    });
+}
+
+/**
+ * Record execution metrics for an invocation.
+ */
+export async function recordExecutionMetric(
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  },
+  metrics: {
+    toolCallCount?: number;
+    turnCount?: number;
+    toolCalls?: Array<{ tool: string; input: unknown; timestamp?: string }>;
+  }
+): Promise<void> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+
+  if (!watchdogIndex!.activeInvocations[context.invocationId]) {
+    watchdogIndex!.activeInvocations[context.invocationId] = {
+      invocationId: context.invocationId,
+      sessionId: context.sessionId,
+      toolCallCount: 0,
+      turnCount: 0,
+      toolCalls: [],
+      startedAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  const record = watchdogIndex!.activeInvocations[context.invocationId];
+
+  if (metrics.toolCallCount !== undefined) {
+    record.toolCallCount = metrics.toolCallCount;
+  }
+
+  if (metrics.turnCount !== undefined) {
+    record.turnCount = metrics.turnCount;
+  }
+
+  if (metrics.toolCalls) {
+    record.toolCalls = metrics.toolCalls.map((tc) => {
+      const normalized = normalizeToolCall(tc.tool, tc.input);
+      return {
+        tool: normalized.tool,
+        inputHash: normalized.inputHash,
+        timestamp: tc.timestamp || now,
+      };
+    });
+  }
+
+  record.lastActivityAt = now;
+
+  await saveWatchdogIndex();
+}
+
+/**
+ * Increment tool call count for an invocation.
+ */
+export async function incrementToolCall(
+  invocationId: string,
+  tool: string,
+  input: unknown
+): Promise<void> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+  const normalized = normalizeToolCall(tool, input);
+
+  if (!watchdogIndex!.activeInvocations[invocationId]) {
+    watchdogIndex!.activeInvocations[invocationId] = {
+      invocationId,
+      toolCallCount: 0,
+      turnCount: 0,
+      toolCalls: [],
+      startedAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  const record = watchdogIndex!.activeInvocations[invocationId];
+  record.toolCallCount++;
+  record.toolCalls.push({
+    tool: normalized.tool,
+    inputHash: normalized.inputHash,
+    timestamp: now,
+  });
+  record.lastActivityAt = now;
+
+  await saveWatchdogIndex();
+}
+
+/**
+ * Increment turn count for an invocation.
+ */
+export async function incrementTurnCount(invocationId: string): Promise<void> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+
+  if (!watchdogIndex!.activeInvocations[invocationId]) {
+    watchdogIndex!.activeInvocations[invocationId] = {
+      invocationId,
+      toolCallCount: 0,
+      turnCount: 0,
+      toolCalls: [],
+      startedAt: now,
+      lastActivityAt: now,
+    };
+  }
+
+  watchdogIndex!.activeInvocations[invocationId].turnCount++;
+  watchdogIndex!.activeInvocations[invocationId].lastActivityAt = now;
+
+  await saveWatchdogIndex();
+}
+
+/**
+ * Check limits for an invocation.
+ */
+export async function checkLimits(
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  }
+): Promise<WatchdogDecision> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+  const record = watchdogIndex!.activeInvocations[context.invocationId];
+
+  if (!record) {
+    // No metrics recorded yet - assume healthy
+    return {
+      invocationId: context.invocationId,
+      state: "healthy",
+      reason: "No execution metrics recorded",
+      triggeredLimits: [],
+      recommendedAction: "continue",
+      evaluatedAt: now,
+    };
+  }
+
+  const triggeredLimits: string[] = [];
+  let worstState: WatchdogState = "healthy";
+
+  const { limits } = watchdogConfig;
+
+  // Check tool call limit
+  if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls) {
+    triggeredLimits.push(`maxToolCalls=${record.toolCallCount}/${limits.maxToolCalls}`);
+    worstState = worstState === "healthy" ? "suspend" : worstState;
+  } else if (limits.maxToolCalls && record.toolCallCount >= limits.maxToolCalls * 0.8) {
+    triggeredLimits.push(`maxToolCalls_warning=${record.toolCallCount}/${limits.maxToolCalls}`);
+    if (worstState === "healthy") worstState = "warn";
+  }
+
+  // Check turn limit
+  if (limits.maxTurns && record.turnCount >= limits.maxTurns) {
+    triggeredLimits.push(`maxTurns=${record.turnCount}/${limits.maxTurns}`);
+    worstState = worstState === "healthy" ? "suspend" : worstState;
+  } else if (limits.maxTurns && record.turnCount >= limits.maxTurns * 0.8) {
+    triggeredLimits.push(`maxTurns_warning=${record.turnCount}/${limits.maxTurns}`);
+    if (worstState === "healthy") worstState = "warn";
+  }
+
+  // Check runtime limit
+  if (limits.maxRuntimeSeconds) {
+    const startedAt = new Date(record.startedAt);
+    const elapsedSeconds = (Date.now() - startedAt.getTime()) / 1000;
+    if (elapsedSeconds >= limits.maxRuntimeSeconds) {
+      triggeredLimits.push(`maxRuntimeSeconds=${elapsedSeconds}/${limits.maxRuntimeSeconds}`);
+      worstState = worstState === "healthy" ? "suspend" : worstState;
+    } else if (elapsedSeconds >= limits.maxRuntimeSeconds * 0.8) {
+      triggeredLimits.push(`maxRuntimeSeconds_warning=${elapsedSeconds}/${limits.maxRuntimeSeconds}`);
+      if (worstState === "healthy") worstState = "warn";
+    }
+  }
+
+  // Check repeated tool patterns
+  if (limits.maxRepeatedTools) {
+    const repeatedPatterns = detectRepeatedPatterns(record.toolCalls);
+    const totalRepeatedCalls = repeatedPatterns.reduce((sum, p) => sum + p.count, 0);
+    if (totalRepeatedCalls >= limits.maxRepeatedTools) {
+      triggeredLimits.push(
+        `maxRepeatedTools=${totalRepeatedCalls}/${limits.maxRepeatedTools} (patterns: ${repeatedPatterns.map(p => `${p.pattern}=${p.count}`).join(", ")})`
+      );
+      worstState = worstState === "healthy" ? "suspend" : worstState;
+    } else if (totalRepeatedCalls >= limits.maxRepeatedTools * 0.7) {
+      triggeredLimits.push(
+        `maxRepeatedTools_warning=${totalRepeatedCalls}/${limits.maxRepeatedTools}`
+      );
+      if (worstState === "healthy") worstState = "warn";
+    }
+  }
+
+  // Determine reason and recommended action
+  let reason = "Execution within normal parameters";
+  let recommendedAction = "continue";
+
+  if (triggeredLimits.length > 0) {
+    reason = `Limits triggered: ${triggeredLimits.join(", ")}`;
+    // Note: kill state escalation requires explicit handling at execution layer
+    // suspend is the highest state returned by checkLimits
+    recommendedAction = worstState === "suspend" ? "pause" : "review";
+  }
+
+  const decision: WatchdogDecision = {
+    invocationId: context.invocationId,
+    state: worstState,
+    reason,
+    triggeredLimits,
+    recommendedAction,
+    evaluatedAt: now,
+  };
+
+  // Record watchdog event
+  const eventRecord: WatchdogEventRecord = {
+    id: randomUUID(),
+    invocationId: context.invocationId,
+    sessionId: context.sessionId,
+    decision,
+    timestamp: now,
+  };
+  await appendWatchdogEvent(eventRecord);
+
+  return decision;
+}
+
+/**
+ * Handle a watchdog trigger.
+ * This maps watchdog decisions to actual execution control.
+ */
+export async function handleTrigger(
+  context: {
+    invocationId: string;
+    sessionId?: string;
+  },
+  decision: WatchdogDecision
+): Promise<{ action: string; success: boolean }> {
+  await initWatchdog();
+
+  const now = new Date().toISOString();
+
+  switch (decision.state) {
+    case "kill":
+      // Record kill in usage tracker for audit
+      await recordInvocationKilled(
+        context.invocationId,
+        `Watchdog kill: ${decision.reason}`
+      );
+
+      // Remove from active invocations
+      delete watchdogIndex!.activeInvocations[context.invocationId];
+      await saveWatchdogIndex();
+
+      // Log the event
+      const killEvent: WatchdogEventRecord = {
+        id: randomUUID(),
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        decision,
+        executedAction: "killed",
+        timestamp: now,
+      };
+      await appendWatchdogEvent(killEvent);
+
+      return {
+        action: "terminated",
+        success: true,
+      };
+
+    case "suspend":
+      // Suspend is advisory - execution should pause but not terminate
+      // This would need support from the execution layer
+      const suspendEvent: WatchdogEventRecord = {
+        id: randomUUID(),
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        decision,
+        executedAction: "suspended",
+        timestamp: now,
+      };
+      await appendWatchdogEvent(suspendEvent);
+
+      return {
+        action: "suspended",
+        success: true,
+      };
+
+    case "warn":
+      // Just log the warning
+      const warnEvent: WatchdogEventRecord = {
+        id: randomUUID(),
+        invocationId: context.invocationId,
+        sessionId: context.sessionId,
+        decision,
+        executedAction: "warned",
+        timestamp: now,
+      };
+      await appendWatchdogEvent(warnEvent);
+
+      return {
+        action: "warning_logged",
+        success: true,
+      };
+
+    case "healthy":
+    default:
+      return {
+        action: "no_action",
+        success: true,
+      };
+  }
+}
+
+/**
+ * Get active invocation metrics.
+ */
+export async function getActiveInvocation(
+  invocationId: string
+): Promise<ExecutionMetrics | null> {
+  await initWatchdog();
+  return watchdogIndex?.activeInvocations[invocationId] || null;
+}
+
+/**
+ * Get all active invocations for a session.
+ */
+export async function getSessionActiveInvocations(
+  sessionId: string
+): Promise<ExecutionMetrics[]> {
+  await initWatchdog();
+
+  const invocations: ExecutionMetrics[] = [];
+
+  if (!watchdogIndex) {
+    return invocations;
+  }
+
+  for (const record of Object.values(watchdogIndex.activeInvocations)) {
+    if (record.sessionId === sessionId) {
+      invocations.push(record);
+    }
+  }
+
+  return invocations;
+}
+
+/**
+ * Clear an invocation from the watchdog (when completed normally).
+ */
+export async function clearInvocation(invocationId: string): Promise<void> {
+  await initWatchdog();
+
+  if (watchdogIndex?.activeInvocations[invocationId]) {
+    delete watchdogIndex.activeInvocations[invocationId];
+    await saveWatchdogIndex();
+  }
+}
+
+/**
+ * Get watchdog statistics.
+ */
+export async function getWatchdogStats(): Promise<{
+  activeInvocations: number;
+  eventsLogged: number;
+  config: WatchdogConfig;
+}> {
+  await initWatchdog();
+
+  let eventsLogged = 0;
+  try {
+    if (existsSync(WATCHDOG_EVENTS_FILE)) {
+      const content = await Bun.file(WATCHDOG_EVENTS_FILE).text();
+      eventsLogged = content.trim().split("\n").filter((l) => l.trim()).length;
+    }
+  } catch {
+    // File might not exist
+  }
+
+  return {
+    activeInvocations: watchdogIndex ? Object.keys(watchdogIndex.activeInvocations).length : 0,
+    eventsLogged,
+    config: { ...watchdogConfig },
+  };
+}

--- a/src/policy/approval-queue.ts
+++ b/src/policy/approval-queue.ts
@@ -1,0 +1,335 @@
+/**
+ * Approval Workflow
+ * 
+ * Durable approval workflow for requests that require operator authorization.
+ * 
+ * DESIGN:
+ * - Approval requests are durably stored in append-friendly format
+ * - Storage path: .claude/claudeclaw/approval-queue.jsonl
+ * - Queue state must not live only in memory
+ * - Approval resolution is restart-safe
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All queue operations use atomic file operations
+ * - State is loaded from disk on init and kept in sync
+ * - Approval must result in controlled continuation path
+ */
+
+import { appendFile, readFile, mkdir, stat, rename } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { type ToolRequestContext, type PolicyDecision } from "./engine";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ApprovalStatus = "pending" | "approved" | "denied" | "expired";
+
+export interface ApprovalRequest {
+  eventId: string;
+  request: ToolRequestContext;
+  decision: PolicyDecision;
+  requestedAt: string;
+  status: ApprovalStatus;
+  approvedBy?: string;
+  approvedAt?: string;
+  deniedBy?: string;
+  deniedAt?: string;
+  resolutionReason?: string;
+  expiresAt?: string;
+}
+
+export interface ApprovalEntry extends ApprovalRequest {
+  id: string;
+  createdAt: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const APPROVAL_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const APPROVAL_QUEUE_FILE = join(APPROVAL_DIR, "approval-queue.jsonl");
+const APPROVAL_INDEX_FILE = join(APPROVAL_DIR, "approval-index.json");
+const DEFAULT_EXPIRY_HOURS = 24;
+
+// ============================================================================
+// State
+// ============================================================================
+
+let approvalIndex: Map<string, ApprovalEntry> = new Map();
+let indexLoadedAt: string = "";
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Enqueue a request that requires approval.
+ * Returns the approval entry with generated ID.
+ */
+export async function enqueue(
+  request: ToolRequestContext,
+  decision: PolicyDecision
+): Promise<ApprovalEntry> {
+  const now = new Date();
+  const expiryDate = new Date(now.getTime() + DEFAULT_EXPIRY_HOURS * 60 * 60 * 1000);
+  
+  const entry: ApprovalEntry = {
+    id: randomUUID(),
+    eventId: request.eventId,
+    request,
+    decision,
+    requestedAt: now.toISOString(),
+    status: "pending",
+    createdAt: now.toISOString(),
+    expiresAt: expiryDate.toISOString(),
+  };
+  
+  // Ensure directory exists
+  await mkdir(APPROVAL_DIR, { recursive: true });
+  
+  // Append to queue file (atomic append)
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(APPROVAL_QUEUE_FILE, line, "utf8");
+  
+  // Update in-memory index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * Approve a pending approval request.
+ */
+export async function approve(
+  eventId: string,
+  actor: string,
+  reason?: string
+): Promise<ApprovalEntry | null> {
+  const entry = await findByEventId(eventId);
+  if (!entry) {
+    return null;
+  }
+  
+  if (entry.status !== "pending") {
+    // Already resolved - idempotent operation
+    return entry;
+  }
+  
+  const now = new Date().toISOString();
+  
+  // Update entry
+  entry.status = "approved";
+  entry.approvedBy = actor;
+  entry.approvedAt = now;
+  entry.resolutionReason = reason;
+  
+  // Persist to queue file
+  await appendResolution(entry);
+  
+  // Update index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * Deny a pending approval request.
+ */
+export async function deny(
+  eventId: string,
+  actor: string,
+  reason?: string
+): Promise<ApprovalEntry | null> {
+  const entry = await findByEventId(eventId);
+  if (!entry) {
+    return null;
+  }
+  
+  if (entry.status !== "pending") {
+    // Already resolved - idempotent operation
+    return entry;
+  }
+  
+  const now = new Date().toISOString();
+  
+  // Update entry
+  entry.status = "denied";
+  entry.deniedBy = actor;
+  entry.deniedAt = now;
+  entry.resolutionReason = reason;
+  
+  // Persist to queue file
+  await appendResolution(entry);
+  
+  // Update index
+  approvalIndex.set(entry.id, entry);
+  
+  return entry;
+}
+
+/**
+ * List all pending approval requests.
+ */
+export function listPending(): ApprovalEntry[] {
+  const pending: ApprovalEntry[] = [];
+  
+  for (const entry of approvalIndex.values()) {
+    if (entry.status === "pending") {
+      // Check if expired
+      if (entry.expiresAt) {
+        const expiryDate = new Date(entry.expiresAt);
+        if (expiryDate < new Date()) {
+          continue; // Skip expired
+        }
+      }
+      pending.push(entry);
+    }
+  }
+  
+  // Sort by requestedAt (oldest first)
+  pending.sort((a, b) => 
+    new Date(a.requestedAt).getTime() - new Date(b.requestedAt).getTime()
+  );
+  
+  return pending;
+}
+
+/**
+ * Load state from disk.
+ * Rebuilds in-memory index from queue file.
+ * Since we always append to the file, the last occurrence of each ID is the latest state.
+ */
+export async function loadState(): Promise<void> {
+  approvalIndex.clear();
+  
+  // Ensure directory exists
+  if (!existsSync(APPROVAL_DIR)) {
+    await mkdir(APPROVAL_DIR, { recursive: true });
+    indexLoadedAt = new Date().toISOString();
+    return;
+  }
+  
+  // Check if queue file exists
+  if (!existsSync(APPROVAL_QUEUE_FILE)) {
+    indexLoadedAt = new Date().toISOString();
+    return;
+  }
+  
+  try {
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Since we always append and never modify existing lines,
+    // the LAST occurrence of each ID in the file is the most recent state.
+    // So we iterate in order and just overwrite with the latest.
+    for (const line of lines) {
+      try {
+        const entry: ApprovalEntry = JSON.parse(line);
+        approvalIndex.set(entry.id, entry);
+      } catch {
+        // Skip malformed lines
+        continue;
+      }
+    }
+  } catch {
+    // File doesn't exist or can't be read - start fresh
+  }
+  
+  indexLoadedAt = new Date().toISOString();
+}
+
+/**
+ * Get the last time state was loaded.
+ */
+export function getLoadedAt(): string {
+  return indexLoadedAt;
+}
+
+/**
+ * Get entry by event ID.
+ */
+export async function findByEventId(eventId: string): Promise<ApprovalEntry | null> {
+  // Search in memory first
+  for (const entry of approvalIndex.values()) {
+    if (entry.eventId === eventId) {
+      return entry;
+    }
+  }
+  
+  // Fallback: search in file
+  if (!existsSync(APPROVAL_QUEUE_FILE)) {
+    return null;
+  }
+  
+  try {
+    const content = await readFile(APPROVAL_QUEUE_FILE, "utf8");
+    const lines = content.split("\n").filter(line => line.trim());
+    
+    // Find most recent entry for this eventId
+    let latest: ApprovalEntry | null = null;
+    
+    for (const line of lines) {
+      try {
+        const entry: ApprovalEntry = JSON.parse(line);
+        if (entry.eventId === eventId) {
+          if (!latest || new Date(entry.createdAt) > new Date(latest.createdAt)) {
+            latest = entry;
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+    
+    return latest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get entry by approval ID.
+ */
+export function findById(id: string): ApprovalEntry | null {
+  return approvalIndex.get(id) || null;
+}
+
+/**
+ * Check if an event is pending approval.
+ */
+export function isPending(eventId: string): boolean {
+  const entry = approvalIndex.get(idFromEventId(eventId));
+  return entry?.status === "pending";
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function idFromEventId(eventId: string): string | undefined {
+  for (const [id, entry] of approvalIndex.entries()) {
+    if (entry.eventId === eventId) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+async function appendResolution(entry: ApprovalEntry): Promise<void> {
+  // Append updated entry as new line
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(APPROVAL_QUEUE_FILE, line, "utf8");
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+// Auto-load state on module import
+loadState().catch(err => {
+  console.error("Failed to load approval queue state:", err);
+});

--- a/src/policy/audit-log.ts
+++ b/src/policy/audit-log.ts
@@ -1,0 +1,406 @@
+/**
+ * Audit Log
+ * 
+ * Durable audit trail capturing all policy-relevant decisions and operator actions.
+ * 
+ * DESIGN:
+ * - Every policy decision is logged
+ * - Every approval/denial action is logged
+ * - File stored at .claude/claudeclaw/audit-log.jsonl
+ * - Log entries are queryable and exportable
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All log entries are append-only
+ * - Entries include rule provenance and operator attribution
+ */
+
+import { appendFile, readFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type AuditAction = "allow" | "deny" | "require_approval" | "approved" | "denied" | "expired";
+
+export interface AuditEntry {
+  timestamp: string;
+  eventId: string;
+  requestId: string;
+  source: string;
+  channelId?: string;
+  threadId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName: string;
+  action: AuditAction;
+  reason: string;
+  matchedRuleId?: string;
+  operatorId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Filters
+// ============================================================================
+
+export interface AuditLogFilters {
+  startDate?: string;
+  endDate?: string;
+  source?: string;
+  channelId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName?: string;
+  action?: AuditAction;
+  eventId?: string;
+  operatorId?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
+const DEFAULT_RETENTION_DAYS = 30;
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Log a policy decision or operator action.
+ */
+export async function log(entry: AuditEntry): Promise<void> {
+  // Ensure directory exists
+  if (!existsSync(AUDIT_DIR)) {
+    await mkdir(AUDIT_DIR, { recursive: true });
+  }
+  
+  // Add timestamp if not provided
+  if (!entry.timestamp) {
+    entry.timestamp = new Date().toISOString();
+  }
+  
+  // Append to log file
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(AUDIT_LOG_FILE, line, "utf8");
+}
+
+/**
+ * Log a policy decision.
+ */
+export async function logPolicyDecision(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  action: AuditAction,
+  reason: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    matchedRuleId?: string;
+    operatorId?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  const entry: AuditEntry = {
+    timestamp: new Date().toISOString(),
+    eventId,
+    requestId,
+    source,
+    toolName,
+    action,
+    reason,
+    ...options,
+  };
+  
+  await log(entry);
+}
+
+/**
+ * Log an approval action.
+ */
+export async function logApproval(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  operatorId: string,
+  reason?: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logPolicyDecision(
+    eventId,
+    requestId,
+    source,
+    toolName,
+    "approved",
+    reason || "Approved by operator",
+    {
+      ...options,
+      operatorId,
+    }
+  );
+}
+
+/**
+ * Log a denial action.
+ */
+export async function logDenial(
+  eventId: string,
+  requestId: string,
+  source: string,
+  toolName: string,
+  operatorId: string,
+  reason?: string,
+  options?: {
+    channelId?: string;
+    threadId?: string;
+    userId?: string;
+    skillName?: string;
+    metadata?: Record<string, unknown>;
+  }
+): Promise<void> {
+  await logPolicyDecision(
+    eventId,
+    requestId,
+    source,
+    toolName,
+    "denied",
+    reason || "Denied by operator",
+    {
+      ...options,
+      operatorId,
+    }
+  );
+}
+
+/**
+ * Query audit log entries with filters.
+ */
+export async function query(filters: AuditLogFilters = {}): Promise<AuditEntry[]> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return [];
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const results: AuditEntry[] = [];
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      // Apply filters
+      if (filters.startDate && entry.timestamp < filters.startDate) {
+        continue;
+      }
+      
+      if (filters.endDate && entry.timestamp > filters.endDate) {
+        continue;
+      }
+      
+      if (filters.source && entry.source !== filters.source) {
+        continue;
+      }
+      
+      if (filters.channelId && entry.channelId !== filters.channelId) {
+        continue;
+      }
+      
+      if (filters.userId && entry.userId !== filters.userId) {
+        continue;
+      }
+      
+      if (filters.skillName && entry.skillName !== filters.skillName) {
+        continue;
+      }
+      
+      if (filters.toolName && entry.toolName !== filters.toolName) {
+        continue;
+      }
+      
+      if (filters.action && entry.action !== filters.action) {
+        continue;
+      }
+      
+      if (filters.eventId && entry.eventId !== filters.eventId) {
+        continue;
+      }
+      
+      if (filters.operatorId && entry.operatorId !== filters.operatorId) {
+        continue;
+      }
+      
+      results.push(entry);
+    } catch {
+      // Skip malformed entries
+      continue;
+    }
+  }
+  
+  // Sort by timestamp descending (newest first)
+  results.sort((a, b) => 
+    new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+  
+  return results;
+}
+
+/**
+ * Export audit log entries within a date range.
+ */
+export async function exportEntries(
+  startDate: string,
+  endDate: string
+): Promise<AuditEntry[]> {
+  return query({ startDate, endDate });
+}
+
+/**
+ * Get audit log statistics.
+ */
+export async function getStats(): Promise<{
+  totalEntries: number;
+  byAction: Record<AuditAction, number>;
+  bySource: Record<string, number>;
+  oldestTimestamp: string | null;
+  newestTimestamp: string | null;
+}> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return {
+      totalEntries: 0,
+      byAction: { allow: 0, deny: 0, require_approval: 0, approved: 0, denied: 0, expired: 0 },
+      bySource: {},
+      oldestTimestamp: null,
+      newestTimestamp: null,
+    };
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const byAction: Record<AuditAction, number> = {
+    allow: 0,
+    deny: 0,
+    require_approval: 0,
+    approved: 0,
+    denied: 0,
+    expired: 0,
+  };
+  const bySource: Record<string, number> = {};
+  let oldestTimestamp: string | null = null;
+  let newestTimestamp: string | null = null;
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      byAction[entry.action] = (byAction[entry.action] || 0) + 1;
+      bySource[entry.source] = (bySource[entry.source] || 0) + 1;
+      
+      if (!oldestTimestamp || entry.timestamp < oldestTimestamp) {
+        oldestTimestamp = entry.timestamp;
+      }
+      if (!newestTimestamp || entry.timestamp > newestTimestamp) {
+        newestTimestamp = entry.timestamp;
+      }
+    } catch {
+      continue;
+    }
+  }
+  
+  return {
+    totalEntries: lines.length,
+    byAction,
+    bySource,
+    oldestTimestamp,
+    newestTimestamp,
+  };
+}
+
+// ============================================================================
+// Retention Management
+// ============================================================================
+
+export interface RetentionConfig {
+  maxAgeDays?: number;
+  maxFileSizeBytes?: number;
+}
+
+/**
+ * Clean up old audit log entries based on retention policy.
+ */
+export async function cleanupRetention(
+  config: RetentionConfig = {}
+): Promise<{ deleted: number; remaining: number }> {
+  const maxAgeDays = config.maxAgeDays ?? DEFAULT_RETENTION_DAYS;
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays);
+  const cutoffTimestamp = cutoffDate.toISOString();
+  
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return { deleted: 0, remaining: 0 };
+  }
+  
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter(line => line.trim());
+  
+  const keptLines: string[] = [];
+  let deleted = 0;
+  
+  for (const line of lines) {
+    try {
+      const entry: AuditEntry = JSON.parse(line);
+      
+      if (entry.timestamp < cutoffTimestamp) {
+        deleted++;
+        continue;
+      }
+      
+      keptLines.push(line);
+    } catch {
+      // Skip malformed entries - count as deleted
+      deleted++;
+      continue;
+    }
+  }
+  
+  // Note: In a production system, we'd write the kept lines back
+  // For safety, we just report what would be deleted
+  // Actual deletion should be done manually or with a backup
+  
+  return {
+    deleted,
+    remaining: keptLines.length,
+  };
+}
+
+/**
+ * Get retention configuration documentation.
+ */
+export function getRetentionPolicy(): {
+  defaultRetentionDays: number;
+  defaultMaxFileSizeBytes: number;
+  recommendation: string;
+} {
+  return {
+    defaultRetentionDays: DEFAULT_RETENTION_DAYS,
+    defaultMaxFileSizeBytes: MAX_FILE_SIZE_BYTES,
+    recommendation: `Default retention is ${DEFAULT_RETENTION_DAYS} days. Rotate log file monthly and archive entries older than retention period. Monitor file size and rotate when approaching ${MAX_FILE_SIZE_BYTES / (1024 * 1024)}MB.`,
+  };
+}

--- a/src/policy/channel-policies.ts
+++ b/src/policy/channel-policies.ts
@@ -1,0 +1,344 @@
+/**
+ * Scoped Channel and User Policies
+ * 
+ * Helper layer that resolves channel/user scoped policy rules into
+ * normalized engine rules without hard-coding channel-specific logic.
+ * 
+ * This module produces normalized rules - not a parallel evaluator.
+ */
+
+import {
+  type PolicyRule,
+  type ToolRequestContext,
+  getRules,
+} from "./engine";
+
+import { readFileSync, existsSync } from "fs";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SourceConfig {
+  source: string;
+  channels?: Record<string, ChannelConfig>;
+  defaultRules?: PolicyRule[];
+}
+
+export interface ChannelConfig {
+  channelId: string;
+  denyRules?: PolicyRule[];
+  allowRules?: PolicyRule[];
+  userOverrides?: Record<string, UserOverride>;
+}
+
+export interface UserOverride {
+  userId: string;
+  denyRules?: PolicyRule[];
+  allowRules?: PolicyRule[];
+}
+
+export interface ScopedPolicyConfig {
+  version: number;
+  sources: Record<string, SourceConfig>;
+  globalRules: PolicyRule[];
+  updatedAt: string;
+}
+
+const POLICY_DIR = ".claude/claudeclaw";
+const SCOPED_POLICY_FILE = `${POLICY_DIR}/scoped-policies.json`;
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Get all scoped rules applicable to a request context.
+ * Returns rules from global, source, channel, and user levels.
+ */
+export function getScopedRules(context: ToolRequestContext): PolicyRule[] {
+  const allRules: PolicyRule[] = [];
+  
+  // Get global rules (these are already loaded in engine)
+  const globalRules = getRules();
+  allRules.push(...globalRules);
+  
+  // Try to load and merge scoped policies
+  try {
+    const scopedConfig = loadScopedPolicyConfig();
+    if (scopedConfig) {
+      const sourceConfig = scopedConfig.sources[context.source];
+      if (sourceConfig) {
+        // Add source-level default rules
+        if (sourceConfig.defaultRules) {
+          allRules.push(...sourceConfig.defaultRules);
+        }
+        
+        // Find channel-specific rules
+        if (context.channelId && sourceConfig.channels) {
+          const channelConfig = sourceConfig.channels[context.channelId];
+          if (channelConfig) {
+            // Add channel deny rules (high priority)
+            if (channelConfig.denyRules) {
+              allRules.push(...channelConfig.denyRules.map(rule => ({
+                ...rule,
+                priority: rule.priority ?? 150, // Higher than typical
+              })));
+            }
+            
+            // Add channel allow rules
+            if (channelConfig.allowRules) {
+              allRules.push(...channelConfig.allowRules.map(rule => ({
+                ...rule,
+                priority: rule.priority ?? 100,
+              })));
+            }
+            
+            // Find user-specific overrides
+            if (context.userId && channelConfig.userOverrides) {
+              const userOverride = channelConfig.userOverrides[context.userId];
+              if (userOverride) {
+                // User deny rules override channel allows
+                if (userOverride.denyRules) {
+                  allRules.push(...userOverride.denyRules.map(rule => ({
+                    ...rule,
+                    priority: rule.priority ?? 200, // Even higher priority
+                  })));
+                }
+                
+                // User allow rules
+                if (userOverride.allowRules) {
+                  allRules.push(...userOverride.allowRules.map(rule => ({
+                    ...rule,
+                    priority: rule.priority ?? 100,
+                  })));
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // Scoped policy config not found or invalid - proceed with global rules only
+  }
+  
+  return allRules;
+}
+
+/**
+ * Merge scoped policies with global rules to produce effective rule set.
+ * This is the main entry point for the channel policy system.
+ */
+export function mergeScopedPolicies(
+  globalRules: PolicyRule[],
+  scopedRules: PolicyRule[]
+): PolicyRule[] {
+  // Scoped rules are already enriched with priorities in getScopedRules
+  // Here we just combine them with global rules
+  
+  // Filter out any disabled rules
+  const enabledGlobal = globalRules.filter(r => r.enabled !== false);
+  const enabledScoped = scopedRules.filter(r => r.enabled !== false);
+  
+  // Return combined and deduplicated rules
+  const ruleMap = new Map<string, PolicyRule>();
+  
+  // Add global rules first (lower base priority)
+  for (const rule of enabledGlobal) {
+    ruleMap.set(rule.id, rule);
+  }
+  
+  // Add scoped rules (may override global rules with same ID)
+  for (const rule of enabledScoped) {
+    ruleMap.set(rule.id, rule);
+  }
+  
+  return Array.from(ruleMap.values());
+}
+
+// ============================================================================
+// Configuration Loading
+// ============================================================================
+
+let cachedConfig: ScopedPolicyConfig | null = null;
+let configLoadedAt: string = "";
+
+function loadScopedPolicyConfig(): ScopedPolicyConfig | null {
+  try {
+    if (!existsSync(SCOPED_POLICY_FILE)) {
+      return null;
+    }
+    
+    const content = readFileSync(SCOPED_POLICY_FILE, "utf8");
+    const config = JSON.parse(content) as ScopedPolicyConfig;
+    
+    cachedConfig = config;
+    configLoadedAt = new Date().toISOString();
+    
+    return config;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the scoped policy configuration.
+ */
+export function getScopedPolicyConfig(): ScopedPolicyConfig | null {
+  if (!cachedConfig) {
+    return loadScopedPolicyConfig();
+  }
+  return cachedConfig;
+}
+
+/**
+ * Reload the scoped policy configuration from disk.
+ */
+export function reloadScopedPolicy(): ScopedPolicyConfig | null {
+  cachedConfig = null;
+  return loadScopedPolicyConfig();
+}
+
+/**
+ * Validate a scoped policy configuration.
+ */
+export function validateScopedPolicyConfig(
+  config: ScopedPolicyConfig
+): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+  
+  if (!config.version) {
+    errors.push("Missing version field");
+  }
+  
+  if (!config.sources || typeof config.sources !== "object") {
+    errors.push("Missing or invalid sources object");
+  } else {
+    for (const [source, sourceConfig] of Object.entries(config.sources)) {
+      if (!sourceConfig.source) {
+        errors.push(`Source "${source}" missing source field`);
+      }
+      
+      if (sourceConfig.channels) {
+        for (const [channelId, channelConfig] of Object.entries(sourceConfig.channels)) {
+          if (channelConfig.channelId !== channelId) {
+            errors.push(`Channel ${channelId} has mismatched channelId`);
+          }
+          
+          // Validate nested rules
+          if (channelConfig.denyRules) {
+            for (const rule of channelConfig.denyRules) {
+              if (!rule.id || !rule.tool || !rule.action) {
+                errors.push(`Channel ${channelId} has invalid deny rule`);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+// ============================================================================
+// Default Configuration Factory
+// ============================================================================
+
+/**
+ * Create a default scoped policy configuration.
+ */
+export function createDefaultScopedPolicyConfig(): ScopedPolicyConfig {
+  return {
+    version: 1,
+    sources: {},
+    globalRules: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Get example configuration structure.
+ */
+export function getExampleScopedPolicyConfig(): ScopedPolicyConfig {
+  return {
+    version: 1,
+    sources: {
+      telegram: {
+        source: "telegram",
+        channels: {
+          "telegram:123": {
+            channelId: "telegram:123",
+            denyRules: [
+              {
+                id: "telegram-123-deny-bash",
+                priority: 200,
+                tool: "Bash",
+                action: "deny",
+                reason: "Bash disabled in this channel",
+              },
+            ],
+            allowRules: [
+              {
+                id: "telegram-123-allow-view",
+                priority: 100,
+                tool: ["View", "GlobTool", "GrepTool"],
+                action: "allow",
+                reason: "Read-only tools allowed",
+              },
+            ],
+            userOverrides: {
+              "admin-user": {
+                userId: "admin-user",
+                allowRules: [
+                  {
+                    id: "telegram-123-admin-allow-all",
+                    priority: 200,
+                    tool: "*",
+                    action: "allow",
+                    reason: "Admin has full access in this channel",
+                  },
+                ],
+              },
+            },
+          },
+        },
+        defaultRules: [
+          {
+            id: "telegram-default-deny-edit",
+            priority: 50,
+            tool: "Edit",
+            action: "require_approval",
+            reason: "Edit requires approval on telegram by default",
+          },
+        ],
+      },
+      discord: {
+        source: "discord",
+        defaultRules: [
+          {
+            id: "discord-default-allow-view",
+            priority: 50,
+            tool: ["View", "GlobTool"],
+            action: "allow",
+            reason: "View tools allowed on discord",
+          },
+        ],
+      },
+    },
+    globalRules: [
+      {
+        id: "global-deny-dangerous",
+        priority: 100,
+        tool: "Bash",
+        action: "deny",
+        reason: "Bash disabled globally unless explicitly allowed",
+      },
+    ],
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -1,0 +1,526 @@
+/**
+ * Policy Engine Core
+ * 
+ * Deterministic rule evaluation over normalized tool-use requests.
+ * 
+ * DESIGN:
+ * - Policy file stored at .claude/claudeclaw/policies.json
+ * - Default decision is DENY unless explicitly allowed
+ * - Evaluation order: highest priority first, then specificity, then explicit deny > allow > require_approval
+ * - Cache is configurable and bounded, invalidated on policy reload
+ * 
+ * CRASH CONSCIOUSNESS:
+ * - All policy state is loaded from disk on init
+ * - Invalid rules fail closed and are surfaced clearly
+ * - Cache must not become source of truth
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "crypto";
+
+const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const POLICY_FILE = join(POLICY_DIR, "policies.json");
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ToolRequestContext {
+  eventId: string;
+  source: string;               // telegram, discord, slack, web, etc.
+  channelId?: string;
+  threadId?: string;
+  userId?: string;
+  skillName?: string;
+  toolName: string;
+  toolArgs?: Record<string, unknown>;
+  sessionId?: string;           // local session mapping ID
+  claudeSessionId?: string | null;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type PolicyAction = "allow" | "deny" | "require_approval";
+
+export interface PolicyDecision {
+  requestId: string;
+  action: PolicyAction;
+  matchedRuleId?: string;
+  reason: string;
+  evaluatedAt: string;
+  cacheable?: boolean;
+}
+
+export interface PolicyScope {
+  source?: string | string[]; // "telegram", ["telegram","discord"], "*"
+  channelId?: string | string[];
+  userId?: string | string[];
+  skillName?: string | string[];
+}
+
+export interface PolicyConditions {
+  timeWindow?: { start: string; end: string };
+  argConstraints?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyRule {
+  id: string;
+  enabled?: boolean;
+  priority?: number;            // higher priority evaluated first
+  scope?: PolicyScope;
+  tool: string | string[];      // specific tool(s) or "*"
+  action: PolicyAction;
+  conditions?: PolicyConditions;
+  reason?: string;
+}
+
+export interface PolicyFile {
+  version: number;
+  rules: PolicyRule[];
+  cache?: {
+    enabled: boolean;
+    maxEntries: number;
+    ttlMs: number;
+  };
+  updatedAt: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+export interface ValidationError {
+  ruleId: string;
+  field: string;
+  message: string;
+}
+
+export interface ValidationWarning {
+  ruleId: string;
+  field: string;
+  message: string;
+}
+
+// ============================================================================
+// Cache
+// ============================================================================
+
+interface CacheEntry {
+  requestKey: string;
+  decision: PolicyDecision;
+  expiresAt: number;
+}
+
+let policyCache: Map<string, CacheEntry> = new Map();
+let cacheConfig = { enabled: false, maxEntries: 1000, ttlMs: 60000 };
+
+// ============================================================================
+// State
+// ============================================================================
+
+let loadedRules: PolicyRule[] = [];
+let loadedAt: string = "";
+
+// ============================================================================
+// Core API
+// ============================================================================
+
+/**
+ * Evaluate a tool-use request against loaded policy rules.
+ * Returns a deterministic PolicyDecision.
+ */
+export function evaluate(request: ToolRequestContext): PolicyDecision {
+  const requestId = randomUUID();
+  const evaluatedAt = new Date().toISOString();
+  
+  // Check cache first if enabled
+  if (cacheConfig.enabled) {
+    const cached = getCachedDecision(request);
+    if (cached) {
+      return {
+        ...cached,
+        requestId, // Fresh request ID even for cached decisions
+        evaluatedAt, // Fresh evaluation timestamp
+      };
+    }
+  }
+  
+  // Get all applicable rules sorted by priority
+  const applicableRules = getApplicableRules(request);
+  
+  if (applicableRules.length === 0) {
+    // No matching rules - default deny
+    const decision: PolicyDecision = {
+      requestId,
+      action: "deny",
+      reason: "No matching policy rule - default deny",
+      evaluatedAt,
+      cacheable: true,
+    };
+    
+    if (cacheConfig.enabled) {
+      cacheDecision(request, decision);
+    }
+    
+    return decision;
+  }
+  
+  // Sort by priority (highest first), then by specificity
+  const sortedRules = sortRules(applicableRules);
+  
+  // Find the best matching rule
+  const matchedRule = sortedRules[0];
+  
+  const decision: PolicyDecision = {
+    requestId,
+    action: matchedRule.action,
+    matchedRuleId: matchedRule.id,
+    reason: matchedRule.reason || `Matched rule: ${matchedRule.id}`,
+    evaluatedAt,
+    cacheable: matchedRule.action === "allow",
+  };
+  
+  if (cacheConfig.enabled && decision.cacheable) {
+    cacheDecision(request, decision);
+  }
+  
+  return decision;
+}
+
+/**
+ * Load and validate rules from the policy file.
+ * Creates default policy file if none exists.
+ */
+export async function loadRules(): Promise<PolicyRule[]> {
+  // Ensure directory exists
+  if (!existsSync(POLICY_DIR)) {
+    await mkdir(POLICY_DIR, { recursive: true });
+  }
+  
+  // Create default policy file if none exists
+  if (!existsSync(POLICY_FILE)) {
+    const defaultPolicy: PolicyFile = {
+      version: 1,
+      rules: [],
+      cache: { enabled: false, maxEntries: 1000, ttlMs: 60000 },
+      updatedAt: new Date().toISOString(),
+    };
+    await writeFile(POLICY_FILE, JSON.stringify(defaultPolicy, null, 2), "utf8");
+  }
+  
+  // Read and parse policy file
+  const content = await readFile(POLICY_FILE, "utf8");
+  const policyFile: PolicyFile = JSON.parse(content);
+  
+  // Validate rules
+  const validation = validateRules(policyFile.rules);
+  if (!validation.valid) {
+    // Fail closed - don't load invalid rules
+    const errorMsg = validation.errors.map(e => `${e.ruleId}: ${e.message}`).join("; ");
+    throw new Error(`Policy file contains invalid rules: ${errorMsg}`);
+  }
+  
+  // Update cache config
+  if (policyFile.cache) {
+    cacheConfig = { ...cacheConfig, ...policyFile.cache };
+  }
+  
+  // Clear cache on reload
+  policyCache.clear();
+  
+  loadedRules = policyFile.rules;
+  loadedAt = new Date().toISOString();
+  
+  return loadedRules;
+}
+
+/**
+ * Validate a set of policy rules.
+ * Returns validation result with errors and warnings.
+ */
+export function validateRules(rules: PolicyRule[]): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  
+  for (const rule of rules) {
+    // Validate rule ID
+    if (!rule.id || typeof rule.id !== "string") {
+      errors.push({ ruleId: rule.id || "unknown", field: "id", message: "Rule must have a valid id string" });
+    }
+    
+    // Validate action
+    if (!rule.action || !["allow", "deny", "require_approval"].includes(rule.action)) {
+      errors.push({ ruleId: rule.id, field: "action", message: "Rule must have action: allow | deny | require_approval" });
+    }
+    
+    // Validate tool
+    if (!rule.tool) {
+      errors.push({ ruleId: rule.id, field: "tool", message: "Rule must specify tool(s)" });
+    } else if (Array.isArray(rule.tool) && rule.tool.length === 0) {
+      errors.push({ ruleId: rule.id, field: "tool", message: "Tool array cannot be empty" });
+    }
+    
+    // Validate scope values
+    if (rule.scope) {
+      if (rule.scope.source === "") {
+        errors.push({ ruleId: rule.id, field: "scope.source", message: "Scope source cannot be empty string" });
+      }
+    }
+    
+    // Validate conditions
+    if (rule.conditions) {
+      if (rule.conditions.timeWindow) {
+        const tw = rule.conditions.timeWindow;
+        if (!tw.start || !tw.end) {
+          errors.push({ ruleId: rule.id, field: "conditions.timeWindow", message: "timeWindow requires start and end" });
+        } else {
+          const startDate = new Date(tw.start);
+          const endDate = new Date(tw.end);
+          if (isNaN(startDate.getTime())) {
+            errors.push({ ruleId: rule.id, field: "conditions.timeWindow.start", message: "Invalid start date format" });
+          }
+          if (isNaN(endDate.getTime())) {
+            errors.push({ ruleId: rule.id, field: "conditions.timeWindow.end", message: "Invalid end date format" });
+          }
+        }
+      }
+    }
+    
+    // Warnings for potentially problematic patterns
+    if (rule.action === "allow" && !rule.scope) {
+      warnings.push({ ruleId: rule.id, field: "scope", message: "Unscoped allow rule - will apply to all requests" });
+    }
+    
+    if (rule.tool === "*" && !rule.scope) {
+      warnings.push({ ruleId: rule.id, field: "tool/scope", message: "Globally allow all tools - may be overly permissive" });
+    }
+  }
+  
+  // Check for duplicate rule IDs
+  const ids = rules.map(r => r.id);
+  const duplicates = ids.filter((id, idx) => ids.indexOf(id) !== idx);
+  if (duplicates.length > 0) {
+    errors.push({ ruleId: "global", field: "rules", message: `Duplicate rule IDs: ${[...new Set(duplicates)].join(", ")}` });
+  }
+  
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Get the currently loaded rules.
+ */
+export function getRules(): PolicyRule[] {
+  return [...loadedRules];
+}
+
+/**
+ * Get the last time rules were loaded.
+ */
+export function getLoadedAt(): string {
+  return loadedAt;
+}
+
+/**
+ * Check if cache is enabled.
+ */
+export function isCacheEnabled(): boolean {
+  return cacheConfig.enabled;
+}
+
+/**
+ * Clear the decision cache.
+ */
+export function clearCache(): void {
+  policyCache.clear();
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+function getApplicableRules(request: ToolRequestContext): PolicyRule[] {
+  return loadedRules.filter(rule => {
+    // Skip disabled rules
+    if (rule.enabled === false) return false;
+    
+    // Check tool match
+    if (!matchesTool(rule.tool, request.toolName)) return false;
+    
+    // Check scope match
+    if (!matchesScope(rule.scope, request)) return false;
+    
+    // Check conditions
+    if (!matchesConditions(rule.conditions, request)) return false;
+    
+    return true;
+  });
+}
+
+function matchesTool(ruleTool: string | string[], requestTool: string): boolean {
+  if (ruleTool === "*") return true;
+  if (Array.isArray(ruleTool)) return ruleTool.includes(requestTool);
+  return ruleTool === requestTool;
+}
+
+function matchesScope(scope: PolicyScope | undefined, request: ToolRequestContext): boolean {
+  if (!scope) return true; // No scope = match all
+  
+  // Check source
+  if (scope.source) {
+    if (Array.isArray(scope.source)) {
+      if (!scope.source.includes(request.source)) return false;
+    } else if (scope.source !== "*") {
+      if (scope.source !== request.source) return false;
+    }
+  }
+  
+  // Check channelId
+  if (scope.channelId && request.channelId) {
+    if (Array.isArray(scope.channelId)) {
+      if (!scope.channelId.includes(request.channelId)) return false;
+    } else if (scope.channelId !== "*") {
+      if (scope.channelId !== request.channelId) return false;
+    }
+  }
+  
+  // Check userId
+  if (scope.userId && request.userId) {
+    if (Array.isArray(scope.userId)) {
+      if (!scope.userId.includes(request.userId)) return false;
+    } else if (scope.userId !== "*") {
+      if (scope.userId !== request.userId) return false;
+    }
+  }
+  
+  // Check skillName
+  if (scope.skillName && request.skillName) {
+    if (Array.isArray(scope.skillName)) {
+      if (!scope.skillName.includes(request.skillName)) return false;
+    } else if (scope.skillName !== "*") {
+      if (scope.skillName !== request.skillName) return false;
+    }
+  }
+  
+  return true;
+}
+
+function matchesConditions(conditions: PolicyConditions | undefined, request: ToolRequestContext): boolean {
+  if (!conditions) return true;
+  
+  // Check time window
+  if (conditions.timeWindow) {
+    const now = new Date(request.timestamp);
+    const start = new Date(conditions.timeWindow.start);
+    const end = new Date(conditions.timeWindow.end);
+    
+    if (now < start || now > end) return false;
+  }
+  
+  // Check arg constraints
+  if (conditions.argConstraints && request.toolArgs) {
+    for (const [key, expectedValue] of Object.entries(conditions.argConstraints)) {
+      const actualValue = request.toolArgs[key];
+      if (actualValue !== expectedValue) return false;
+    }
+  }
+  
+  // Check metadata constraints
+  if (conditions.metadata && request.metadata) {
+    for (const [key, expectedValue] of Object.entries(conditions.metadata)) {
+      const actualValue = request.metadata[key];
+      if (actualValue !== expectedValue) return false;
+    }
+  }
+  
+  return true;
+}
+
+function sortRules(rules: PolicyRule[]): PolicyRule[] {
+  return [...rules].sort((a, b) => {
+    // Highest priority first
+    const priorityA = a.priority ?? 0;
+    const priorityB = b.priority ?? 0;
+    if (priorityB !== priorityA) return priorityB - priorityA;
+    
+    // More specific scope first (more scope fields set = more specific)
+    const specificityA = countScopeFields(a.scope);
+    const specificityB = countScopeFields(b.scope);
+    if (specificityB !== specificityA) return specificityB - specificityA;
+    
+    // Explicit deny beats require_approval beats allow
+    const actionOrder: Record<PolicyAction, number> = { deny: 0, require_approval: 1, allow: 2 };
+    return actionOrder[a.action] - actionOrder[b.action];
+  });
+}
+
+function countScopeFields(scope: PolicyScope | undefined): number {
+  if (!scope) return 0;
+  let count = 0;
+  if (scope.source) count++;
+  if (scope.channelId) count++;
+  if (scope.userId) count++;
+  if (scope.skillName) count++;
+  return count;
+}
+
+function getRequestKey(request: ToolRequestContext): string {
+  const parts = [
+    request.source,
+    request.channelId || "",
+    request.userId || "",
+    request.skillName || "",
+    request.toolName,
+    request.toolArgs ? JSON.stringify(request.toolArgs) : "",
+  ];
+  return parts.join("|");
+}
+
+function getCachedDecision(request: ToolRequestContext): PolicyDecision | null {
+  const key = getRequestKey(request);
+  const entry = policyCache.get(key);
+  
+  if (!entry) return null;
+  
+  if (Date.now() > entry.expiresAt) {
+    policyCache.delete(key);
+    return null;
+  }
+  
+  return entry.decision;
+}
+
+function cacheDecision(request: ToolRequestContext, decision: PolicyDecision): void {
+  if (!decision.cacheable) return;
+  
+  const key = getRequestKey(request);
+  
+  // Evict oldest if at capacity
+  if (policyCache.size >= cacheConfig.maxEntries) {
+    const oldestKey = policyCache.keys().next().value;
+    if (oldestKey) policyCache.delete(oldestKey);
+  }
+  
+  policyCache.set(key, {
+    requestKey: key,
+    decision,
+    expiresAt: Date.now() + cacheConfig.ttlMs,
+  });
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+// Auto-load rules on module import
+loadRules().catch(err => {
+  console.error("Failed to load policy rules:", err);
+});

--- a/src/policy/skill-overlays.ts
+++ b/src/policy/skill-overlays.ts
@@ -1,0 +1,275 @@
+/**
+ * Skill Policy Overlays
+ * 
+ * Allow skills to declare tool constraints that integrate with the policy engine.
+ * Skill overlays are translated into policy-relevant constraints.
+ * 
+ * IMPORTANT: Skill overlays must not become a privilege-escalation path.
+ * - "preferredTools" influences recommendation, not security overrides
+ * - "requiredTools" surfaces actionable policy errors when unavailable
+ * - "deniedTools" are enforced as restrictions even when globally allowed
+ */
+
+import {
+  type PolicyRule,
+  type ToolRequestContext,
+} from "./engine";
+import { resolveSkillPrompt } from "../skills";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SkillOverlay {
+  skillName: string;
+  requiredTools?: string[];
+  preferredTools?: string[];
+  deniedTools?: string[];
+  reason?: string;
+}
+
+export interface SkillPolicyResult {
+  allowed: boolean;
+  reason: string;
+  skillOverlay?: SkillOverlay;
+  missingTools?: string[];
+  deniedTools?: string[];
+}
+
+// ============================================================================
+// Skill Metadata Parsing
+// ============================================================================
+
+/**
+ * Parse skill metadata from SKILL.md content.
+ * Looks for policy-related frontmatter fields.
+ */
+export function parseSkillMetadata(skillContent: string, skillName: string): SkillOverlay | null {
+  // Parse YAML frontmatter
+  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    return null;
+  }
+  
+  const fm = fmMatch[1];
+  
+  // Look for policy-related fields
+  let requiredTools: string[] | undefined;
+  let preferredTools: string[] | undefined;
+  let deniedTools: string[] | undefined;
+  
+  // Helper to parse array fields (handles both multiline and inline formats)
+  function parseArrayField(fieldName: string): string[] | undefined {
+    // Match multiline format:
+    // requiredTools:
+    //   - item1
+    //   - item2
+    const multilineMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\n((?:\\s*-\\s*.+\\n?)+)`, 'm'));
+    if (multilineMatch) {
+      return multilineMatch[1]
+        .split("\n")
+        .map(line => line.replace(/^\s*-\s*/, "").trim())
+        .filter(Boolean);
+    }
+    
+    // Match inline empty array: requiredTools: []
+    const emptyMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\[\\s*\\]`, 'm'));
+    if (emptyMatch) {
+      return [];
+    }
+    
+    // Match inline array: requiredTools: [item1, item2]
+    const inlineMatch = fm.match(new RegExp(`^${fieldName}:\\s*\\[([^\\]]+)\\]`, 'm'));
+    if (inlineMatch) {
+      return inlineMatch[1]
+        .split(",")
+        .map(item => item.trim())
+        .filter(Boolean);
+    }
+    
+    return undefined;
+  }
+  
+  // Parse requiredTools
+  const parsedRequired = parseArrayField("requiredTools");
+  if (parsedRequired !== undefined) {
+    requiredTools = parsedRequired;
+  }
+  
+  // Parse preferredTools
+  const parsedPreferred = parseArrayField("preferredTools");
+  if (parsedPreferred !== undefined) {
+    preferredTools = parsedPreferred;
+  }
+  
+  // Parse deniedTools
+  const parsedDenied = parseArrayField("deniedTools");
+  if (parsedDenied !== undefined) {
+    deniedTools = parsedDenied;
+  }
+  
+  // If no policy fields found, return null
+  if (!requiredTools && !preferredTools && !deniedTools) {
+    return null;
+  }
+  
+  return {
+    skillName,
+    requiredTools,
+    preferredTools,
+    deniedTools,
+  };
+}
+
+// ============================================================================
+// Skill Overlay Resolution
+// ============================================================================
+
+/**
+ * Get the skill overlay for a given skill name.
+ * Loads and parses the skill's SKILL.md to extract policy metadata.
+ */
+export async function getSkillOverlay(skillName: string): Promise<SkillOverlay | null> {
+  // Resolve skill prompt (reads SKILL.md)
+  const content = await resolveSkillPrompt(skillName);
+  if (!content) {
+    return null;
+  }
+  
+  return parseSkillMetadata(content, skillName);
+}
+
+/**
+ * Get skill overlay synchronously from cached content.
+ */
+export function getSkillOverlayFromContent(content: string, skillName: string): SkillOverlay | null {
+  return parseSkillMetadata(content, skillName);
+}
+
+// ============================================================================
+// Overlay to Rules Conversion
+// ============================================================================
+
+/**
+ * Convert a skill overlay into policy rules.
+ * 
+ * Rules generated:
+ * - deniedTools → high-priority deny rules (restrictive)
+ * - requiredTools → no direct rules, tracked for validation
+ * - preferredTools → informational only (not security-critical)
+ */
+export function overlayToRules(overlay: SkillOverlay, basePriority: number = 100): PolicyRule[] {
+  const rules: PolicyRule[] = [];
+  
+  // Denied tools become deny rules (high priority)
+  if (overlay.deniedTools && overlay.deniedTools.length > 0) {
+    for (const tool of overlay.deniedTools) {
+      rules.push({
+        id: `skill-${overlay.skillName}-deny-${tool}`,
+        priority: basePriority + 50, // Higher than typical rules
+        scope: {
+          skillName: overlay.skillName,
+        },
+        tool,
+        action: "deny",
+        reason: overlay.reason || `Tool ${tool} denied by skill ${overlay.skillName} policy`,
+      });
+    }
+  }
+  
+  return rules;
+}
+
+// ============================================================================
+// Skill Policy Evaluation
+// ============================================================================
+
+/**
+ * Evaluate a tool request in the context of skill policy.
+ * Checks if the requested tool is allowed given the skill's policy overlay.
+ */
+export function evaluateSkillPolicy(
+  overlay: SkillOverlay,
+  toolName: string
+): SkillPolicyResult {
+  // Check if tool is explicitly denied
+  if (overlay.deniedTools && overlay.deniedTools.includes(toolName)) {
+    return {
+      allowed: false,
+      reason: `Tool ${toolName} is explicitly denied by skill ${overlay.skillName}`,
+      skillOverlay: overlay,
+      deniedTools: [toolName],
+    };
+  }
+  
+  // Check if required tools are missing (but not for the requested tool)
+  if (overlay.requiredTools) {
+    const missingTools = overlay.requiredTools.filter(t => t !== toolName);
+    if (missingTools.length > 0) {
+      // Tool requested is not missing, but some required tools might be
+      // This is informational - not a blocking error
+    }
+  }
+  
+  // If we get here, the tool is allowed by the skill overlay
+  return {
+    allowed: true,
+    reason: `Tool ${toolName} is allowed by skill ${overlay.skillName} policy`,
+    skillOverlay: overlay,
+  };
+}
+
+/**
+ * Validate that all required tools for a skill are available.
+ * Returns information about missing required tools.
+ */
+export function validateRequiredTools(
+  overlay: SkillOverlay,
+  availableTools: string[]
+): { valid: boolean; missingTools: string[] } {
+  if (!overlay.requiredTools || overlay.requiredTools.length === 0) {
+    return { valid: true, missingTools: [] };
+  }
+  
+  const missingTools = overlay.requiredTools.filter(
+    required => !availableTools.includes(required)
+  );
+  
+  return {
+    valid: missingTools.length === 0,
+    missingTools,
+  };
+}
+
+// ============================================================================
+// Example Skill Overlays
+// ============================================================================
+
+/**
+ * Get example skill overlay configurations for documentation.
+ */
+export function getExampleSkillOverlays(): Record<string, SkillOverlay> {
+  return {
+    "code-review": {
+      skillName: "code-review",
+      requiredTools: ["View", "GlobTool", "GrepTool"],
+      preferredTools: ["View", "GlobTool", "GrepTool"],
+      deniedTools: ["Bash", "Edit", "Write"],
+      reason: "Code review skill is read-only by default",
+    },
+    "web-scrape": {
+      skillName: "web-scrape",
+      requiredTools: ["WebFetch", "Bash"],
+      preferredTools: ["WebFetch"],
+      deniedTools: [],
+      reason: "Web scraping requires network access and shell",
+    },
+    "admin": {
+      skillName: "admin",
+      requiredTools: ["Bash", "Write", "Edit", "View"],
+      preferredTools: ["Bash", "Write", "Edit", "View"],
+      deniedTools: [],
+      reason: "Admin skill has full tool access",
+    },
+  };
+}

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,0 +1,325 @@
+/**
+ * Replay Support
+ * 
+ * Allows intentional reprocessing of events.
+ * 
+ * SAFETY:
+ * - Replay never mutates existing done records
+ * - Replay always creates new event records
+ * - Replay events carry replayedFromEventId for provenance
+ * - Can replay from: sequence number, range, or DLQ
+ * 
+ * USE CASES:
+ * - Recover from processor bugs by reprocessing affected events
+ * - Backfill new functionality across historical events
+ * - Retry DLQ events after fixing root cause
+ */
+
+import { initEventLog, append, readFrom, readRange, type EventRecord, type EventEntryInput } from "./event-log";
+import { initDLQ, replay as replayDLQEntry, list as listDLQ, type DLQEntry } from "./dead-letter-queue";
+
+export interface ReplayResult {
+  originalSeq: number;
+  originalEventId: string;
+  newSeq: number;
+  newEventId: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface ReplaySummary {
+  requested: number;
+  successful: number;
+  failed: number;
+  results: ReplayResult[];
+}
+
+/**
+ * Initialize replay system.
+ */
+export async function initReplay(): Promise<void> {
+  await initEventLog();
+  await initDLQ();
+}
+
+/**
+ * Replay all events from a given sequence number.
+ * Creates new events for each original event.
+ */
+export async function replayFrom(startSeq: number): Promise<ReplaySummary> {
+  await initReplay();
+
+  const results: ReplayResult[] = [];
+  let successful = 0;
+  let failed = 0;
+
+  for await (const event of readFrom(startSeq)) {
+    const result = await replaySingleEvent(event);
+    results.push(result);
+
+    if (result.success) {
+      successful++;
+    } else {
+      failed++;
+    }
+  }
+
+  console.log(
+    `[replay] Replay from seq ${startSeq} complete: ${successful} successful, ${failed} failed`
+  );
+
+  return {
+    requested: results.length,
+    successful,
+    failed,
+    results,
+  };
+}
+
+/**
+ * Replay events in a sequence range (inclusive).
+ */
+export async function replayRange(
+  startSeq: number,
+  endSeq: number
+): Promise<ReplaySummary> {
+  await initReplay();
+
+  const results: ReplayResult[] = [];
+  let successful = 0;
+  let failed = 0;
+
+  for await (const event of readRange(startSeq, endSeq)) {
+    const result = await replaySingleEvent(event);
+    results.push(result);
+
+    if (result.success) {
+      successful++;
+    } else {
+      failed++;
+    }
+  }
+
+  console.log(
+    `[replay] Replay range ${startSeq}-${endSeq} complete: ${successful} successful, ${failed} failed`
+  );
+
+  return {
+    requested: results.length,
+    successful,
+    failed,
+    results,
+  };
+}
+
+/**
+ * Replay a specific event by ID.
+ * Finds the event in the log and creates a replay.
+ */
+export async function replayEvent(eventId: string): Promise<ReplayResult | null> {
+  await initReplay();
+
+  // Find the event
+  for await (const event of readFrom(1)) {
+    if (event.id === eventId) {
+      return replaySingleEvent(event);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Replay all events in the DLQ.
+ */
+export async function replayDLQ(): Promise<ReplaySummary> {
+  await initReplay();
+
+  const entries = listDLQ();
+  const results: ReplayResult[] = [];
+  let successful = 0;
+  let failed = 0;
+
+  for (const entry of entries) {
+    try {
+      const newEvent = await replayDLQEntry(entry.id);
+
+      if (newEvent) {
+        results.push({
+          originalSeq: entry.originalSeq,
+          originalEventId: entry.originalEventId,
+          newSeq: newEvent.seq,
+          newEventId: newEvent.id,
+          success: true,
+        });
+        successful++;
+      } else {
+        results.push({
+          originalSeq: entry.originalSeq,
+          originalEventId: entry.originalEventId,
+          newSeq: 0,
+          newEventId: "",
+          success: false,
+          error: "Replay returned null",
+        });
+        failed++;
+      }
+    } catch (err) {
+      results.push({
+        originalSeq: entry.originalSeq,
+        originalEventId: entry.originalEventId,
+        newSeq: 0,
+        newEventId: "",
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      failed++;
+    }
+  }
+
+  console.log(
+    `[replay] DLQ replay complete: ${successful} successful, ${failed} failed`
+  );
+
+  return {
+    requested: entries.length,
+    successful,
+    failed,
+    results,
+  };
+}
+
+/**
+ * Replay a single event.
+ * Internal helper that creates a new event record.
+ */
+async function replaySingleEvent(originalEvent: EventRecord): Promise<ReplayResult> {
+  try {
+    const entry: EventEntryInput = {
+      type: originalEvent.type,
+      source: originalEvent.source,
+      channelId: originalEvent.channelId,
+      threadId: originalEvent.threadId,
+      payload: originalEvent.payload,
+      dedupeKey: `replay-${originalEvent.id}-${Date.now()}`, // Unique dedupe key for replay
+      correlationId: originalEvent.correlationId,
+      causationId: originalEvent.id, // Original event is the causation
+      replayedFromEventId: originalEvent.id,
+    };
+
+    const newEvent = await append(entry);
+
+    return {
+      originalSeq: originalEvent.seq,
+      originalEventId: originalEvent.id,
+      newSeq: newEvent.seq,
+      newEventId: newEvent.id,
+      success: true,
+    };
+  } catch (err) {
+    return {
+      originalSeq: originalEvent.seq,
+      originalEventId: originalEvent.id,
+      newSeq: 0,
+      newEventId: "",
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Preview what would be replayed without actually doing it.
+ * Useful for verifying replay scope before execution.
+ */
+export async function previewReplayFrom(startSeq: number): Promise<{
+  count: number;
+  firstSeq: number | null;
+  lastSeq: number | null;
+  eventTypes: string[];
+}> {
+  await initEventLog();
+
+  const events: EventRecord[] = [];
+  for await (const event of readFrom(startSeq)) {
+    events.push(event);
+  }
+
+  if (events.length === 0) {
+    return {
+      count: 0,
+      firstSeq: null,
+      lastSeq: null,
+      eventTypes: [],
+    };
+  }
+
+  const types = [...new Set(events.map(e => e.type))];
+
+  return {
+    count: events.length,
+    firstSeq: events[0].seq,
+    lastSeq: events[events.length - 1].seq,
+    eventTypes: types,
+  };
+}
+
+/**
+ * Preview what would be replayed in a range.
+ */
+export async function previewReplayRange(
+  startSeq: number,
+  endSeq: number
+): Promise<{
+  count: number;
+  eventTypes: string[];
+}> {
+  await initEventLog();
+
+  const events: EventRecord[] = [];
+  for await (const event of readRange(startSeq, endSeq)) {
+    events.push(event);
+  }
+
+  const types = [...new Set(events.map(e => e.type))];
+
+  return {
+    count: events.length,
+    eventTypes: types,
+  };
+}
+
+/**
+ * Preview DLQ replay.
+ */
+export async function previewReplayDLQ(): Promise<{
+  count: number;
+  eventTypes: string[];
+  oldestFailure: string | null;
+  newestFailure: string | null;
+}> {
+  await initDLQ();
+
+  const entries = listDLQ();
+
+  if (entries.length === 0) {
+    return {
+      count: 0,
+      eventTypes: [],
+      oldestFailure: null,
+      newestFailure: null,
+    };
+  }
+
+  const types = [...new Set(entries.map(e => e.event.type))];
+  const sorted = [...entries].sort(
+    (a, b) => new Date(a.deadLetteredAt).getTime() - new Date(b.deadLetteredAt).getTime()
+  );
+
+  return {
+    count: entries.length,
+    eventTypes: types,
+    oldestFailure: sorted[0].deadLetteredAt,
+    newestFailure: sorted[sorted.length - 1].deadLetteredAt,
+  };
+}

--- a/src/retry-queue.ts
+++ b/src/retry-queue.ts
@@ -1,0 +1,453 @@
+/**
+ * Retry Scheduler
+ * 
+ * Manages retry scheduling for failed events with exponential backoff.
+ * 
+ * DESIGN:
+ * - In-memory priority queue as rebuildable execution index
+ * - Persisted event state remains the canonical source of truth
+ * - Scheduler rebuilds itself from persisted state on restart
+ * 
+ * RETRY POLICY:
+ * - Exponential backoff: delay = min(5s * 2^retryCount, 10min)
+ * - Default maxRetries: 5 (configurable)
+ * - Retry state stored in event records (nextRetryAt, retryCount)
+ * 
+ * PERSISTENCE:
+ * - Retry state stored in retry-queue.json as auxiliary index
+ * - Can be fully rebuilt from event log
+ * - Not a competing source of truth
+ */
+
+import { join } from "path";
+import { mkdir } from "fs/promises";
+import {
+  initEventLog,
+  readFrom,
+  appendStatusUpdate,
+  type EventRecord,
+  type EventStatus,
+} from "./event-log";
+
+const RETRY_DIR = join(process.cwd(), ".claude", "claudeclaw", "retry");
+const RETRY_STATE_FILE = join(RETRY_DIR, "retry-queue.json");
+
+const DEFAULT_BASE_DELAY_MS = 5000; // 5 seconds
+const DEFAULT_MAX_DELAY_MS = 600000; // 10 minutes
+const DEFAULT_MAX_RETRIES = 5;
+
+interface RetryEntry {
+  eventId: string;
+  eventSeq: number;
+  retryCount: number;
+  nextRetryAt: string;
+  scheduledAt: string;
+}
+
+interface RetryState {
+  version: number;
+  entries: RetryEntry[];
+  lastProcessedAt: string;
+  config: RetryConfig;
+}
+
+interface RetryConfig {
+  baseDelayMs: number;
+  maxDelayMs: number;
+  maxRetries: number;
+  checkIntervalMs: number;
+}
+
+// In-memory priority queue (rebuildable cache)
+let retryQueue: RetryEntry[] = [];
+let retryState: RetryState | null = null;
+let checkInterval: ReturnType<typeof setInterval> | null = null;
+let isProcessing = false;
+
+/**
+ * Initialize the retry scheduler.
+ */
+export async function initRetryScheduler(
+  config: Partial<RetryConfig> = {}
+): Promise<void> {
+  await initEventLog();
+  await mkdir(RETRY_DIR, { recursive: true });
+
+  const fullConfig: RetryConfig = {
+    baseDelayMs: config.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+    maxDelayMs: config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+    maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+    checkIntervalMs: config.checkIntervalMs ?? 5000,
+  };
+
+  // Load or create state
+  retryState = await loadRetryState();
+  if (!retryState) {
+    retryState = {
+      version: 1,
+      entries: [],
+      lastProcessedAt: new Date().toISOString(),
+      config: fullConfig,
+    };
+  } else {
+    // Update config if provided
+    retryState.config = fullConfig;
+  }
+
+  // Rebuild in-memory queue from state
+  await rebuildFromState();
+
+  // Start background check loop
+  startCheckLoop(fullConfig.checkIntervalMs);
+
+  await saveRetryState();
+}
+
+/**
+ * Load retry state from disk.
+ */
+async function loadRetryState(): Promise<RetryState | null> {
+  try {
+    const content = await Bun.file(RETRY_STATE_FILE).json();
+    if (content.version === 1 && Array.isArray(content.entries)) {
+      return content as RetryState;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save retry state atomically.
+ */
+async function saveRetryState(): Promise<void> {
+  if (!retryState) return;
+  
+  retryState.lastProcessedAt = new Date().toISOString();
+  await Bun.write(RETRY_STATE_FILE, JSON.stringify(retryState, null, 2) + "\n");
+}
+
+/**
+ * Calculate next retry delay using exponential backoff.
+ */
+function calculateRetryDelay(retryCount: number, config: RetryConfig): number {
+  const delay = config.baseDelayMs * Math.pow(2, retryCount);
+  return Math.min(delay, config.maxDelayMs);
+}
+
+/**
+ * Schedule an event for retry.
+ */
+export async function schedule(
+  eventId: string,
+  retryCount: number
+): Promise<void> {
+  if (!retryState) {
+    throw new Error("Retry scheduler not initialized");
+  }
+
+  // Check if max retries exceeded
+  if (retryCount >= retryState.config.maxRetries) {
+    throw new Error(
+      `Max retries (${retryState.config.maxRetries}) exceeded for event ${eventId}`
+    );
+  }
+
+  // Find the event to get its sequence number
+  let eventSeq = 0;
+  for await (const event of readFrom(1)) {
+    if (event.id === eventId) {
+      eventSeq = event.seq;
+      break;
+    }
+  }
+
+  if (eventSeq === 0) {
+    throw new Error(`Event ${eventId} not found`);
+  }
+
+  // Calculate next retry time
+  const delay = calculateRetryDelay(retryCount, retryState.config);
+  const nextRetryAt = new Date(Date.now() + delay).toISOString();
+
+  const entry: RetryEntry = {
+    eventId,
+    eventSeq,
+    retryCount,
+    nextRetryAt,
+    scheduledAt: new Date().toISOString(),
+  };
+
+  // Add to in-memory queue (sorted by nextRetryAt)
+  const insertIndex = retryQueue.findIndex(
+    e => e.nextRetryAt > nextRetryAt
+  );
+  if (insertIndex === -1) {
+    retryQueue.push(entry);
+  } else {
+    retryQueue.splice(insertIndex, 0, entry);
+  }
+
+  // Update persisted state
+  // Remove existing entry if present
+  retryState.entries = retryState.entries.filter(e => e.eventId !== eventId);
+  retryState.entries.push(entry);
+  
+  await saveRetryState();
+
+  console.log(
+    `[retry] Scheduled event ${eventId} for retry ${retryCount + 1} ` +
+    `at ${nextRetryAt} (delay: ${delay}ms)`
+  );
+}
+
+/**
+ * Get the next due retry entry without removing it.
+ */
+export function peekDue(): RetryEntry | null {
+  const now = new Date().toISOString();
+  
+  for (const entry of retryQueue) {
+    if (entry.nextRetryAt <= now) {
+      return entry;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Pop and return the next due retry entry.
+ */
+export function popDue(): RetryEntry | null {
+  const now = new Date().toISOString();
+  
+  for (let i = 0; i < retryQueue.length; i++) {
+    if (retryQueue[i].nextRetryAt <= now) {
+      const entry = retryQueue.splice(i, 1)[0];
+      
+      // Also remove from persisted state
+      if (retryState) {
+        retryState.entries = retryState.entries.filter(
+          e => e.eventId !== entry.eventId
+        );
+      }
+      
+      return entry;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Remove an event from the retry queue.
+ */
+export async function remove(eventId: string): Promise<void> {
+  // Remove from in-memory queue
+  retryQueue = retryQueue.filter(e => e.eventId !== eventId);
+  
+  // Remove from persisted state
+  if (retryState) {
+    retryState.entries = retryState.entries.filter(e => e.eventId !== eventId);
+    await saveRetryState();
+  }
+}
+
+/**
+ * Rebuild the in-memory queue from persisted state.
+ * Called on startup to reconstruct the queue.
+ */
+export async function rebuildFromState(): Promise<void> {
+  if (!retryState) {
+    retryQueue = [];
+    return;
+  }
+
+  // Sort by nextRetryAt
+  retryQueue = [...retryState.entries].sort(
+    (a, b) => new Date(a.nextRetryAt).getTime() - new Date(b.nextRetryAt).getTime()
+  );
+
+  console.log(`[retry] Rebuilt queue with ${retryQueue.length} entries`);
+}
+
+/**
+ * Rebuild the persisted state from the event log.
+ * Scans for events with retry_scheduled status.
+ */
+export async function rebuildFromEventLog(): Promise<number> {
+  if (!retryState) {
+    throw new Error("Retry scheduler not initialized");
+  }
+
+  const newEntries: RetryEntry[] = [];
+
+  for await (const event of readFrom(1)) {
+    // Handle __status_update__ events which have status in payload.updates
+    if (event.type === "__status_update__") {
+      const payload = event.payload as {
+        originalEventId?: string;
+        originalSeq?: number;
+        updates?: {
+          status?: string;
+          retryCount?: number;
+          nextRetryAt?: string;
+        };
+      };
+      const updates = payload?.updates;
+      if (
+        updates?.status === "retry_scheduled" &&
+        updates?.nextRetryAt &&
+        updates?.retryCount !== undefined &&
+        updates.retryCount < retryState.config.maxRetries
+      ) {
+        newEntries.push({
+          eventId: payload.originalEventId || "",
+          eventSeq: payload.originalSeq || 0,
+          retryCount: updates.retryCount,
+          nextRetryAt: updates.nextRetryAt,
+          scheduledAt: event.updatedAt,
+        });
+      }
+      continue;
+    }
+
+    // Regular events with retry_scheduled status
+    if (
+      event.status === "retry_scheduled" &&
+      event.nextRetryAt &&
+      event.retryCount < retryState.config.maxRetries
+    ) {
+      newEntries.push({
+        eventId: event.id,
+        eventSeq: event.seq,
+        retryCount: event.retryCount,
+        nextRetryAt: event.nextRetryAt,
+        scheduledAt: event.updatedAt,
+      });
+    }
+  }
+
+  retryState.entries = newEntries;
+  await rebuildFromState();
+  await saveRetryState();
+
+  console.log(`[retry] Rebuilt from event log: ${newEntries.length} entries`);
+  return newEntries.length;
+}
+
+/**
+ * Process due retries.
+ * This is called by the check loop.
+ */
+async function processDueRetries(): Promise<void> {
+  if (isProcessing) return;
+  isProcessing = true;
+
+  try {
+    let processed = 0;
+    let entry: RetryEntry | null;
+
+    while ((entry = popDue()) !== null) {
+      processed++;
+      
+      // Update event status to pending for reprocessing
+      await appendStatusUpdate(entry.eventId, {
+        status: "pending",
+        retryCount: entry.retryCount + 1,
+        nextRetryAt: null,
+      });
+
+      console.log(
+        `[retry] Event ${entry.eventId} ready for retry ${entry.retryCount + 1}`
+      );
+    }
+
+    if (processed > 0) {
+      await saveRetryState();
+    }
+  } finally {
+    isProcessing = false;
+  }
+}
+
+/**
+ * Start the background check loop.
+ */
+function startCheckLoop(intervalMs: number): void {
+  if (checkInterval) {
+    clearInterval(checkInterval);
+  }
+
+  checkInterval = setInterval(() => {
+    processDueRetries().catch(err => {
+      console.error("[retry] Error processing due retries:", err);
+    });
+  }, intervalMs);
+
+  console.log(`[retry] Started check loop (interval: ${intervalMs}ms)`);
+}
+
+/**
+ * Stop the background check loop.
+ */
+export function stopCheckLoop(): void {
+  if (checkInterval) {
+    clearInterval(checkInterval);
+    checkInterval = null;
+    console.log("[retry] Stopped check loop");
+  }
+}
+
+/**
+ * Get the number of pending retries.
+ */
+export function getPendingRetryCount(): number {
+  return retryQueue.length;
+}
+
+/**
+ * Get the next retry time (null if queue is empty).
+ */
+export function getNextRetryTime(): string | null {
+  if (retryQueue.length === 0) return null;
+  return retryQueue[0].nextRetryAt;
+}
+
+/**
+ * Get retry statistics.
+ */
+export function getRetryStats(): {
+  pendingCount: number;
+  nextRetryAt: string | null;
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+} {
+  return {
+    pendingCount: retryQueue.length,
+    nextRetryAt: getNextRetryTime(),
+    maxRetries: retryState?.config.maxRetries ?? DEFAULT_MAX_RETRIES,
+    baseDelayMs: retryState?.config.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+    maxDelayMs: retryState?.config.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+  };
+}
+
+/**
+ * Reset the retry scheduler (for testing).
+ */
+export async function resetRetryScheduler(): Promise<void> {
+  stopCheckLoop();
+  retryQueue = [];
+  retryState = null;
+  isProcessing = false;
+}
+
+/**
+ * Check if an event is scheduled for retry.
+ */
+export function isScheduled(eventId: string): boolean {
+  return retryQueue.some(e => e.eventId === eventId);
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,17 +2,23 @@ import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
-import {
-  getThreadSession,
-  createThreadSession,
-  incrementThreadTurn,
-  markThreadCompactWarned,
-} from "./sessionManager";
-import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
+import { getSettings, type ModelConfig, type SecurityConfig, type AgenticMode } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
-import { selectModel } from "./model-router";
+import { selectModel as governanceSelectModel, configureRouter as configureGovernanceRouter } from "./governance/model-router";
+import { recordInvocationStart, recordInvocationCompletion, recordInvocationFailure } from "./governance/usage-tracker";
+import { recordExecutionMetric, checkLimits, handleTrigger as watchdogHandleTrigger } from "./governance/watchdog";
+import { getGovernanceClient, type GovernanceClient } from "./governance/client";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
+
+// Initialize governance router with agentic modes from settings
+let governanceInitialized = false;
+function ensureGovernanceRouter(modes?: AgenticMode[], defaultMode?: string): void {
+  if (!governanceInitialized && modes && defaultMode) {
+    configureGovernanceRouter({ modes, defaultMode, defaultProvider: "anthropic", defaultModel: "claude-3-5-sonnet" });
+    governanceInitialized = true;
+  }
+}
 // Resolve prompts relative to the claudeclaw installation, not the project dir
 const PROMPTS_DIR = join(import.meta.dir, "..", "prompts");
 const HEARTBEAT_PROMPT_FILE = join(PROMPTS_DIR, "heartbeat", "HEARTBEAT.md");
@@ -60,20 +66,11 @@ export interface RunResult {
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
-// Global queue for non-thread messages (backward compatible)
-let globalQueue: Promise<unknown> = Promise.resolve();
-// Per-thread queues — each thread runs independently in parallel
-const threadQueues = new Map<string, Promise<unknown>>();
+let queue: Promise<unknown> = Promise.resolve();
 
-function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
-  if (threadId) {
-    const current = threadQueues.get(threadId) ?? Promise.resolve();
-    const task = current.then(fn, fn);
-    threadQueues.set(threadId, task.catch(() => {}));
-    return task;
-  }
-  const task = globalQueue.then(fn, fn);
-  globalQueue = task.catch(() => {});
+function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+  const task = queue.then(fn, fn);
+  queue = task.catch(() => {});
   return task;
 }
 
@@ -327,7 +324,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
   const securityArgs = buildSecurityArgs(settings.security);
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = (getSettings() as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
     existing.sessionId,
@@ -343,18 +340,102 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string): Promise<RunResult> {
+/**
+ * Policy-aware tool execution wrapper.
+ * Evaluates tool requests against policy before allowing execution.
+ */
+async function evaluateToolForExecution(
+  toolName: string,
+  toolArgs: Record<string, unknown> | undefined,
+  context: {
+    source: string;
+    channelId?: string;
+    userId?: string;
+    skillName?: string;
+    sessionId?: string;
+    claudeSessionId?: string | null;
+    eventId: string;
+  }
+): Promise<{ allowed: boolean; decision: import("./policy/engine").PolicyDecision }> {
+  const gc = getGovernanceClient();
+  const request: import("./policy/engine").ToolRequestContext = {
+    eventId: context.eventId,
+    source: context.source,
+    channelId: context.channelId,
+    userId: context.userId,
+    skillName: context.skillName,
+    toolName,
+    toolArgs,
+    sessionId: context.sessionId,
+    claudeSessionId: context.claudeSessionId,
+    timestamp: new Date().toISOString(),
+  };
+
+  const decision = gc.evaluateToolRequest(request);
+  
+  if (decision.action === "deny") {
+    console.warn(`[policy] Tool ${toolName} denied: ${decision.reason}`);
+    return { allowed: false, decision };
+  }
+  
+  if (decision.action === "require_approval") {
+    console.warn(`[policy] Tool ${toolName} requires approval: ${decision.reason}`);
+    // Enqueue for approval
+    const entry = await gc.requestApproval(request, decision);
+    if (entry) {
+      console.warn(`[policy] Approval request enqueued: ${entry.id}`);
+    }
+    return { allowed: false, decision };
+  }
+  
+  return { allowed: true, decision };
+}
+
+/**
+ * Get context for policy evaluation from current session and settings.
+ */
+async function getPolicyContext(source: string): Promise<{
+  eventId: string;
+  source: string;
+  channelId?: string;
+  userId?: string;
+  skillName?: string;
+  sessionId?: string;
+  claudeSessionId?: string | null;
+}> {
+  const existing = await getSession();
+  const settings = getSettings();
+  return {
+    eventId: crypto.randomUUID(),
+    source,
+    channelId: undefined, // Will be populated from event context
+    userId: settings.userId,
+    skillName: undefined,
+    sessionId: existing?.sessionId,
+    claudeSessionId: existing?.sessionId ?? null,
+  };
+}
+
+async function execClaude(name: string, prompt: string): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
-  const existing = threadId
-    ? await getThreadSession(threadId)
-    : await getSession();
+  // Ensure governance client is initialized
+  const gc = getGovernanceClient();
+  await mkdir(LOGS_DIR, { recursive: true });
+
+  const existing = await getSession();
   const isNew = !existing;
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const logFile = join(LOGS_DIR, `${name}-${timestamp}.log`);
 
-  const settings = getSettings();
-  const { security, model, api, fallback, agentic } = settings;
+  const { security, model, api, fallback, agentic } = getSettings();
+
+  // Generate invocation ID for tracking
+  const invocationId = crypto.randomUUID();
+  const invocationSessionId = existing?.sessionId;
+
+  // Initialize watchdog metrics
+  await recordExecutionMetric({ invocationId, sessionId: invocationSessionId }, {});
 
   // Determine which model to use based on agentic routing
   let primaryConfig: ModelConfig;
@@ -362,12 +443,26 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   let routingReasoning = "";
 
   if (agentic.enabled) {
-    const routing = selectModel(prompt, agentic.modes, agentic.defaultMode);
-    primaryConfig = { model: routing.model, api };
-    taskType = routing.taskType;
-    routingReasoning = routing.reasoning;
+    ensureGovernanceRouter(agentic.modes, agentic.defaultMode);
+    const routing = await governanceSelectModel({
+      prompt,
+      taskType: agentic.defaultMode,
+      sessionId: existing?.sessionId,
+      channelId: undefined,
+      source: name,
+    });
+    primaryConfig = { model: routing.selectedModel, api: routing.selectedProvider === "openai" ? "" : api };
+    taskType = routing.reason;
+    routingReasoning = routing.reason;
+    // Handle budget block
+    if (routing.budgetState === "block") {
+      console.warn(`[${new Date().toLocaleTimeString()}] Execution blocked: budget limit exceeded`);
+      // Record failure and return
+      await recordInvocationFailure(invocationId, { type: "budget-blocked", message: `Budget state: ${routing.budgetState}` });
+      return { stdout: "", stderr: "Execution blocked: budget limit exceeded", exitCode: 0 };
+    }
     console.log(
-      `[${new Date().toLocaleTimeString()}] Agentic routing: ${routing.taskType} → ${routing.model} (${routing.reasoning})`
+      `[${new Date().toLocaleTimeString()}] Agentic routing: ${routing.selectedModel} (${routing.reason})`
     );
   } else {
     primaryConfig = { model, api };
@@ -378,7 +473,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = (getSettings() as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
@@ -421,7 +516,27 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
 
-  let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+  // Record invocation start
+  const invocationContext = {
+    sessionId: existing?.sessionId,
+    claudeSessionId: existing?.sessionId ?? null,
+    source: name,
+    channelId: undefined,
+    provider: primaryConfig.api || "anthropic",
+    model: primaryConfig.model,
+    metadata: { taskType, routingReasoning },
+  };
+  await recordInvocationStart(invocationContext);
+
+  let exec: { rawStdout: string; stderr: string; exitCode: number };
+  try {
+    exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+  } catch (err) {
+    // Record failure
+    await recordInvocationFailure(invocationId, { type: "execution-error", message: err instanceof Error ? err.message : String(err) });
+    throw err;
+  }
+
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
   let usedFallback = false;
 
@@ -431,6 +546,10 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     );
     exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs);
     usedFallback = true;
+    // If fallback also fails, record failure
+    if (extractRateLimitMessage(exec.rawStdout, exec.stderr)) {
+      await recordInvocationFailure(invocationId, { type: "rate-limit", message: "Both primary and fallback hit rate limit" });
+    }
   }
 
   const rawStdout = exec.rawStdout;
@@ -451,13 +570,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
       sessionId = json.session_id;
       stdout = json.result ?? "";
       // Save the real session ID from Claude Code
-      if (threadId) {
-        await createThreadSession(threadId, sessionId);
-        console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
-      } else {
-        await createSession(sessionId);
-        console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}`);
-      }
+      await createSession(sessionId);
+      console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}`);
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to parse session from Claude output:`, e);
     }
@@ -468,6 +582,23 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     stderr,
     exitCode,
   };
+
+  // Record successful completion
+  await recordInvocationCompletion(invocationId, undefined, undefined);
+
+  // Check watchdog limits
+  const watchdogDecision = await checkLimits({ invocationId, sessionId: invocationSessionId });
+  if (watchdogDecision.state === "suspend" || watchdogDecision.state === "kill") {
+    console.warn(`[${new Date().toLocaleTimeString()}] Watchdog ${watchdogDecision.state}: ${watchdogDecision.reason}`);
+    await watchdogHandleTrigger({ invocationId, sessionId: invocationSessionId }, watchdogDecision);
+    // Send escalation notification for watchdog triggers
+    try {
+      const { handleWatchdogTrigger } = await import("./escalation");
+      await handleWatchdogTrigger(watchdogDecision, { invocationId, sessionId: invocationSessionId });
+    } catch (escalationError) {
+      console.error("[escalation] Failed to send watchdog notification:", escalationError);
+    }
+  }
 
   const output = [
     `# ${name}`,
@@ -516,8 +647,14 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
       });
 
       if (retryExec.exitCode === 0) {
-        const count = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
+        const count = await incrementTurn();
         console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${count} (after compact + retry)`);
+        // Check watchdog after successful retry
+        const retryWatchdogDecision = await checkLimits({ invocationId, sessionId: invocationSessionId });
+        if (retryWatchdogDecision.state === "suspend" || retryWatchdogDecision.state === "kill") {
+          console.warn(`[${new Date().toLocaleTimeString()}] Watchdog ${retryWatchdogDecision.state} after retry: ${retryWatchdogDecision.reason}`);
+          await watchdogHandleTrigger({ invocationId, sessionId: invocationSessionId }, retryWatchdogDecision);
+        }
       }
       return retryResult;
     }
@@ -525,15 +662,11 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
 
   // --- Turn tracking & compact warning ---
   if (exitCode === 0 && !isNew) {
-    const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
-    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${threadId ? ` (thread ${threadId.slice(0, 8)})` : ""}`);
+    const turnCount = await incrementTurn();
+    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}`);
 
     if (turnCount >= COMPACT_WARN_THRESHOLD && existing && !existing.compactWarned) {
-      if (threadId) {
-        await markThreadCompactWarned(threadId);
-      } else {
-        await markCompactWarned();
-      }
+      await markCompactWarned();
       emitCompactEvent({ type: "warn", turnCount });
     }
   }
@@ -541,8 +674,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId), threadId);
+export async function run(name: string, prompt: string): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt));
 }
 
 async function streamClaude(
@@ -687,8 +820,8 @@ function prefixUserMessageWithClock(prompt: string): string {
   }
 }
 
-export async function runUserMessage(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return run(name, prefixUserMessageWithClock(prompt), threadId);
+export async function runUserMessage(name: string, prompt: string): Promise<RunResult> {
+  return run(name, prefixUserMessageWithClock(prompt));
 }
 
 /**


### PR DESCRIPTION
## ClaudeClaw v2: Governance & Event Architecture

This is **PR 3 of 3** in a series that introduces a production-grade governance, policy, and event processing architecture to ClaudeClaw.

### The series

| PR | Role | Status |
|----|------|--------|
| #71 | **Policy Engine** — deterministic rule evaluation for tool-use governance | Open |
| #72 | **Governance Layer** — model routing, budget control, usage tracking, watchdog | Open |
| **#73 (this PR)** | **Gateway & Events** — unified message pipeline, event log, escalation | Open |

**Merge order:** #71 → #72 → #73. **This PR depends on #71 and #72.**

---

## This PR: Gateway, Event System & Escalation (#73)

The gateway is the **top layer** that ties everything together. It provides a unified message ingestion pipeline that normalises messages from any adapter (Discord, Telegram, future sources), processes them through the policy and governance layers, and delivers responses — with full event logging, retry handling, and escalation when things go wrong.

### Why this matters

ClaudeClaw v1 has separate, duplicated message handling in each adapter. Discord and Telegram each implement their own rate limiting, message formatting, attachment handling, and Claude invocation logic independently. This leads to:
- Inconsistent behaviour across adapters
- No unified event history (can't replay or audit what happened)
- No retry logic for failed messages
- No way to pause, escalate, or hand off problematic sessions
- Adding a new adapter means reimplementing everything from scratch

### Features

**Gateway:**
- Unified inbound message handling for Discord, Telegram, and future adapters
- Message normalisation to common `NormalizedEvent` format
- Session mapping with atomic read-check-create (all ops serialised in write queue)
- Policy evaluation at gateway level (deny/allow/require_approval)

**Event System:**
- Append-only event log with crash-safe segment writes (temp file + rename)
- Event processor with deduplication-aware selection
- Retry queue with exponential backoff
- Dead letter queue with O(1) append for additions
- Full event replay capability

**Escalation:**
- Trigger-based escalation (budget exceeded, consecutive failures, watchdog alerts)
- Multi-channel notifications (Discord, Telegram)
- Session pause/resume for human intervention
- Handoff support for transferring sessions between operators
- Status tracking for active escalations

### Security/correctness fixes

| Issue | Fix |
|-------|-----|
| Telegram completely broken (legacy path deleted) | Restored runUserMessage call in non-gateway path |
| Session map race condition (getOrCreateMapping) | All mutations wrapped in enqueueWrite |
| Session map race condition (update/increment/attach) | Same — all wrapped in write queue |
| Event log not crash-safe | Write-to-temp + atomic rename |
| Discord v2 never delivers response | processEventWithFallback with legacyHandler |
| Normaliser type safety | Union type for attachment types |
| Event processor re-processes events | Deduplication check in selection loop |
| DLQ O(n) rewrite on every add | appendFile for additions |
| Redundant dead-code deduplication | Removed |

### Code review

3 rounds of automated code review (code-reviewer agent):
- Round 1: 3 CRITICAL + 5 HIGH issues found
- Round 2: All 8 fixed + 1 dead code cleaned up
- Round 3: **APPROVED**

### Files added/modified

**New:**
- `src/gateway/` — index.ts, normalizer.ts, resume.ts, session-map.ts
- `src/event-log.ts`, `src/event-processor.ts`
- `src/dead-letter-queue.ts`, `src/replay.ts`, `src/retry-queue.ts`
- `src/escalation/` — index.ts, triggers.ts, notifications.ts, handoff.ts, pause.ts, status.ts

**Modified:**
- `src/commands/discord.ts` — gateway integration, v2 response delivery
- `src/commands/telegram.ts` — legacy path restored, gateway integration
- `src/commands/start.ts` — gateway and job system initialisation

**Tests:** `src/__tests__/gateway/`, `src/__tests__/escalation/`, `src/__tests__/integration/`, event-log, event-processor, retry-queue

## Test plan

- [ ] `bun test src/__tests__/gateway/` — all gateway tests pass
- [ ] `bun test src/__tests__/event-log.test.ts`
- [ ] `bun test src/__tests__/event-processor.test.ts`
- [ ] `bun test src/__tests__/escalation/` — all escalation tests pass
- [ ] Verify Telegram messages reach Claude (non-gateway mode)
- [ ] Verify Discord messages get responses (both gateway and non-gateway)