### PR TITLE
fix: Superfluous addition of prompt templates with every invocation

### DIFF
--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -1,4 +1,4 @@
-import { runUserMessage } from "../runner";
+import { runUserMessage, ensureProjectClaudeMd } from "../runner";
 import { getSession } from "../sessions";
 import { loadSettings, initConfig } from "../config";
 
@@ -14,6 +14,7 @@ export async function send(args: string[]) {
 
   await initConfig();
   await loadSettings();
+  await ensureProjectClaudeMd();
 
   const session = await getSession();
   if (!session) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -393,23 +393,20 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     args.push("--resume", existing.sessionId);
   }
 
-  // Build the appended system prompt: prompt files + directory scoping
+  // Build the appended system prompt: CLAUDE.md + directory scoping
   // This is passed on EVERY invocation (not just new sessions) because
   // --append-system-prompt does not persist across --resume.
-  const promptContent = await loadPrompts();
+  // Prompt files (IDENTITY.md, USER.md, SOUL.md) are already embedded in
+  // CLAUDE.md by ensureProjectClaudeMd(), which runs before every call.
   const appendParts: string[] = [
     "You are running inside ClaudeClaw.",
   ];
-  if (promptContent) appendParts.push(promptContent);
 
-  // Load the project's CLAUDE.md if it exists
-  if (existsSync(PROJECT_CLAUDE_MD)) {
-    try {
-      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
-      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
-    } catch (e) {
-      console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
-    }
+  try {
+    const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+    if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+  } catch (e) {
+    console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -564,16 +561,12 @@ async function streamClaude(
 
   if (existing) args.push("--resume", existing.sessionId);
 
-  const promptContent = await loadPrompts();
   const appendParts: string[] = ["You are running inside ClaudeClaw."];
-  if (promptContent) appendParts.push(promptContent);
 
-  if (existsSync(PROJECT_CLAUDE_MD)) {
-    try {
-      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
-      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
-    } catch {}
-  }
+  try {
+    const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+    if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+  } catch {}
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
   if (appendParts.length > 0) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -431,23 +431,20 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
     args.push("--resume", existing.sessionId);
   }
 
-  // Build the appended system prompt: prompt files + directory scoping
+  // Build the appended system prompt: CLAUDE.md + directory scoping
   // This is passed on EVERY invocation (not just new sessions) because
   // --append-system-prompt does not persist across --resume.
-  const promptContent = await loadPrompts();
+  // Prompt files (IDENTITY.md, USER.md, SOUL.md) are already embedded in
+  // CLAUDE.md by ensureProjectClaudeMd(), which runs before every call.
   const appendParts: string[] = [
     "You are running inside ClaudeClaw.",
   ];
-  if (promptContent) appendParts.push(promptContent);
 
-  // Load the project's CLAUDE.md if it exists
-  if (existsSync(PROJECT_CLAUDE_MD)) {
-    try {
-      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
-      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
-    } catch (e) {
-      console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
-    }
+  try {
+    const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+    if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+  } catch (e) {
+    console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -600,16 +597,12 @@ async function streamClaude(
 
   if (existing) args.push("--resume", existing.sessionId);
 
-  const promptContent = await loadPrompts();
   const appendParts: string[] = ["You are running inside ClaudeClaw."];
-  if (promptContent) appendParts.push(promptContent);
 
-  if (existsSync(PROJECT_CLAUDE_MD)) {
-    try {
-      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
-      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
-    } catch {}
-  }
+  try {
+    const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+    if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+  } catch {}
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
   if (appendParts.length > 0) {


### PR DESCRIPTION
This PR addresses some points raised in issue #51, namely the contents of `CLAUDE.md` (that is created from the *template* documents `IDENTITY.md`, `USER.md`, `SOUL.md`) **AND** the *templates* themselves, all are added twice in every system prompt.

**IMPORTANT:** According to the documentation of Claude Code, the contents of `CLAUDE.md` are added automatically as the first user message to every session. Hence, we might have contents of `CLAUDE.md` in every session twice even after accepting this PR (trice before this PR). This issue remains untouched by this PR. *I propose renaming `CLAUDE.md` to something else.*

**Technical Description**
`ensureProjectClaudeMd()` already embeds the prompt files (`IDENTITY.md`, `USER.md`, `SOUL.md`) into the project-root `CLAUDE.md` via managed blocks, and it runs before every `execClaude()` call. Despite this, both functions were independently calling `loadPrompts()` and appending the raw prompt content to `--append-system-prompt` **in addition to** reading `CLAUDE.md`, resulting in the same template text appearing **twice in every system prompt**. Meanwhile, `CLAUDE.md` is the file that actually evolves over time (user and agent edit it), while the plugin's prompt files `IDENTITY.md`, `USER.md`, `SOUL.md` remain static *templates* unless someone finds out about them.

This PR removes the `loadPrompts()` calls from `execClaude()` and `streamClaude()` so both now read solely from `CLAUDE.md` as the single source of truth for appended system prompt content. `loadPrompts()` itself is retained because it's still used by `ensureProjectClaudeMd()` to generate the managed block during initial `CLAUDE.md` creation. If `CLAUDE.md` can't be read at runtime (e.g. the earlier write failed), the invocation proceeds with just the baseline "You are running inside ClaudeClaw." preamble rather than silently falling back to the raw templates.