### PR TITLE
feat: add multi-session chat UI with session browser and agent picker

### DIFF
--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -943,6 +943,11 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     const chatSend = $("chat-send");
 
     var CHAT_STORAGE_KEY = "claudeclaw.chat.history";
+    var activeSessionId = null;
+    var activeAgent = null;
+    var messagesOffset = 0;
+    var totalMessages = 0;
+    var MESSAGES_PER_PAGE = 10;
     let chatBusy = false;
     let chatAbortController = null;
     let chatElapsedTimer = null;
@@ -1110,6 +1115,212 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
       chatMessages.scrollTop = chatMessages.scrollHeight;
     }
 
+    // --- Session & Agent Management ---
+
+    async function loadSessions() {
+      var listEl = document.getElementById('session-list');
+      if (!listEl) return;
+      try {
+        var res = await fetch('/api/sessions');
+        var sessions = await res.json();
+        listEl.innerHTML = '';
+        if (!sessions.length) {
+          listEl.innerHTML = '<div class="session-loading">No sessions yet</div>';
+          return;
+        }
+        sessions.forEach(function(s) {
+          var item = document.createElement('div');
+          item.className = 'session-item' + (s.id === activeSessionId ? ' active' : '');
+          item.innerHTML = '<div class="session-item-header">'
+            + '<span class="session-agent">' + (s.agent || 'mike') + '</span>'
+            + '<span class="session-channel">' + (s.channel || '') + '</span>'
+            + '</div>'
+            + '<div class="session-preview">' + escapeHtml(s.lastMessage || s.firstMessage || '(empty)') + '</div>'
+            + '<div class="session-time">' + formatTime(s.lastUsedAt) + ' · ' + s.turnCount + ' turns</div>';
+          item.addEventListener('click', function() { selectSession(s.id, s.agent); });
+          listEl.appendChild(item);
+        });
+      } catch (e) {
+        listEl.innerHTML = '<div class="session-loading">Failed to load</div>';
+      }
+    }
+
+    async function loadAgents() {
+      var selectEl = document.getElementById('agent-select');
+      if (!selectEl) return;
+      try {
+        var res = await fetch('/api/agents');
+        var agents = await res.json();
+        selectEl.innerHTML = '<option value="">Select agent...</option>';
+        var inlineSelect = document.getElementById('inline-agent-select');
+        if (inlineSelect) inlineSelect.innerHTML = '';
+        agents.forEach(function(a) {
+          var opt = document.createElement('option');
+          opt.value = a.id;
+          opt.textContent = a.name + (a.description ? ' — ' + a.description.substring(0, 40) : '');
+          selectEl.appendChild(opt);
+          if (inlineSelect) {
+            var opt2 = opt.cloneNode(true);
+            inlineSelect.appendChild(opt2);
+          }
+        });
+      } catch {}
+    }
+
+    async function selectSession(sessionId, agent) {
+      activeSessionId = sessionId;
+      activeAgent = agent || 'mike';
+      messagesOffset = 0;
+
+      // Update sidebar active state
+      document.querySelectorAll('.session-item').forEach(function(el) { el.classList.remove('active'); });
+      var items = document.querySelectorAll('.session-item');
+      // Highlight by finding the clicked one (re-render is simpler)
+      loadSessions();
+
+      // Show header
+      var headerEl = document.getElementById('chat-header');
+      var agentBadge = document.getElementById('chat-session-agent');
+      var sessionInfo = document.getElementById('chat-session-info');
+      if (headerEl) headerEl.hidden = false;
+      if (agentBadge) agentBadge.textContent = activeAgent;
+      if (sessionInfo) sessionInfo.textContent = 'Session ' + sessionId.substring(0, 8);
+
+      // Load messages
+      chatHistory = [];
+      renderChatHistory();
+      await loadMessages(sessionId);
+    }
+
+    async function loadMessages(sessionId, loadMore) {
+      var loadMoreContainer = document.getElementById('load-more-container');
+      var loadMoreBtn = document.getElementById('load-more-btn');
+
+      if (!loadMore) {
+        // Initial load — get last N messages
+        try {
+          var res = await fetch('/api/sessions/' + sessionId + '/messages?limit=' + MESSAGES_PER_PAGE + '&offset=-1');
+          var messages = await res.json();
+          chatHistory = messages.map(function(m) { return { role: m.role, text: m.text }; });
+          renderChatHistory();
+
+          // Check if there are more
+          var countRes = await fetch('/api/sessions/' + sessionId + '/messages?limit=999999&offset=0');
+          var allMsgs = await countRes.json();
+          totalMessages = allMsgs.length;
+          messagesOffset = Math.max(0, totalMessages - MESSAGES_PER_PAGE);
+
+          if (messagesOffset > 0 && loadMoreContainer) {
+            loadMoreContainer.hidden = false;
+            if (loadMoreBtn) loadMoreBtn.textContent = 'Load older (' + messagesOffset + ' more)';
+          } else if (loadMoreContainer) {
+            loadMoreContainer.hidden = true;
+          }
+        } catch (e) {
+          console.error('Failed to load messages:', e);
+        }
+      } else {
+        // Load more — prepend older messages
+        var newOffset = Math.max(0, messagesOffset - MESSAGES_PER_PAGE);
+        var limit = messagesOffset - newOffset;
+        try {
+          var res = await fetch('/api/sessions/' + sessionId + '/messages?limit=' + limit + '&offset=' + newOffset);
+          var older = await res.json();
+          var olderMapped = older.map(function(m) { return { role: m.role, text: m.text }; });
+          chatHistory = olderMapped.concat(chatHistory);
+          messagesOffset = newOffset;
+          // Preserve scroll position
+          var chatMsgs = document.getElementById('chat-messages');
+          var scrollHeightBefore = chatMsgs ? chatMsgs.scrollHeight : 0;
+          renderChatHistory();
+          if (chatMsgs) { chatMsgs.scrollTop = chatMsgs.scrollHeight - scrollHeightBefore; }
+
+          if (messagesOffset <= 0 && loadMoreContainer) {
+            loadMoreContainer.hidden = true;
+          } else if (loadMoreBtn) {
+            loadMoreBtn.textContent = 'Load older (' + messagesOffset + ' more)';
+          }
+        } catch (e) {
+          console.error('Failed to load more:', e);
+        }
+      }
+    }
+
+    function escapeHtml(text) {
+      var div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function formatTime(isoStr) {
+      if (!isoStr) return '';
+      try {
+        var d = new Date(isoStr);
+        var now = new Date();
+        if (d.toDateString() === now.toDateString()) {
+          return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        }
+        return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+      } catch { return ''; }
+    }
+
+    // --- Wire up UI ---
+
+    var newSessionBtn = document.getElementById('new-session-btn');
+    var agentSelectorEl = document.getElementById('agent-selector');
+    var agentSelectEl = document.getElementById('agent-select');
+    var loadMoreBtn2 = document.getElementById('load-more-btn');
+
+    if (newSessionBtn) {
+      newSessionBtn.addEventListener('click', function() {
+        // Start new session — clear chat, show agent dropdown above input
+        activeSessionId = null;
+        activeAgent = 'mike';
+        chatHistory = [];
+        renderChatHistory();
+        // Deselect sidebar items
+        document.querySelectorAll('.session-item').forEach(function(el) { el.classList.remove('active'); });
+        // Show header
+        var headerEl = document.getElementById('chat-header');
+        var agentBadge = document.getElementById('chat-session-agent');
+        var sessionInfo = document.getElementById('chat-session-info');
+        if (headerEl) headerEl.hidden = false;
+        if (agentBadge) agentBadge.textContent = 'mike';
+        if (sessionInfo) sessionInfo.textContent = 'New session';
+        // Show agent picker above input
+        var inlineAgent = document.getElementById('inline-agent-selector');
+        if (inlineAgent) inlineAgent.hidden = false;
+        // Focus input
+        if (chatInput) chatInput.focus();
+      });
+    }
+
+    // Inline agent selector above input
+    var inlineAgentSelect = document.getElementById('inline-agent-select');
+    if (inlineAgentSelect) {
+      inlineAgentSelect.addEventListener('change', function() {
+        activeAgent = inlineAgentSelect.value || 'mike';
+        var agentBadge = document.getElementById('chat-session-agent');
+        if (agentBadge) agentBadge.textContent = activeAgent;
+      });
+    }
+
+    if (loadMoreBtn2) {
+      loadMoreBtn2.addEventListener('click', function() {
+        if (activeSessionId) loadMessages(activeSessionId, true);
+      });
+    }
+
+    // Load sessions and agents on chat tab activation
+    var origSetActiveTab = setActiveTab;
+    setActiveTab = function(tab) {
+      origSetActiveTab(tab);
+      if (tab === 'chat') {
+        loadSessions();
+        loadAgents();
+      }
+    };
+
     function autoResizeChatInput() {
       if (!chatInput) return;
       chatInput.style.height = "auto";
@@ -1126,6 +1337,9 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
       setChatBusy(true);
 
       chatHistory.push({ role: "user", text: message });
+      // Hide agent selector after first message
+      var inlineAgent = document.getElementById('inline-agent-selector');
+      if (inlineAgent) inlineAgent.hidden = true;
       var assistantIdx = chatHistory.length;
       chatHistory.push({ role: "assistant", text: "", streaming: true });
       renderChatHistory();

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1371,4 +1371,208 @@ export const pageStyles = String.raw`    :root {
       .pill:nth-last-child(2) {
         border-bottom: 0;
       }
-    }`;
+    }
+
+/* --- Multi-session Chat Layout --- */
+.chat-layout {
+  display: flex;
+  height: 100%;
+  gap: 0;
+}
+
+.chat-sidebar {
+  width: 280px;
+  min-width: 280px;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.chat-sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.chat-sidebar-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.new-session-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.agent-selector {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.agent-selector select {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 13px;
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.session-item {
+  padding: 10px 16px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  transition: background 0.15s;
+}
+
+.session-item:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+.session-item.active {
+  background: rgba(255,255,255,0.1);
+  border-left: 3px solid var(--accent);
+}
+
+.session-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.session-agent {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: capitalize;
+}
+
+.session-channel {
+  font-size: 10px;
+  color: var(--fg-dim);
+  background: rgba(255,255,255,0.1);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.session-preview {
+  font-size: 12px;
+  color: var(--fg-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-time {
+  font-size: 10px;
+  color: var(--fg-dim);
+  margin-top: 2px;
+}
+
+.session-loading {
+  padding: 20px;
+  text-align: center;
+  color: var(--fg-dim);
+  font-size: 13px;
+}
+
+.chat-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.chat-header {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.chat-agent-badge {
+  background: var(--accent);
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.chat-session-info {
+  color: var(--fg-dim);
+  font-size: 12px;
+}
+
+.load-more-container {
+  text-align: center;
+  padding: 8px;
+}
+
+.load-more-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg-dim);
+  padding: 6px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.load-more-btn:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+@media (max-width: 768px) {
+  .chat-sidebar { width: 200px; min-width: 200px; }
+}
+
+@media (max-width: 480px) {
+  .chat-layout { flex-direction: column; }
+  .chat-sidebar { width: 100%; min-width: 100%; max-height: 200px; border-right: none; border-bottom: 1px solid var(--border); }
+}
+
+.inline-agent-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+
+.inline-agent-selector label {
+  font-weight: 600;
+}
+
+.inline-agent-select {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 12px;
+}
+`;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -184,10 +184,34 @@ ${pageStyles}
       </form>
     </section>
     </div>
-    <div id="chat-panel" class="chat-panel" hidden>
-      <div id="chat-messages" class="chat-messages"></div>
+    <div id="chat-panel" class="chat-panel" hidden><div class="chat-layout">
+      <div class="chat-sidebar" id="chat-sidebar">
+        <div class="chat-sidebar-header">
+          <h3>Sessions</h3>
+          <button id="new-session-btn" class="new-session-btn" type="button">+ New</button>
+        </div>
+        <div id="agent-selector" class="agent-selector" hidden>
+          <select id="agent-select"><option value="">Select agent...</option></select>
+        </div>
+        <div id="session-list" class="session-list">
+          <div class="session-loading">Loading sessions...</div>
+        </div>
+      </div>
+      <div class="chat-main">
+        <div id="chat-header" class="chat-header" hidden>
+          <span id="chat-session-agent" class="chat-agent-badge"></span>
+          <span id="chat-session-info" class="chat-session-info"></span>
+        </div>
+        <div id="load-more-container" class="load-more-container" hidden>
+          <button id="load-more-btn" class="load-more-btn" type="button">Load older messages</button>
+        </div>
+        <div id="chat-messages" class="chat-messages"></div>
       <div class="chat-input-area">
-        <form id="chat-form" class="chat-form">
+        <div id="inline-agent-selector" class="inline-agent-selector" hidden>
+            <label>Agent:</label>
+            <select id="inline-agent-select" class="inline-agent-select"></select>
+          </div>
+          <form id="chat-form" class="chat-form">
           <textarea
             id="chat-input"
             class="chat-input"
@@ -199,6 +223,8 @@ ${pageStyles}
           <button id="chat-send" class="chat-send" type="submit">Send</button>
         </form>
       </div>
+      </div><!-- chat-main -->
+      </div><!-- chat-layout -->
     </div>
   </main>
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -5,6 +5,7 @@ import { buildState, buildTechnicalInfo, sanitizeSettings } from "./services/sta
 import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/settings";
 import { createQuickJob, deleteJob } from "./services/jobs";
 import { readLogs } from "./services/logs";
+import { listSessions, readSessionMessages, listAgents } from "./services/sessions";
 
 export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
   const server = Bun.serve({
@@ -147,6 +148,35 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       if (url.pathname === "/api/logs") {
         const tail = clampInt(url.searchParams.get("tail"), 200, 20, 2000);
         return json(await readLogs(tail));
+      }
+
+      // --- Session & Agent APIs ---
+
+      if (url.pathname === "/api/sessions" && req.method === "GET") {
+        try {
+          return json(await listSessions());
+        } catch (err) {
+          return json({ error: String(err) }, 500);
+        }
+      }
+
+      if (url.pathname === "/api/agents" && req.method === "GET") {
+        try {
+          return json(await listAgents());
+        } catch (err) {
+          return json({ error: String(err) }, 500);
+        }
+      }
+
+      if (url.pathname.startsWith("/api/sessions/") && url.pathname.endsWith("/messages") && req.method === "GET") {
+        const sessionId = url.pathname.replace("/api/sessions/", "").replace("/messages", "");
+        const limit = parseInt(url.searchParams.get("limit") || "10");
+        const offset = parseInt(url.searchParams.get("offset") || "-1");
+        try {
+          return json(await readSessionMessages(sessionId, limit, offset));
+        } catch (err) {
+          return json({ error: String(err) }, 500);
+        }
       }
 
       if (url.pathname === "/api/chat" && req.method === "POST") {

--- a/src/ui/services/sessions.ts
+++ b/src/ui/services/sessions.ts
@@ -1,0 +1,230 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+
+// --- Types ---
+
+export interface SessionInfo {
+  id: string;
+  agent: string;
+  channel: string;
+  lastUsedAt: string;
+  createdAt: string;
+  turnCount: number;
+  firstMessage: string;
+  lastMessage: string;
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: string;
+  uuid?: string;
+}
+
+// --- JSONL project directory ---
+
+function getProjectDir(): string {
+  const cwd = process.cwd().replace(/\//g, "-").replace(/^-/, "-");
+  return join(homedir(), ".claude", "projects", cwd);
+}
+
+// --- List sessions ---
+
+export async function listSessions(): Promise<SessionInfo[]> {
+  const projectDir = getProjectDir();
+  const sessionFile = join(process.cwd(), ".claude", "claudeclaw", "session.json");
+  const threadFile = join(process.cwd(), ".claude", "claudeclaw", "sessions.json");
+
+  const sessions: SessionInfo[] = [];
+
+  // Read global session
+  try {
+    if (existsSync(sessionFile)) {
+      const data = JSON.parse(await readFile(sessionFile, "utf-8"));
+      const messages = await readSessionMessages(data.sessionId, 1, 0);
+      const lastMsgs = await readSessionMessages(data.sessionId, 1, -1);
+      sessions.push({
+        id: data.sessionId,
+        agent: "mike",
+        channel: "global",
+        lastUsedAt: data.lastUsedAt || data.createdAt,
+        createdAt: data.createdAt,
+        turnCount: data.turnCount || 0,
+        firstMessage: messages[0]?.text?.substring(0, 100) || "",
+        lastMessage: lastMsgs[0]?.text?.substring(0, 100) || "",
+      });
+    }
+  } catch {}
+
+  // Read thread sessions
+  try {
+    if (existsSync(threadFile)) {
+      const data = JSON.parse(await readFile(threadFile, "utf-8"));
+      for (const [threadId, thread] of Object.entries(data.threads || {})) {
+        const t = thread as any;
+        const channel = threadId.startsWith("slk:") ? "slack" : "whatsapp";
+        const messages = await readSessionMessages(t.sessionId, 1, 0);
+        const lastMsgs = await readSessionMessages(t.sessionId, 1, -1);
+        sessions.push({
+          id: t.sessionId,
+          agent: "mike",
+          channel,
+          lastUsedAt: t.lastUsedAt || t.createdAt,
+          createdAt: t.createdAt,
+          turnCount: t.turnCount || 0,
+          firstMessage: messages[0]?.text?.substring(0, 100) || "",
+          lastMessage: lastMsgs[0]?.text?.substring(0, 100) || "",
+        });
+      }
+    }
+  } catch {}
+
+  // Also scan JSONL files for orphaned sessions
+  try {
+    const knownIds = new Set(sessions.map((s) => s.id));
+    const files = await readdir(projectDir);
+    for (const file of files.slice(-20)) { // Last 20 files only
+      if (!file.endsWith(".jsonl")) continue;
+      const id = basename(file, ".jsonl");
+      if (knownIds.has(id)) continue;
+      try {
+        const fileStat = await stat(join(projectDir, file));
+        const messages = await readSessionMessages(id, 1, 0);
+        sessions.push({
+          id,
+          agent: "unknown",
+          channel: "unknown",
+          lastUsedAt: fileStat.mtime.toISOString(),
+          createdAt: fileStat.birthtime.toISOString(),
+          turnCount: 0,
+          firstMessage: messages[0]?.text?.substring(0, 100) || "",
+          lastMessage: "",
+        });
+      } catch {}
+    }
+  } catch {}
+
+  // Sort by lastUsedAt descending
+  sessions.sort((a, b) => new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime());
+  return sessions;
+}
+
+// --- Read session messages ---
+
+export async function readSessionMessages(
+  sessionId: string,
+  limit: number = 10,
+  offset: number = 0 // 0 = from start, -1 = last N
+): Promise<ChatMessage[]> {
+  const projectDir = getProjectDir();
+  const filePath = join(projectDir, `${sessionId}.jsonl`);
+
+  if (!existsSync(filePath)) return [];
+
+  const content = await readFile(filePath, "utf-8");
+  const lines = content.trim().split("\n");
+
+  // Parse all user/assistant messages
+  const messages: ChatMessage[] = [];
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === "user") {
+        const msg = entry.message;
+        let text = "";
+        if (msg?.content) {
+          if (typeof msg.content === "string") {
+            text = msg.content;
+          } else if (Array.isArray(msg.content)) {
+            text = msg.content
+              .filter((c: any) => c.type === "text")
+              .map((c: any) => c.text)
+              .join("\n");
+          }
+        }
+        // Strip ClaudeClaw prefixes (timestamps, channel info, directives)
+        text = text.replace(/^\[[\d-]+\s[\d:]+\sUTC[^\]]*\]\n/m, "");
+        text = text.replace(/^\[(?:WhatsApp|Slack|Discord)[^\]]*\]\n/m, "");
+        text = text.replace(/^## Slack Directives[\s\S]*?(?=\n[A-Z]|\n$)/m, "").trim();
+        // Get just the user's actual message
+        const lastLine = text.split("\n").pop()?.trim() || text.trim();
+        if (lastLine) {
+          messages.push({
+            role: "user",
+            text: lastLine,
+            timestamp: entry.timestamp || "",
+            uuid: entry.uuid,
+          });
+        }
+      } else if (entry.type === "assistant") {
+        const content = entry.message?.content;
+        if (Array.isArray(content)) {
+          const textParts = content
+            .filter((c: any) => c.type === "text" && c.text)
+            .map((c: any) => c.text);
+          if (textParts.length > 0) {
+            messages.push({
+              role: "assistant",
+              text: textParts.join("\n"),
+              timestamp: entry.timestamp || "",
+              uuid: entry.uuid,
+            });
+          }
+        }
+      }
+    } catch {}
+  }
+
+  // Apply pagination
+  if (offset === -1) {
+    // Last N messages
+    return messages.slice(-limit);
+  }
+  return messages.slice(offset, offset + limit);
+}
+
+// --- List agents ---
+
+export async function listAgents(): Promise<Array<{ id: string; name: string; description: string }>> {
+  const agentsDir = join(process.cwd(), ".claude", "agents");
+  const agents: Array<{ id: string; name: string; description: string }> = [];
+
+  // Main agent (Mike)
+  agents.push({ id: "mike", name: "Mike", description: "General assistant" });
+
+  try {
+    const dirs = await readdir(agentsDir);
+    for (const dir of dirs) {
+      const agentFile = join(agentsDir, dir, "agent.md");
+      if (!existsSync(agentFile)) {
+        // Legacy flat file
+        const flatFile = join(agentsDir, `${dir}.md`);
+        if (existsSync(flatFile)) {
+          const content = await readFile(flatFile, "utf-8");
+          const nameMatch = content.match(/^name:\s*(.+)$/m);
+          const descMatch = content.match(/^description:\s*(.+)$/m);
+          agents.push({
+            id: dir,
+            name: nameMatch?.[1] || dir,
+            description: descMatch?.[1]?.substring(0, 80) || "",
+          });
+        }
+        continue;
+      }
+      const content = await readFile(agentFile, "utf-8");
+      const nameMatch = content.match(/^name:\s*(.+)$/m);
+      const descMatch = content.match(/^description:\s*(.+)$/m);
+      if (nameMatch) {
+        agents.push({
+          id: dir,
+          name: nameMatch[1],
+          description: descMatch?.[1]?.substring(0, 80) || "",
+        });
+      }
+    }
+  } catch {}
+
+  return agents;
+}


### PR DESCRIPTION
Adds a session sidebar and agent selector to the web UI chat tab, enabling users to browse, resume, and create sessions across all channels.

Server-side:
- New GET /api/sessions — lists all active sessions from session.json, sessions.json (thread sessions), and JSONL files in ~/.claude/projects/
- New GET /api/sessions/:id/messages — reads JSONL session files, extracts user/assistant messages with pagination (limit + offset params)
- New GET /api/agents — lists available agents from .claude/agents/ dirs (supports both workspace layout agent/<name>/agent.md and legacy flat files)

UI changes:
- Session sidebar (left panel) with session list showing agent name, channel badge (global/slack/whatsapp), message preview, timestamp, turns
- Click session to load its message history
- "Load older" button at top for paginated history (loads 10 at a time)
- Scroll position preserved when loading older messages
- "+ New" button opens clean chat with agent dropdown above input
- Agent dropdown defaults to Mike, hides after first message sent
- Mobile responsive — sidebar collapses on small screens

JSONL parsing:
- Reads Claude Code session files from ~/.claude/projects/<project>/*.jsonl
- Extracts user messages (strips ClaudeClaw prefixes: timestamps, channel info, Slack directives)
- Extracts assistant text (skips thinking blocks and tool_use)
- Supports offset=-1 for "last N messages" loading