### PR TITLE
Fix "command line is too long" on Windows by bypassing claude.cmd

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { join } from "path";
+import { join, dirname } from "path";
 import { existsSync } from "fs";
+import { execSync } from "child_process";
 import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
 import {
   getThreadSession,
@@ -22,6 +23,37 @@ const PROJECT_CLAUDE_MD = join(process.cwd(), "CLAUDE.md");
 const LEGACY_PROJECT_CLAUDE_MD = join(process.cwd(), ".claude", "CLAUDE.md");
 const CLAUDECLAW_BLOCK_START = "<!-- claudeclaw:managed:start -->";
 const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
+
+/**
+ * On Windows, `claude` resolves to `claude.cmd`, a batch wrapper that must
+ * be run through cmd.exe (8191-char command-line limit). Resolving the
+ * underlying `claude.exe` lets us call it directly via CreateProcessW
+ * (32767-char limit). This is required because --append-system-prompt +
+ * prompt files + CLAUDE.md can easily exceed 8K.
+ */
+function resolveClaudeExecutable(): string {
+  if (process.platform !== "win32") return "claude";
+  try {
+    const out = execSync("where claude", { encoding: "utf8" });
+    const cmdPath = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find((s) => s.toLowerCase().endsWith(".cmd"));
+    if (!cmdPath) return "claude";
+    const exePath = join(
+      dirname(cmdPath),
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "bin",
+      "claude.exe"
+    );
+    return existsSync(exePath) ? exePath : "claude";
+  } catch {
+    return "claude";
+  }
+}
+const CLAUDE_EXECUTABLE = resolveClaudeExecutable();
 
 /**
  * Compact configuration.
@@ -303,7 +335,7 @@ export async function runCompact(
   timeoutMs: number
 ): Promise<boolean> {
   const compactArgs = [
-    "claude", "-p", "/compact",
+    CLAUDE_EXECUTABLE, "-p", "/compact",
     "--output-format", "text",
     "--resume", sessionId,
     ...securityArgs,
@@ -387,7 +419,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   // New session: use json output to capture Claude's session_id
   // Resumed session: use text output with --resume
   const outputFormat = isNew ? "json" : "text";
-  const args = ["claude", "-p", prompt, "--output-format", outputFormat, ...securityArgs];
+  const args = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", outputFormat, ...securityArgs];
 
   if (!isNew) {
     args.push("--resume", existing.sessionId);
@@ -560,7 +592,7 @@ async function streamClaude(
   // stream-json gives us events as they happen — text before tool calls,
   // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
   // --verbose is required for stream-json to produce output in -p (print) mode.
-  const args = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+  const args = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
 
   if (existing) args.push("--resume", existing.sessionId);
 


### PR DESCRIPTION
## Summary
- Every ClaudeClaw invocation on Windows fails with `stderr: "The command line is too long"` and exit code 1, because `Bun.spawn(["claude", ...])` resolves to `claude.cmd`, which must be run through `cmd.exe` (8191-char command-line limit). Once `--append-system-prompt` includes the prompt files + project `CLAUDE.md`, the payload exceeds that limit.
- Fix: resolve the underlying `claude.exe` (shipped inside `@anthropic-ai/claude-code`) and invoke it directly, using `CreateProcessW` (32767-char limit). No-op on non-Windows platforms; falls back to `"claude"` if the `.exe` can't be located.

## Root cause
On Windows, npm installs `claude` as three wrappers in the npm bin directory:
- `claude` (bash, no extension)
- `claude.cmd` ← Windows picks this via PATHEXT
- `claude.ps1`

The `.cmd` file just forwards `%*` to `node_modules\@anthropic-ai\claude-code\bin\claude.exe`. Executing a `.cmd` requires `cmd.exe`, which caps command lines at **8191 chars**. A typical ClaudeClaw call passes:
- `-p <prompt>` (~700 chars for heartbeat template)
- `--append-system-prompt "<IDENTITY + USER + SOUL + CLAUDE.md>"` (~9.5 KB in a fresh install)
- security/model/resume flags (~100 chars)

After Windows quote-escaping of embedded newlines and quotes, total easily exceeds 8K. Every spawn returns exit 1 with `The command line is too long` on stderr. Nothing gets to Claude.

Repro (Windows only):
1. Fresh ClaudeClaw install (`/claudeclaw:start`) with default prompt files.
2. Enable heartbeat or send a Telegram message to the bot.
3. `.claude/claudeclaw/logs/*.log` shows exit code 1, empty output, stderr `"The command line is too long."`

## Fix
Invoke `claude.exe` directly instead of going through `claude.cmd`:

```ts
function resolveClaudeExecutable(): string {
  if (process.platform !== "win32") return "claude";
  try {
    const out = execSync("where claude", { encoding: "utf8" });
    const cmdPath = out.split(/\r?\n/).map(s => s.trim())
      .find(s => s.toLowerCase().endsWith(".cmd"));
    if (!cmdPath) return "claude";
    const exePath = join(
      dirname(cmdPath),
      "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe"
    );
    return existsSync(exePath) ? exePath : "claude";
  } catch {
    return "claude";
  }
}
const CLAUDE_EXECUTABLE = resolveClaudeExecutable();
```

Then replace the three hardcoded `"claude"` literals in the spawn-arg arrays (`runCompact`, `execClaude`, `streamClaude`) with `CLAUDE_EXECUTABLE`. Total diff: +36 / -4 lines in one file.

Calling `claude.exe` directly skips `cmd.exe` entirely — Windows uses `CreateProcessW` which accepts up to **32767 chars**, comfortably above realistic payloads.

## Before / after (Windows 11, Bun 1.3.12)

**Before** — `bootstrap-*.log`:
```
Exit code: 1
## Output
## Stderr
The command line is too long.
```

**After** — same prompt, same fresh install:
```
Session: 2ce45a12-332f-43cf-89be-aa96e80607e1 (new)
Exit code: 0
## Output
I'm Claw. Ghost in the machine, sharp-but-warm, here to help.
...
```

Round-trip test via Telegram bot:
- `[5:39:04 PM] Telegram 8660881667: "Hey, is the patch working?"`
- `[5:39:04 PM] Running: telegram (resume 2ce45a12, security: unrestricted)`
- `[5:39:15 PM] Done: telegram → ...log` (exit 0, real reply delivered)

## Risk / compatibility
- **Non-Windows**: `resolveClaudeExecutable()` returns `"claude"` unchanged → zero behavior change.
- **Non-standard installs** (not npm, or unusual layout): `.exe` not found at the expected relative path → falls back to `"claude"`, which is the current behavior. **No regression possible.**
- **Memoization**: result is cached at module load. Daemon restart required after `claude` install path changes, but that's unusual.
- **`where` availability**: built into every modern Windows (Vista+).

## Test plan
- [x] Bootstrap on Windows produces exit 0 + real session ID
- [x] Heartbeat round-trip produces exit 0
- [x] Telegram round-trip produces exit 0, reply delivered to user chat
- [ ] Verify on Linux (should be no-op — `"claude"` unchanged)
- [ ] Verify on macOS (should be no-op)
- [ ] Verify fallback path when `where claude` fails (non-npm install)