### PR TITLE
feat: add listenGuilds for guild-wide message listening

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -273,6 +273,9 @@ function guildTriggerReason(message: DiscordMessage): string | null {
   const config = getSettings().discord;
   if (config.listenChannels.includes(message.channel_id)) return "listen_channel";
 
+  // Listen guild (respond to all messages in any channel/thread of this guild)
+  if (message.guild_id && config.listenGuilds?.includes(message.guild_id)) return "listen_guild";
+
   // Thread whose parent channel is a listen channel
   const threadInfo = knownThreads.get(message.channel_id);
   if (threadInfo && config.listenChannels.includes(threadInfo.parentId)) return "listen_channel_thread";

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,7 @@ const DEFAULT_SETTINGS: Settings = {
     forwardToTelegram: true,
   },
   telegram: { token: "", allowedUserIds: [] },
-  discord: { token: "", allowedUserIds: [], listenChannels: [] },
+  discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
@@ -86,6 +86,7 @@ export interface DiscordConfig {
   token: string;
   allowedUserIds: string[]; // Discord snowflake IDs exceed Number.MAX_SAFE_INTEGER
   listenChannels: string[]; // Channel IDs where bot responds to all messages (no mention needed)
+  listenGuilds: string[]; // Guild IDs where bot responds to all messages in any channel/thread
 }
 
 export type SecurityLevel =
@@ -254,6 +255,9 @@ function parseSettings(raw: Record<string, any>): Settings {
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)
         ? raw.discord.listenChannels.map(String)
+        : [],
+      listenGuilds: Array.isArray(raw.discord?.listenGuilds)
+        ? raw.discord.listenGuilds.map(String)
         : [],
     },
     security: {


### PR DESCRIPTION
## Problem

When using `listenChannels` to listen to a specific Discord channel, threads created in that channel rely on an in-memory `knownThreads` map to track parent-child relationships. This map is volatile — after a restart, threads not persisted in `sessions.json` become unresponsive because the bot doesn't recognize them as belonging to a listened channel.

## Solution

Add `discord.listenGuilds`: an array of guild IDs where the bot responds to **all messages** in any channel or thread, without requiring mention or per-channel setup.

```json
{
  "discord": {
    "listenGuilds": ["123456789012345678"]
  }
}
```

This is checked in `guildTriggerReason()` after `listenChannels` — if the message's `guild_id` matches, the bot responds immediately without needing the thread's parent to be tracked.

## Files changed
- `src/config.ts` — `DiscordConfig.listenGuilds`, DEFAULT_SETTINGS, parseSettings
- `src/commands/discord.ts` — `listen_guild` trigger reason

## Backward compatible
- `listenGuilds` defaults to `[]` — no behavior change unless configured
- Existing `listenChannels` behavior is unchanged