### PR TITLE
feat: daemon-level plugin system with OpenClaw-compatible API

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -10,6 +10,7 @@ import { initConfig, loadSettings, reloadSettings, resolvePrompt, type Heartbeat
 import { getDayAndMinuteAtOffset } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
 import type { Job } from "../jobs";
+import { PluginManager, setPluginManager } from "../plugins";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -319,7 +320,18 @@ export async function start(args: string[] = []) {
   let web: WebServerHandle | null = null;
   let discordStopGateway: (() => void) | null = null;
 
+  // ── Plugin system ──
+  const pluginManager = new PluginManager(process.cwd());
+  if (Object.keys(settings.plugins).length > 0) {
+    await pluginManager.loadAll(settings.plugins);
+    await pluginManager.startServices();
+    await pluginManager.emit("gateway_start", {}, { workspaceDir: process.cwd() });
+    setPluginManager(pluginManager);
+  }
+
   async function shutdown() {
+    await pluginManager.stopServices();
+    setPluginManager(null);
     if (discordStopGateway) discordStopGateway();
     if (web) web.stop();
     await teardownStatusline();
@@ -394,6 +406,22 @@ export async function start(args: string[] = []) {
 
   await initDiscord(currentSettings.discord.token);
   if (!discordToken) console.log("  Discord: not configured");
+
+  // Wire channel senders into plugin runtime
+  if (pluginManager.hasPlugins) {
+    pluginManager.setChannelSenders({
+      telegram: {
+        sendMessageTelegram: telegramSend
+          ? (chatId: number, text: string) => telegramSend!(chatId, text)
+          : () => Promise.resolve(),
+      },
+      discord: {
+        sendMessageDiscord: discordSendToUser
+          ? (userId: string, text: string) => discordSendToUser!(userId, text)
+          : () => Promise.resolve(),
+      },
+    });
+  }
 
   function isAddrInUse(err: unknown): boolean {
     if (!err || typeof err !== "object") return false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { join, isAbsolute } from "path";
 import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
+import { parsePlugins, type PluginEntry } from "./plugins";
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
@@ -61,6 +62,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  plugins: {},
 };
 
 export interface HeartbeatExcludeWindow {
@@ -113,6 +115,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  plugins: Record<string, PluginEntry>;
 }
 
 export interface AgenticMode {
@@ -274,6 +277,7 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    plugins: parsePlugins(raw.plugins),
   };
 }
 

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,362 @@
+/**
+ * ClaudeClaw Daemon Plugin System
+ *
+ * Provides an OpenClaw-compatible Plugin API for daemon-level plugins.
+ * Plugins hook into lifecycle events that fire AROUND Claude Code invocations
+ * (not inside them — that's handled by Claude Code's native plugin system).
+ *
+ * Usage in settings.json:
+ *   "plugins": {
+ *     "claude-mem": {
+ *       "enabled": true,
+ *       "source": "openclaw",
+ *       "config": { "workerPort": 37777, "project": "myproject" }
+ *     }
+ *   }
+ */
+
+import { join } from "path";
+import { existsSync } from "fs";
+
+// ── Event types ──────────────────────────────────────────────────────────────
+
+export type DaemonEvent =
+  | "gateway_start"
+  | "session_start"
+  | "before_agent_start"
+  | "before_prompt_build"
+  | "tool_result_persist"
+  | "agent_end"
+  | "session_end"
+  | "message_received"
+  | "after_compaction";
+
+export interface EventContext {
+  sessionKey?: string;
+  conversationId?: string;
+  channelId?: string;
+  agentId?: string;
+  workspaceDir?: string;
+}
+
+export type EventHandler = (data: any, ctx: EventContext) => Promise<any> | any;
+
+// ── Plugin API types ─────────────────────────────────────────────────────────
+
+export interface PluginService {
+  id: string;
+  start: (ctx: any) => Promise<void>;
+  stop: (ctx: any) => Promise<void>;
+}
+
+export interface PluginCommand {
+  name: string;
+  description?: string;
+  acceptsArgs?: boolean;
+  handler: (ctx: any) => Promise<any>;
+}
+
+export interface PluginApi {
+  on(event: string, handler: EventHandler): void;
+  registerService(service: PluginService): void;
+  registerCommand(cmd: PluginCommand): void;
+  runtime: {
+    channel: Record<string, Record<string, Function>>;
+  };
+  logger: {
+    info: (...args: any[]) => void;
+    warn: (...args: any[]) => void;
+    error: (...args: any[]) => void;
+    debug: (...args: any[]) => void;
+  };
+  pluginConfig: Record<string, any>;
+}
+
+export type PluginInitFn = (api: PluginApi) => void | Promise<void>;
+
+// ── Settings types ───────────────────────────────────────────────────────────
+
+export interface PluginEntry {
+  enabled: boolean;
+  /** "openclaw" | npm package name | absolute path to plugin dir */
+  source: string;
+  config: Record<string, any>;
+}
+
+// ── Plugin Manager ───────────────────────────────────────────────────────────
+
+export class PluginManager {
+  private handlers = new Map<string, EventHandler[]>();
+  private services = new Map<string, PluginService>();
+  private commands = new Map<string, PluginCommand>();
+  private channelRuntime: Record<string, Record<string, Function>> = {};
+  private workspaceDir: string;
+  private loadedPlugins: string[] = [];
+
+  constructor(workspaceDir: string) {
+    this.workspaceDir = workspaceDir;
+  }
+
+  // ── Loading ────────────────────────────────────────────────────────────
+
+  async loadAll(plugins: Record<string, PluginEntry>): Promise<void> {
+    for (const [id, entry] of Object.entries(plugins)) {
+      if (!entry.enabled) continue;
+      try {
+        await this.loadPlugin(id, entry);
+      } catch (err) {
+        console.error(`[${ts()}] [plugins] Failed to load "${id}":`, err);
+      }
+    }
+  }
+
+  private async loadPlugin(id: string, entry: PluginEntry): Promise<void> {
+    const source = entry.source || "openclaw";
+
+    // For openclaw-source plugins, check worker health first
+    if (source === "openclaw" && entry.config?.workerPort) {
+      const host = entry.config.workerHost || "127.0.0.1";
+      const port = entry.config.workerPort;
+      const healthy = await this.checkHealth(host, port);
+      if (!healthy) {
+        console.warn(`[${ts()}] [plugins] ${id}: worker not running on ${host}:${port}, skipping`);
+        return;
+      }
+    }
+
+    // Resolve plugin module path
+    const modulePath = this.resolvePluginPath(id, source);
+    if (!modulePath) {
+      console.warn(`[${ts()}] [plugins] ${id}: could not resolve module (source: ${source})`);
+      return;
+    }
+
+    // Build scoped API for this plugin
+    const api = this.buildApi(id, entry.config || {});
+
+    // Load and initialize
+    const mod = await import(modulePath);
+    const initFn: PluginInitFn = mod.default || mod;
+    if (typeof initFn !== "function") {
+      console.warn(`[${ts()}] [plugins] ${id}: module does not export a function`);
+      return;
+    }
+
+    await initFn(api);
+    this.loadedPlugins.push(id);
+    console.log(`[${ts()}] [plugins] ${id}: loaded (source: ${source})`);
+  }
+
+  private resolvePluginPath(id: string, source: string): string | null {
+    const candidates: string[] = [];
+
+    if (source.startsWith("/")) {
+      // Absolute path
+      candidates.push(
+        join(source, "openclaw", "dist", "index.js"),
+        join(source, "dist", "index.js"),
+        join(source, "index.js"),
+      );
+    } else if (source === "openclaw") {
+      // OpenClaw plugin format: openclaw/dist/index.js
+      candidates.push(
+        join(this.workspaceDir, ".claude", "claudeclaw", id, "openclaw", "dist", "index.js"),
+        join(this.workspaceDir, "node_modules", id, "openclaw", "dist", "index.js"),
+        join(process.env.HOME || "", ".claude", "plugins", "marketplaces", "thedotmack", "openclaw", "dist", "index.js"),
+        join(process.env.HOME || "", ".openclaw", "extensions", id, "dist", "index.js"),
+      );
+    } else {
+      // npm package or relative path
+      candidates.push(
+        join(this.workspaceDir, "node_modules", source, "dist", "index.js"),
+        join(this.workspaceDir, "node_modules", source, "index.js"),
+      );
+    }
+
+    for (const p of candidates) {
+      if (existsSync(p)) return p;
+    }
+    return null;
+  }
+
+  private async checkHealth(host: string, port: number): Promise<boolean> {
+    try {
+      const res = await fetch(`http://${host}:${port}/api/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private buildApi(pluginId: string, config: Record<string, any>): PluginApi {
+    const self = this;
+    return {
+      on(event: string, handler: EventHandler) {
+        const list = self.handlers.get(event) || [];
+        list.push(handler);
+        self.handlers.set(event, list);
+      },
+      registerService(service: PluginService) {
+        self.services.set(service.id, service);
+      },
+      registerCommand(cmd: PluginCommand) {
+        self.commands.set(cmd.name, cmd);
+      },
+      runtime: {
+        channel: self.channelRuntime,
+      },
+      logger: {
+        info: (...args: any[]) => console.log(`[${ts()}] [${pluginId}]`, ...args),
+        warn: (...args: any[]) => console.warn(`[${ts()}] [${pluginId}]`, ...args),
+        error: (...args: any[]) => console.error(`[${ts()}] [${pluginId}]`, ...args),
+        debug: () => {},
+      },
+      pluginConfig: config,
+    };
+  }
+
+  // ── Services ───────────────────────────────────────────────────────────
+
+  async startServices(): Promise<void> {
+    for (const [id, service] of this.services) {
+      try {
+        await service.start({});
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Service ${id} failed to start:`, err);
+      }
+    }
+  }
+
+  async stopServices(): Promise<void> {
+    for (const [id, service] of this.services) {
+      try {
+        await service.stop({});
+      } catch {}
+    }
+  }
+
+  // ── Channel runtime ────────────────────────────────────────────────────
+
+  setChannelSenders(senders: Record<string, Record<string, Function>>): void {
+    Object.assign(this.channelRuntime, senders);
+  }
+
+  // ── Event emission ─────────────────────────────────────────────────────
+
+  /**
+   * Emit an event to all registered handlers.
+   * For `before_prompt_build`, collects all `appendSystemContext` strings
+   * and returns them concatenated. For other events, returns the last result.
+   */
+  async emit(event: DaemonEvent, data: any, ctx: EventContext): Promise<any> {
+    const handlers = this.handlers.get(event);
+    if (!handlers || handlers.length === 0) return undefined;
+
+    if (event === "before_prompt_build") {
+      // Collect all context injections from all plugins
+      const contexts: string[] = [];
+      for (const handler of handlers) {
+        try {
+          const result = await handler(data, ctx);
+          if (result?.appendSystemContext) {
+            contexts.push(result.appendSystemContext);
+          }
+        } catch (err) {
+          console.warn(`[${ts()}] [plugins] Event ${event} handler error:`, err);
+        }
+      }
+      return contexts.length > 0
+        ? { appendSystemContext: contexts.join("\n\n") }
+        : undefined;
+    }
+
+    // For all other events, run handlers and return last result
+    let result: any;
+    for (const handler of handlers) {
+      try {
+        result = await handler(data, ctx);
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Event ${event} handler error:`, err);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Fire-and-forget emit — does not await handlers.
+   * Use for observations and agent_end where we don't need the result.
+   */
+  emitAsync(event: DaemonEvent, data: any, ctx: EventContext): void {
+    const handlers = this.handlers.get(event);
+    if (!handlers || handlers.length === 0) return;
+    for (const handler of handlers) {
+      try {
+        Promise.resolve(handler(data, ctx)).catch((err) => {
+          console.warn(`[${ts()}] [plugins] Async event ${event} error:`, err);
+        });
+      } catch {}
+    }
+  }
+
+  // ── Commands ───────────────────────────────────────────────────────────
+
+  async runCommand(name: string, args?: string): Promise<string | null> {
+    const cmd = this.commands.get(name);
+    if (!cmd) return null;
+    try {
+      const result = await cmd.handler({ args });
+      return typeof result === "string" ? result : result?.text ?? JSON.stringify(result);
+    } catch {
+      return null;
+    }
+  }
+
+  getCommandNames(): string[] {
+    return Array.from(this.commands.keys());
+  }
+
+  // ── Info ────────────────────────────────────────────────────────────────
+
+  get loaded(): string[] {
+    return this.loadedPlugins;
+  }
+
+  get hasPlugins(): boolean {
+    return this.loadedPlugins.length > 0;
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let manager: PluginManager | null = null;
+
+export function getPluginManager(): PluginManager | null {
+  return manager;
+}
+
+export function setPluginManager(m: PluginManager | null): void {
+  manager = m;
+}
+
+// ── Config parser ────────────────────────────────────────────────────────────
+
+export function parsePlugins(raw: any): Record<string, PluginEntry> {
+  if (!raw || typeof raw !== "object") return {};
+  const result: Record<string, PluginEntry> = {};
+  for (const [id, entry] of Object.entries(raw)) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, any>;
+    result[id] = {
+      enabled: e.enabled ?? false,
+      source: typeof e.source === "string" ? e.source.trim() : "openclaw",
+      config: e.config && typeof e.config === "object" ? e.config : {},
+    };
+  }
+  return result;
+}
+
+function ts() {
+  return new Date().toLocaleTimeString();
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,6 +11,7 @@ import {
 import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
+import { getPluginManager, type EventContext } from "./plugins";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
@@ -58,6 +59,15 @@ export interface RunResult {
 }
 
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
+
+function pluginCtx(threadId?: string): EventContext {
+  return {
+    sessionKey: threadId || "global",
+    conversationId: threadId || "global",
+    channelId: threadId || "global",
+    workspaceDir: process.cwd(),
+  };
+}
 
 // Serial queue — prevents concurrent --resume on the same session
 // Global queue for non-thread messages (backward compatible)
@@ -393,6 +403,11 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     args.push("--resume", existing.sessionId);
   }
 
+  // ── Plugins: before_agent_start ──
+  const pm = getPluginManager();
+  const ctx = pluginCtx(threadId);
+  if (pm) await pm.emit("before_agent_start", { prompt }, ctx);
+
   // Build the appended system prompt: prompt files + directory scoping
   // This is passed on EVERY invocation (not just new sessions) because
   // --append-system-prompt does not persist across --resume.
@@ -410,6 +425,12 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
     }
+  }
+
+  // ── Plugins: before_prompt_build (collect context injections) ──
+  if (pm) {
+    const pluginResult = await pm.emit("before_prompt_build", { prompt }, ctx);
+    if (pluginResult?.appendSystemContext) appendParts.push(pluginResult.appendSystemContext);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -469,6 +490,18 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     exitCode,
   };
 
+  // ── Plugins: observation + agent_end (fire-and-forget) ──
+  if (pm && exitCode === 0) {
+    pm.emitAsync("tool_result_persist", {
+      toolName: name,
+      params: { prompt },
+      message: { content: [{ type: "text", text: stdout.slice(0, 1000) }] },
+    }, ctx);
+    pm.emitAsync("agent_end", {
+      messages: [{ role: "assistant", content: stdout }],
+    }, ctx);
+  }
+
   const output = [
     `# ${name}`,
     `Date: ${new Date().toISOString()}`,
@@ -498,6 +531,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
       timeoutMs
     );
     emitCompactEvent({ type: "auto-compact-done", success: compactOk });
+    if (compactOk && pm) pm.emitAsync("after_compaction", {}, ctx);
 
     if (compactOk) {
       console.log(`[${new Date().toLocaleTimeString()}] Retrying ${name} after compact...`);
@@ -557,6 +591,11 @@ async function streamClaude(
   const { security, model, api } = getSettings();
   const securityArgs = buildSecurityArgs(security);
 
+  // ── Plugins: before_agent_start ──
+  const streamPm = getPluginManager();
+  const streamCtx = pluginCtx();
+  if (streamPm) await streamPm.emit("before_agent_start", { prompt }, streamCtx);
+
   // stream-json gives us events as they happen — text before tool calls,
   // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
   // --verbose is required for stream-json to produce output in -p (print) mode.
@@ -573,6 +612,12 @@ async function streamClaude(
       const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
       if (claudeMd.trim()) appendParts.push(claudeMd.trim());
     } catch {}
+  }
+
+  // ── Plugins: before_prompt_build (collect context injections) ──
+  if (streamPm) {
+    const pluginResult = await streamPm.emit("before_prompt_build", { prompt }, streamCtx);
+    if (pluginResult?.appendSystemContext) appendParts.push(pluginResult.appendSystemContext);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -642,6 +687,14 @@ async function streamClaude(
               hasActivity = true;
             } else if (block.type === "tool_use") {
               hasActivity = true;
+              // ── Plugins: capture per-tool observation from stream ──
+              if (streamPm && block.name) {
+                streamPm.emitAsync("tool_result_persist", {
+                  toolName: block.name,
+                  params: block.input ?? {},
+                  message: { content: [{ type: "text", text: JSON.stringify(block.input ?? {}).slice(0, 500) }] },
+                }, streamCtx);
+              }
             }
           }
           if (hasActivity) maybeUnblock();
@@ -663,6 +716,9 @@ async function streamClaude(
   await proc.exited;
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
+
+  // ── Plugins: agent_end for streaming runs ──
+  if (streamPm) streamPm.emitAsync("agent_end", { messages: [] }, streamCtx);
 
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name}`);
 }


### PR DESCRIPTION
## Summary

- Adds a generic plugin system for ClaudeClaw daemon-level lifecycle events
- Plugins use the same API shape as OpenClaw plugins (`api.on()`, `api.registerService()`, `api.registerCommand()`), so existing OpenClaw plugins like **claude-mem** work without modification
- Core only knows about events and the plugin API — it doesn't know any specific plugin exists
- Zero overhead when no plugins are configured (early returns on empty handler maps)

## Architecture

```
┌─────────────────────────────────────────────┐
│  ClaudeClaw Daemon                          │
│  ┌─ daemon plugin events ─────────────────┐ │
│  │ before_agent_start                     │ │
│  │ before_prompt_build → inject context   │ │
│  │                                        │ │
│  │   ┌─ claude -p ──────────────────────┐ │ │
│  │   │  CC plugin hooks fire here       │ │ │
│  │   │  SessionStart, PostToolUse, etc. │ │ │
│  │   └──────────────────────────────────┘ │ │
│  │                                        │ │
│  │ agent_end → summarize                  │ │
│  └────────────────────────────────────────┘ │
└─────────────────────────────────────────────┘
```

Daemon plugins fire **around** Claude Code invocations (session lifecycle, prompt injection, channel routing). Claude Code's native plugins fire **inside** them (tool-level hooks). Both coexist without conflict.

## Changes

| File | Change |
|---|---|
| `src/plugins.ts` | **NEW** — PluginManager, PluginApi interface, event types, plugin loader/resolver (362 lines) |
| `src/runner.ts` | Event emission at lifecycle points in `execClaude` and `streamClaude` (+56 lines) |
| `src/config.ts` | `plugins` field in Settings interface + parser (+4 lines) |
| `src/commands/start.ts` | Plugin init/shutdown, channel sender wiring (+28 lines) |

## Settings format

```json
"plugins": {
  "claude-mem": {
    "enabled": true,
    "source": "openclaw",
    "config": { "workerPort": 37777, "project": "myproject" }
  }
}
```

## Lifecycle events

`gateway_start`, `session_start`, `before_agent_start`, `before_prompt_build`, `tool_result_persist`, `agent_end`, `session_end`, `message_received`, `after_compaction`

## Test plan

- [x] Plugin loads and initializes on daemon start
- [x] `before_agent_start` → session init in claude-mem worker
- [x] `before_prompt_build` → memory context injected into system prompt
- [x] `tool_result_persist` → observations captured (streaming: per-tool, non-streaming: per-run)
- [x] `agent_end` → summarization triggered
- [x] `after_compaction` → session preserved
- [x] Zero overhead with no plugins configured
- [x] Tested with claude-mem OpenClaw plugin (v12.1.0) end-to-end