### PR TITLE
Add current clock to heartbeat and job prompts

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -7,7 +7,7 @@ import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs } from "../jobs";
 import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
-import { getDayAndMinuteAtOffset } from "../timezone";
+import { getDayAndMinuteAtOffset, buildClockPromptPrefix } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
 import type { Job } from "../jobs";
 
@@ -563,7 +563,8 @@ export async function start(args: string[] = []) {
             .filter((part) => part.length > 0)
             .join("\n\n");
           if (!mergedPrompt) return null;
-          return run("heartbeat", mergedPrompt);
+          const clock = buildClockPromptPrefix(new Date(), currentSettings.timezoneOffsetMinutes);
+          return run("heartbeat", `${clock}\n${mergedPrompt}`);
         })
         .then((r) => {
           if (!r) return;
@@ -697,7 +698,10 @@ export async function start(args: string[] = []) {
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt))
+          .then((prompt) => {
+            const clock = buildClockPromptPrefix(new Date(), currentSettings.timezoneOffsetMinutes);
+            return run(job.name, `${clock}\n${prompt}`);
+          })
           .then((r) => {
             if (job.notify === false) return;
             if (job.notify === "error" && r.exitCode === 0) return;


### PR DESCRIPTION
This PR adds current clock to heartbeat and job prompts. The agent was previously not aware of the current time when running heartbeats or jobs.

**Previously:**
The date in the agent's context is a snapshot from session start. If a session runs long enough, it will drift as the currentDate in the system reminder gets stale relative to when it was loaded. User messages, e.g., from Telegram, help to peace together the current time.

**Proposed Change:**
Inject current clock to heartbeat and job prompt.