### PR TITLE
Adds notify frontmatter support to job creation and editing

### DIFF
--- a/commands/config.md
+++ b/commands/config.md
@@ -40,7 +40,7 @@ Parse `$ARGUMENTS` to identify what the user wants. If no arguments are given, s
    - Enabled: yes/no
    - Address: host:port
 
-3. Also list any cron jobs from `.claude/claudeclaw/jobs/` with their name and schedule.
+3. Also list any cron jobs from `.claude/claudeclaw/jobs/` with their name, schedule, and notify mode.
 4. Remind the user that changes are hot-reloaded every 30s — no daemon restart needed.
 
 ### `heartbeat on` / `heartbeat off` / `heartbeat enable` / `heartbeat disable`

--- a/commands/config.md
+++ b/commands/config.md
@@ -40,7 +40,7 @@ Parse `$ARGUMENTS` to identify what the user wants. If no arguments are given, s
    - Enabled: yes/no
    - Address: host:port
 
-3. Also list any cron jobs from `.claude/claudeclaw/jobs/` with their name, schedule, and notify mode.
+3. Also list any cron jobs from the configured jobs directory (see `jobsDir` in settings, default: `.claude/claudeclaw/jobs/`) with their name, schedule, and notify mode.
 4. Remind the user that changes are hot-reloaded every 30s — no daemon restart needed.
 
 ### `heartbeat on` / `heartbeat off` / `heartbeat enable` / `heartbeat disable`

--- a/commands/jobs.md
+++ b/commands/jobs.md
@@ -51,13 +51,15 @@ Edit an existing cron job.
 1. Read `.claude/claudeclaw/jobs/<job-name>.md`. If it doesn't exist, list available jobs and ask the user which one to edit.
 2. Show the current schedule and prompt.
 3. Use **AskUserQuestion** to ask:
-   - "What do you want to change?" (header: "Edit", options: "Schedule", "Prompt", "Notify", "All")
+   - "What do you want to change?" (header: "Edit", options: "Schedule", "Prompt", "Notify")
 4. Based on the answer:
    - **Schedule**: Ask for a new cron expression with preset options (same as create).
    - **Prompt**: Ask for a new prompt with the current prompt shown for reference.
    - **Notify**: Ask "Should this job notify you on Telegram?" (header: "Notify", options: "Always", "Errors only", "Never"). Map: "Always" → `true`, "Errors only" → `error`, "Never" → `false`.
-   - **All**: Ask all three questions.
-5. Write the updated file and confirm.
+5. Use **AskUserQuestion** to ask:
+   - "Anything else to change?" (header: "Continue", options: "Yes", "No")
+   - If **Yes**, go back to step 3.
+   - If **No**, write the updated file and confirm.
 
 ### `delete` or `remove <job-name>`
 

--- a/commands/jobs.md
+++ b/commands/jobs.md
@@ -16,6 +16,7 @@ Parse `$ARGUMENTS` to identify the sub-command. If no arguments are given, list 
 2. For each file, read it and display:
    - **Job name** (filename without `.md`)
    - **Schedule** (cron expression from frontmatter)
+   - **Notify** (`true`, `false`, or `error` — from frontmatter, default `true`)
    - **Prompt** (body text, truncated to 100 chars if long)
 3. If no jobs exist, tell the user and show how to create one.
 
@@ -29,14 +30,17 @@ Create a new cron job interactively.
 
 2. Then ask:
    - "What prompt should Claude execute?" (header: "Prompt", options: suggest 2-3 prompts relevant to the project context)
+   - "Should this job notify you on Telegram?" (header: "Notify", options: "Always (default)", "Errors only", "Never")
 
 3. Create the job file at `.claude/claudeclaw/jobs/<name>.md` with this exact format:
    ```markdown
    ---
    schedule: "<cron expression>"
+   notify: <true|error|false>
    ---
    <prompt>
    ```
