### PR TITLE
feat: add configurable jobsPath to load jobs from any directory

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,9 @@ import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone"
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
-const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
+
+export const DEFAULT_JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 
 const DEFAULT_SETTINGS: Settings = {
   model: "",
@@ -61,6 +62,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  jobsPath: "",
 };
 
 export interface HeartbeatExcludeWindow {
@@ -113,6 +115,11 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  /** Path to the directory containing job definition .md files.
+   *  When set, jobs are loaded from this path instead of the default
+   *  .claude/claudeclaw/jobs directory. Absolute paths are used as-is;
+   *  relative paths are resolved from the project root. */
+  jobsPath: string;
 }
 
 export interface AgenticMode {
@@ -152,7 +159,7 @@ let cached: Settings | null = null;
 
 export async function initConfig(): Promise<void> {
   await mkdir(HEARTBEAT_DIR, { recursive: true });
-  await mkdir(JOBS_DIR, { recursive: true });
+  await mkdir(DEFAULT_JOBS_DIR, { recursive: true });
   await mkdir(LOGS_DIR, { recursive: true });
 
   if (!existsSync(SETTINGS_FILE)) {
@@ -274,6 +281,7 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    jobsPath: typeof raw.jobsPath === "string" ? raw.jobsPath.trim() : "",
   };
 }
 

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,7 +1,14 @@
 import { readdir } from "fs/promises";
-import { join } from "path";
+import { join, isAbsolute } from "path";
+import { loadSettings, DEFAULT_JOBS_DIR } from "./config";
 
-const JOBS_DIR = join(process.cwd(), ".claude", "claudeclaw", "jobs");
+async function resolveJobsDir(): Promise<string> {
+  const settings = await loadSettings();
+  if (!settings.jobsPath) return DEFAULT_JOBS_DIR;
+  return isAbsolute(settings.jobsPath)
+    ? settings.jobsPath
+    : join(process.cwd(), settings.jobsPath);
+}
 
 export interface Job {
   name: string;
@@ -55,17 +62,18 @@ function parseJobFile(name: string, content: string): Job | null {
 }
 
 export async function loadJobs(): Promise<Job[]> {
+  const jobsDir = await resolveJobsDir();
   const jobs: Job[] = [];
   let files: string[];
   try {
-    files = await readdir(JOBS_DIR);
+    files = await readdir(jobsDir);
   } catch {
     return jobs;
   }
 
   for (const file of files) {
     if (!file.endsWith(".md")) continue;
-    const content = await Bun.file(join(JOBS_DIR, file)).text();
+    const content = await Bun.file(join(jobsDir, file)).text();
     const job = parseJobFile(file.replace(/\.md$/, ""), content);
     if (job) jobs.push(job);
   }
@@ -73,7 +81,8 @@ export async function loadJobs(): Promise<Job[]> {
 }
 
 export async function clearJobSchedule(jobName: string): Promise<void> {
-  const path = join(JOBS_DIR, `${jobName}.md`);
+  const jobsDir = await resolveJobsDir();
+  const path = join(jobsDir, `${jobName}.md`);
   const content = await Bun.file(path).text();
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!match) return;


### PR DESCRIPTION
## Summary

- Adds a `jobsPath` setting to `settings.json` that points to any directory containing job `.md` files
- When set, jobs are loaded from that path instead of the default `.claude/claudeclaw/jobs`
- Enables storing job definitions directly in an Obsidian vault (or any shared directory), with no wrapper files needed

## Motivation

The current setup requires two files per job: the actual job description (e.g. in Obsidian) and a thin wrapper in `.claude/claudeclaw/jobs/` that just says "go read that file." This is redundant and error-prone — the wrapper path can go stale when the vault is remounted.

With `jobsPath`, you point ClaudeClaw directly at your job definitions directory and they're loaded as-is.

## Changes

**`src/config.ts`**
- Export `DEFAULT_JOBS_DIR` constant (backward-compatible fallback)
- Add `jobsPath: string` to `Settings` interface (defaults to `""` = use built-in path)
- Parse `jobsPath` in `parseSettings`
- Use `DEFAULT_JOBS_DIR` in `initConfig` instead of the now-removed local constant

**`src/jobs.ts`**
- Import `loadSettings` and `DEFAULT_JOBS_DIR` from config
- Add `resolveJobsDir()` helper that reads `jobsPath` from settings at runtime
- `loadJobs` and `clearJobSchedule` both use the resolved directory

## Usage

In `.claude/claudeclaw/settings.json`:
```json
{
  "jobsPath": "/obsidian/AI Personal Assistance/Jobs"
}
```

Job files in that directory need a `schedule` field in their frontmatter:
```yaml
---
job_key: disk-space-monitor
schedule: "0 6 * * *"
recurring: true
---
# Job description goes here...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)