### PR TITLE
fix: dual-session fallback to prevent thinking block signature corruption

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -502,7 +502,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown"}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -514,7 +514,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown"}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -10,6 +10,8 @@ import {
   createFallbackSession,
   incrementFallbackTurn,
   markFallbackCompactWarned,
+  peekFallbackSession,
+  resetFallbackSession,
 } from "./sessions";
 import {
   getThreadSession,
@@ -392,6 +394,20 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
   );
+
+  // Reverse handoff: if returning to primary after fallback was active,
+  // tell the primary session to catch up on what happened during the fallback window.
+  const fallbackState = await peekFallbackSession();
+  if (!isNew && fallbackState && fallbackState.turnCount > 0) {
+    prompt = [
+      "[PROVIDER HANDOFF — RETURNING] You were rate-limited and a fallback provider handled requests while you were unavailable.",
+      `The fallback session ran for ${fallbackState.turnCount} turn(s).`,
+      `Read the 3-5 most recent log files in ${LOGS_DIR} to catch up on what happened, then continue with the following request:\n`,
+      prompt,
+    ].join(" ");
+    await resetFallbackSession();
+    console.log(`[${new Date().toLocaleTimeString()}] Reverse handoff: primary resuming after ${fallbackState.turnCount} fallback turn(s)`);
+  }
 
   // New session: use json output to capture Claude's session_id
   // Resumed session: use text output with --resume

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,16 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
+import {
+  getSession,
+  createSession,
+  incrementTurn,
+  markCompactWarned,
+  getFallbackSession,
+  createFallbackSession,
+  incrementFallbackTurn,
+  markFallbackCompactWarned,
+} from "./sessions";
 import {
   getThreadSession,
   createThreadSession,
@@ -424,13 +433,50 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
   let usedFallback = false;
+  // Track whether we created a new session (primary or fallback) for JSON parsing
+  let createdNewSession = false;
+  // Track which session layer we're operating on for turn counting
+  let sessionLayer: "primary" | "fallback" = "primary";
 
   if (primaryRateLimit && hasModelConfig(fallbackConfig) && !sameModelConfig(primaryConfig, fallbackConfig)) {
     console.warn(
-      `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
+      `[${new Date().toLocaleTimeString()}] Claude limit reached; switching to fallback session${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs);
+
+    // Use a separate session for the fallback provider to avoid
+    // mixing thinking block signatures (see issue #18).
+    const fallbackSession = await getFallbackSession();
+    const isFallbackNew = !fallbackSession;
+
+    let fallbackPrompt = prompt;
+    if (isFallbackNew) {
+      // First time on fallback: tell the agent to read recent logs for context handoff
+      fallbackPrompt = [
+        "[PROVIDER HANDOFF] The primary API provider hit a rate limit.",
+        "You are now running on a fallback provider with a fresh session.",
+        "A previous session was active on the primary provider and may have ongoing conversations or tasks.",
+        `Before responding, read the 3-5 most recent log files in ${LOGS_DIR} to understand what was happening.`,
+        "Then continue naturally with the following request:\n",
+        prompt,
+      ].join(" ");
+    }
+
+    const fallbackFormat = isFallbackNew ? "json" : "text";
+    const fallbackArgs = ["claude", "-p", fallbackPrompt, "--output-format", fallbackFormat, ...securityArgs];
+
+    if (!isFallbackNew) {
+      fallbackArgs.push("--resume", fallbackSession.sessionId);
+    }
+
+    // Attach the same system prompt to fallback calls
+    if (appendParts.length > 0) {
+      fallbackArgs.push("--append-system-prompt", appendParts.join("\n\n"));
+    }
+
+    exec = await runClaudeOnce(fallbackArgs, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs);
     usedFallback = true;
+    createdNewSession = isFallbackNew;
+    sessionLayer = "fallback";
   }
 
   const rawStdout = exec.rawStdout;
@@ -444,14 +490,19 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     stdout = rateLimitMessage;
   }
 
-  // For new sessions, parse the JSON to extract session_id and result text
-  if (!rateLimitMessage && isNew && exitCode === 0) {
+  // For new sessions (primary or fallback), parse JSON to extract session_id
+  const isNewSession = (isNew && !usedFallback) || createdNewSession;
+  if (!rateLimitMessage && isNewSession && exitCode === 0) {
     try {
       const json = JSON.parse(rawStdout);
       sessionId = json.session_id;
       stdout = json.result ?? "";
-      // Save the real session ID from Claude Code
-      if (threadId) {
+
+      if (usedFallback) {
+        // Save as fallback session — separate from primary
+        await createFallbackSession(sessionId);
+        console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${sessionId}`);
+      } else if (threadId) {
         await createThreadSession(threadId, sessionId);
         console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
       } else {
@@ -472,7 +523,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   const output = [
     `# ${name}`,
     `Date: ${new Date().toISOString()}`,
-    `Session: ${sessionId} (${isNew ? "new" : "resumed"})`,
+    `Session: ${sessionId} (${isNewSession ? "new" : "resumed"}${sessionLayer === "fallback" ? ", fallback" : ""})`,
     `Model config: ${usedFallback ? "fallback" : "primary"}`,
     ...(agentic.enabled ? [`Task type: ${taskType}`, `Routing: ${routingReasoning}`] : []),
     `Prompt: ${prompt}`,
@@ -487,7 +538,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
 
   // --- Auto-compact on timeout (exit 124) ---
-  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {
+  // Only auto-compact the primary session (fallback timeouts don't compact the primary)
+  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing && sessionLayer === "primary") {
     emitCompactEvent({ type: "auto-compact-start" });
     const compactOk = await runCompact(
       existing.sessionId,
@@ -524,17 +576,35 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   }
 
   // --- Turn tracking & compact warning ---
-  if (exitCode === 0 && !isNew) {
-    const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
-    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${threadId ? ` (thread ${threadId.slice(0, 8)})` : ""}`);
+  if (exitCode === 0 && !isNewSession) {
+    let turnCount: number;
+    if (sessionLayer === "fallback") {
+      turnCount = await incrementFallbackTurn();
+      console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount} (fallback session)`);
+    } else if (threadId) {
+      turnCount = await incrementThreadTurn(threadId);
+      console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount} (thread ${threadId.slice(0, 8)})`);
+    } else {
+      turnCount = await incrementTurn();
+      console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}`);
+    }
 
-    if (turnCount >= COMPACT_WARN_THRESHOLD && existing && !existing.compactWarned) {
-      if (threadId) {
-        await markThreadCompactWarned(threadId);
+    if (turnCount >= COMPACT_WARN_THRESHOLD) {
+      let alreadyWarned = false;
+      if (sessionLayer === "fallback") {
+        const fb = await getFallbackSession();
+        alreadyWarned = fb?.compactWarned ?? false;
+        if (!alreadyWarned) await markFallbackCompactWarned();
+      } else if (threadId) {
+        alreadyWarned = existing?.compactWarned ?? false;
+        if (!alreadyWarned) await markThreadCompactWarned(threadId);
       } else {
-        await markCompactWarned();
+        alreadyWarned = existing?.compactWarned ?? false;
+        if (!alreadyWarned) await markCompactWarned();
       }
-      emitCompactEvent({ type: "warn", turnCount });
+      if (!alreadyWarned) {
+        emitCompactEvent({ type: "warn", turnCount });
+      }
     }
   }
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -3,6 +3,7 @@ import { unlink, readdir, rename } from "fs/promises";
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
+const FALLBACK_SESSION_FILE = join(HEARTBEAT_DIR, "session-fallback.json");
 
 export interface GlobalSession {
   sessionId: string;
@@ -108,4 +109,79 @@ export async function backupSession(): Promise<string | null> {
   current = null;
 
   return backupName;
+}
+
+// --- Fallback session (separate provider, separate session) ---
+
+let fallbackCurrent: GlobalSession | null = null;
+
+async function loadFallbackSession(): Promise<GlobalSession | null> {
+  if (fallbackCurrent) return fallbackCurrent;
+  try {
+    fallbackCurrent = await Bun.file(FALLBACK_SESSION_FILE).json();
+    return fallbackCurrent;
+  } catch {
+    return null;
+  }
+}
+
+async function saveFallbackSession(session: GlobalSession): Promise<void> {
+  fallbackCurrent = session;
+  await Bun.write(FALLBACK_SESSION_FILE, JSON.stringify(session, null, 2) + "\n");
+}
+
+/** Returns the existing fallback session or null. */
+export async function getFallbackSession(): Promise<{ sessionId: string; turnCount: number; compactWarned: boolean } | null> {
+  const existing = await loadFallbackSession();
+  if (existing) {
+    if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+    if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
+    existing.lastUsedAt = new Date().toISOString();
+    await saveFallbackSession(existing);
+    return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
+  }
+  return null;
+}
+
+/** Save a fallback session ID obtained from Claude Code's output. */
+export async function createFallbackSession(sessionId: string): Promise<void> {
+  await saveFallbackSession({
+    sessionId,
+    createdAt: new Date().toISOString(),
+    lastUsedAt: new Date().toISOString(),
+    turnCount: 0,
+    compactWarned: false,
+  });
+}
+
+/** Increment the turn counter for the fallback session. */
+export async function incrementFallbackTurn(): Promise<number> {
+  const existing = await loadFallbackSession();
+  if (!existing) return 0;
+  if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+  existing.turnCount += 1;
+  await saveFallbackSession(existing);
+  return existing.turnCount;
+}
+
+/** Mark that the compact warning has been sent for the fallback session. */
+export async function markFallbackCompactWarned(): Promise<void> {
+  const existing = await loadFallbackSession();
+  if (!existing) return;
+  existing.compactWarned = true;
+  await saveFallbackSession(existing);
+}
+
+export async function resetFallbackSession(): Promise<void> {
+  fallbackCurrent = null;
+  try {
+    await unlink(FALLBACK_SESSION_FILE);
+  } catch {
+    // already gone
+  }
+}
+
+/** Returns fallback session metadata without mutating lastUsedAt. */
+export async function peekFallbackSession(): Promise<GlobalSession | null> {
+  return await loadFallbackSession();
 }


### PR DESCRIPTION
## Summary

Alternative to #26 — addresses the same root cause (issue #18) but preserves session continuity during extended rate-limit windows.

Instead of stripping `--resume` from fallback calls (which makes every fallback call a one-shot with no memory), this PR maintains a **dedicated fallback session** alongside the primary:

- **Separate sessions per provider:** The primary and fallback each have their own session file (`session.json` / `session-fallback.json`). No thinking block signatures are ever mixed.
- **Context handoff:** When the fallback session is first created, the agent is instructed to read recent log files to understand what the primary session was working on. Subsequent fallback calls resume the fallback session normally with full history.
- **No goldfish mode:** During multi-hour rate-limit windows, the fallback session accumulates context just like the primary would — conversations, tasks, and state carry over between calls.

Also includes the `forwardToTelegram`/`forwardToDiscord` fix from #26 (fall back to `result.stdout` when `result.stderr` is empty).

### How it works

1. Primary call hits rate limit → detected via `RATE_LIMIT_PATTERN`
2. Check for existing fallback session (`session-fallback.json`)
3. If no fallback session exists: create one with a handoff prompt that tells the agent to read recent logs for context
4. If fallback session exists: resume it with `--resume` as usual
5. When primary comes back online, the primary session resumes from where it left off

### What this doesn't do (yet)

- **Bidirectional handoff:** When switching _back_ from fallback to primary, the primary doesn't automatically learn what the fallback did. This could be added later.
- **Fallback session cleanup:** The fallback session persists indefinitely. A TTL or manual clear could be added.

## Test plan

- [ ] Configure primary + fallback with different providers
- [ ] Trigger rate limit on primary — verify fallback creates its own session
- [ ] Send multiple messages during rate limit — verify fallback session resumes with context
- [ ] Wait for primary to recover — verify primary session resumes independently
- [ ] Verify Telegram/Discord error messages show actual error text

🤖 Generated with [Claude Code](https://claude.com/claude-code)