+   Map the notify answer: "Always" → `true`, "Errors only" → `error`, "Never" → `false`. Omit the `notify` line if the user chose "Always" (it's the default).
 
 4. Confirm creation. Remind the user the daemon hot-reloads jobs every 30 seconds — no restart needed.
 
@@ -47,11 +51,12 @@ Edit an existing cron job.
 1. Read `.claude/claudeclaw/jobs/<job-name>.md`. If it doesn't exist, list available jobs and ask the user which one to edit.
 2. Show the current schedule and prompt.
 3. Use **AskUserQuestion** to ask:
-   - "What do you want to change?" (header: "Edit", options: "Schedule", "Prompt", "Both")
+   - "What do you want to change?" (header: "Edit", options: "Schedule", "Prompt", "Notify", "All")
 4. Based on the answer:
    - **Schedule**: Ask for a new cron expression with preset options (same as create).
    - **Prompt**: Ask for a new prompt with the current prompt shown for reference.
-   - **Both**: Ask both questions.
+   - **Notify**: Ask "Should this job notify you on Telegram?" (header: "Notify", options: "Always", "Errors only", "Never"). Map: "Always" → `true`, "Errors only" → `error`, "Never" → `false`.
+   - **All**: Ask all three questions.
 5. Write the updated file and confirm.
 
 ### `delete` or `remove <job-name>`
@@ -96,6 +101,16 @@ Your prompt here. Claude will run this at the scheduled time.
 
 **`recurring`**: If `true`, the job repeats on schedule. If omitted or `false`, the job is **one-shot** — the schedule is removed from the file after it runs.
 Legacy compatibility: `daily` is still accepted in existing job files.
+
+**`notify`**: Controls whether job output is forwarded to Telegram. Accepts three values:
+
+| Value   | Behavior                                           |
+|---------|----------------------------------------------------|
+| `true`  | Always forward output to Telegram **(default)**    |
+| `error` | Only forward if the job fails (non-zero exit code) |
+| `false` | Never forward to Telegram (silent job)             |
+
+Logs are always written to `.claude/claudeclaw/logs/` regardless of the `notify` setting.
 
 | Expression       | Meaning                  |
 |------------------|--------------------------|

--- a/commands/jobs.md
+++ b/commands/jobs.md
@@ -4,7 +4,11 @@ description: "Create, list, edit, or delete cron jobs. Triggers: create a job, a
 
 Manage cron jobs for the heartbeat daemon. Use `$ARGUMENTS` to determine the action.
 
-**CRITICAL: Job files MUST be created in the project-relative path `.claude/claudeclaw/jobs/`, NOT in `~/.claude/claudeclaw/jobs/`.** The daemon only watches the project directory. Using the home directory path will silently fail — the job will never fire.
+## Resolving the jobs directory
+
+Read `.claude/claudeclaw/settings.json`. If the `jobsDir` field is set, use that path (resolve relative paths against the project root). Otherwise use the default: `.claude/claudeclaw/jobs/`.
+
+**CRITICAL: Job files MUST live under the project-relative jobs directory, NOT under `~/.claude/claudeclaw/jobs/`.** The daemon only watches the project directory. Using the home directory path will silently fail — the job will never fire.
 
 Parse `$ARGUMENTS` to identify the sub-command. If no arguments are given, list all jobs.
 
@@ -12,7 +16,7 @@ Parse `$ARGUMENTS` to identify the sub-command. If no arguments are given, list 
 
 ### `list` (default when no arguments)
 
-1. List all `.md` files in `.claude/claudeclaw/jobs/`.
+1. List all `.md` files in the jobs directory.
 2. For each file, read it and display:
    - **Job name** (filename without `.md`)
    - **Schedule** (cron expression from frontmatter)
@@ -30,9 +34,9 @@ Create a new cron job interactively.
 
 2. Then ask:
    - "What prompt should Claude execute?" (header: "Prompt", options: suggest 2-3 prompts relevant to the project context)
-   - "Should this job notify you on Telegram?" (header: "Notify", options: "Always (default)", "Errors only", "Never")
+   - "Should this job send notifications?" (header: "Notify", options: "Always (default)", "Errors only", "Never")
 
-3. Create the job file at `.claude/claudeclaw/jobs/<name>.md` with this exact format:
+3. Create the job file at `<jobs-directory>/<name>.md` with this exact format:
    ```markdown
    ---
    schedule: "<cron expression>"
@@ -48,14 +52,14 @@ Create a new cron job interactively.
 
 Edit an existing cron job.
 
-1. Read `.claude/claudeclaw/jobs/<job-name>.md`. If it doesn't exist, list available jobs and ask the user which one to edit.
+1. Read `<jobs-directory>/<job-name>.md`. If it doesn't exist, list available jobs and ask the user which one to edit.
 2. Show the current schedule and prompt.
 3. Use **AskUserQuestion** to ask:
    - "What do you want to change?" (header: "Edit", options: "Schedule", "Prompt", "Notify")
 4. Based on the answer:
    - **Schedule**: Ask for a new cron expression with preset options (same as create).
    - **Prompt**: Ask for a new prompt with the current prompt shown for reference.
-   - **Notify**: Ask "Should this job notify you on Telegram?" (header: "Notify", options: "Always", "Errors only", "Never"). Map: "Always" → `true`, "Errors only" → `error`, "Never" → `false`.
+   - **Notify**: Ask "Should this job send notifications?" (header: "Notify", options: "Always", "Errors only", "Never"). Map: "Always" → `true`, "Errors only" → `error`, "Never" → `false`.
 5. Use **AskUserQuestion** to ask:
    - "Anything else to change?" (header: "Continue", options: "Yes", "No")
    - If **Yes**, go back to step 3.
@@ -67,14 +71,14 @@ Delete a cron job.
 
 1. If no job name given in `$ARGUMENTS`, list all jobs and use **AskUserQuestion** to ask which one to delete.
 2. Confirm deletion with **AskUserQuestion**: "Delete job '<name>'? This cannot be undone." (header: "Confirm", options: "Yes, delete it", "No, keep it")
-3. If confirmed, delete `.claude/claudeclaw/jobs/<job-name>.md`.
+3. If confirmed, delete `<jobs-directory>/<job-name>.md`.
 4. Confirm deletion. The daemon will pick up the change on the next hot-reload cycle (within 30s).
 
 ### `run <job-name>`
 
 Manually trigger a cron job immediately (useful for testing).
 
-1. Read `.claude/claudeclaw/jobs/<job-name>.md`. If it doesn't exist, list available jobs.
+1. Read `<jobs-directory>/<job-name>.md`. If it doesn't exist, list available jobs.
 2. Show the job's prompt and ask for confirmation: "Run job '<name>' now?" (header: "Run", options: "Yes", "No")
 3. If confirmed, run the prompt by executing:
    ```bash
@@ -87,7 +91,7 @@ Manually trigger a cron job immediately (useful for testing).
 
 ## Reference: Job File Format
 
-Jobs live in `.claude/claudeclaw/jobs/` as markdown files:
+Jobs live in the configured jobs directory (default: `.claude/claudeclaw/jobs/`) as markdown files:
 
 ```markdown
 ---
@@ -104,13 +108,13 @@ Your prompt here. Claude will run this at the scheduled time.
 **`recurring`**: If `true`, the job repeats on schedule. If omitted or `false`, the job is **one-shot** — the schedule is removed from the file after it runs.
 Legacy compatibility: `daily` is still accepted in existing job files.
 
-**`notify`**: Controls whether job output is forwarded to Telegram. Accepts three values:
+**`notify`**: Controls whether job output is forwarded to configured messaging platforms (Telegram, Discord). Accepts three values:
 
-| Value   | Behavior                                           |
-|---------|----------------------------------------------------|
-| `true`  | Always forward output to Telegram **(default)**    |
-| `error` | Only forward if the job fails (non-zero exit code) |
-| `false` | Never forward to Telegram (silent job)             |
+| Value   | Behavior                                                         |
+|---------|------------------------------------------------------------------|
+| `true`  | Always forward output to messaging platforms **(default)**       |
+| `error` | Only forward if the job fails (non-zero exit code)               |
+| `false` | Never forward (silent job)                                       |
 
 Logs are always written to `.claude/claudeclaw/logs/` regardless of the `notify` setting.
 


### PR DESCRIPTION
Adds the notify option to the job management commands so users can control whether job output is forwarded to Telegram when creating, listing, or editing jobs.