### PR TITLE
fix: null-safe mentions check + sessionTimeoutMs config parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .claude
 node_modules
 .codemachine
-AGENTS.md
+AGENTS.md__pycache__/

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -264,7 +264,7 @@ function guildTriggerReason(message: DiscordMessage): string | null {
   if (botUserId && message.referenced_message?.author?.id === botUserId) return "reply_to_bot";
 
   // Mention via mentions array
-  if (botUserId && message.mentions.some((m) => m.id === botUserId)) return "mention";
+  if (botUserId && message.mentions?.some((m) => m.id === botUserId)) return "mention";
 
   // Mention in content (fallback)
   if (botUserId && message.content.includes(`<@${botUserId}>`)) return "mention_in_content";

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  sessionTimeoutMs: 0,
 };
 
 export interface HeartbeatExcludeWindow {
@@ -113,6 +114,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  sessionTimeoutMs: number;
 }
 
 export interface AgenticMode {
@@ -274,6 +276,8 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    sessionTimeoutMs: typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
+      ? raw.sessionTimeoutMs : 0,
   };
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -327,7 +327,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
   const securityArgs = buildSecurityArgs(settings.security);
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
     existing.sessionId,
@@ -378,7 +378,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`


### PR DESCRIPTION
## Bug 1: `message.mentions` TypeError crash

Discord gateway `MESSAGE_CREATE` events sometimes lack the `mentions` array. This causes a `TypeError: undefined is not an object (evaluating 'message.mentions.some')` crash in `guildTriggerReason()`, leading to a systemd restart loop.

**Fix:** Optional chaining `message.mentions?.some()`

## Bug 2: `sessionTimeoutMs` setting ignored

The `sessionTimeoutMs` field in `settings.json` is never parsed by `parseSettings()`, so `runner.ts`'s `(settings as any).sessionTimeoutMs` always returns `undefined`, falling back to the hardcoded 5-minute timeout.

**Fix:**
- Add `sessionTimeoutMs: number` to `Settings` interface
- Parse it in `parseSettings()` (default: 0 = use CLAUDE_TIMEOUT_MS)
- Replace `(settings as any).sessionTimeoutMs` with typed `settings.sessionTimeoutMs` in `runner.ts`

## Files changed
- `src/commands/discord.ts` — optional chaining on mentions
- `src/config.ts` — Settings interface + DEFAULT_SETTINGS + parseSettings
- `src/runner.ts` — typed sessionTimeoutMs access