### PR TITLE
Support env vars for Discord/Telegram tokens

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,13 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.0",
-      "keywords": ["cron", "heartbeat", "scheduler", "daemon"],
+      "version": "1.0.1",
+      "keywords": [
+        "cron",
+        "heartbeat",
+        "scheduler",
+        "daemon"
+      ],
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -244,11 +244,11 @@ function parseSettings(raw: Record<string, any>): Settings {
       forwardToTelegram: raw.heartbeat?.forwardToTelegram ?? false,
     },
     telegram: {
-      token: raw.telegram?.token ?? "",
+      token: process.env.TELEGRAM_TOKEN || raw.telegram?.token || "",
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
     },
     discord: {
-      token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
+      token: process.env.DISCORD_TOKEN || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
       allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],

--- a/src/config.ts
+++ b/src/config.ts
@@ -244,11 +244,11 @@ function parseSettings(raw: Record<string, any>): Settings {
       forwardToTelegram: raw.heartbeat?.forwardToTelegram ?? false,
     },
     telegram: {
-      token: process.env.TELEGRAM_TOKEN || raw.telegram?.token || "",
+      token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
     },
     discord: {
-      token: process.env.DISCORD_TOKEN || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
+      token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
       allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],


### PR DESCRIPTION
Hello,

I created this quick fix to read tokens from environment variables so they can be more securely stored, including easier use of secret managers such as the 1Password CLI.

- `DISCORD_TOKEN` and `TELEGRAM_TOKEN` env vars are now checked before falling back to `settings.json` values
- Allows using secret managers like 1Password CLI (`op run`) to inject tokens at runtime without storing them on disk

## Motivation

`settings.json` is the only way to configure bot tokens today, which means they sit in plaintext on disk. This change lets users keep tokens in a secret manager and inject them via environment variables, while remaining fully backward-compatible — if no env var is set, the existing config file value is used as before.

## Test plan

- [ ] Start daemon with `DISCORD_TOKEN` set via env — bot connects
- [ ] Start daemon with `TELEGRAM_TOKEN` set via env — bot connects
- [ ] Start daemon with no env vars and tokens in `settings.json` — existing behavior unchanged
- [ ] Start daemon with both env var and config value — env var takes precedence