### PR TITLE
fix: wire sessionTimeoutMs through parseSettings and fix Discord error display

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -641,7 +641,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt, threadId);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stdout || result.stderr || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  sessionTimeoutMs: 30 * 60 * 1000,
 };
 
 export interface HeartbeatExcludeWindow {
@@ -113,6 +114,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  sessionTimeoutMs: number;
 }
 
 export interface AgenticMode {
@@ -274,6 +276,9 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    sessionTimeoutMs: typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
+      ? raw.sessionTimeoutMs
+      : 30 * 60 * 1000,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,9 @@ const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
 
+/** Default Claude session timeout (30 minutes). Exported so runner.ts can reference the same value. */
+export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
 const DEFAULT_SETTINGS: Settings = {
   model: "",
   api: "",
@@ -61,7 +64,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
-  sessionTimeoutMs: 30 * 60 * 1000,
+  sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
 };
 
 export interface HeartbeatExcludeWindow {
@@ -278,7 +281,7 @@ function parseSettings(raw: Record<string, any>): Settings {
     },
     sessionTimeoutMs: typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
       ? raw.sessionTimeoutMs
-      : 30 * 60 * 1000,
+      : DEFAULT_SESSION_TIMEOUT_MS,
   };
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,7 +8,7 @@ import {
   incrementThreadTurn,
   markThreadCompactWarned,
 } from "./sessionManager";
-import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
+import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
 
@@ -116,15 +116,12 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
   return childEnv;
 }
 
-/** Default timeout for a single Claude Code invocation (5 minutes). */
-const CLAUDE_TIMEOUT_MS = 5 * 60 * 1000;
-
 async function runClaudeOnce(
   baseArgs: string[],
   model: string,
   api: string,
   baseEnv: Record<string, string>,
-  timeoutMs: number = CLAUDE_TIMEOUT_MS
+  timeoutMs: number = DEFAULT_SESSION_TIMEOUT_MS
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -327,7 +327,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
   const securityArgs = buildSecurityArgs(settings.security);
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs;
 
   const ok = await runCompact(
     existing.sessionId,
@@ -378,7 +378,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`


### PR DESCRIPTION
## Summary

- **`sessionTimeoutMs` silently ignored**: `parseSettings()` didn't include `sessionTimeoutMs` in its return, so the value was stripped on every settings load. `runner.ts` used `(settings as any).sessionTimeoutMs` expecting it to pass through, but it always fell back to the hardcoded 5-minute `CLAUDE_TIMEOUT_MS`. Long-running jobs (digests, batch processing) consistently timed out at 300s regardless of what was set in `settings.json`.
- **Discord showed "Unknown error" on failures**: When Claude exits with code 1, the human-readable error is written to `stdout` as JSON, not `stderr`. The error display checked `stderr` first, which is always empty in this case, so users always saw `"Unknown error"` instead of the actual failure reason (e.g. "Autocompact is thrashing", "Prompt is too long").

## Changes

- `src/config.ts`: Add `sessionTimeoutMs: number` to `Settings` interface and `DEFAULT_SETTINGS` (30 min default); parse it in `parseSettings()` with validation
- `src/runner.ts`: Replace `(settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS` with `settings.sessionTimeoutMs` at both call sites
- `src/commands/discord.ts`: Fix error display order to `result.stdout || result.stderr || "Unknown error"`

## Test plan

- [ ] Set `sessionTimeoutMs: 60000` in `settings.json`, trigger a long-running job, confirm it times out at 60s not 300s
- [ ] Set `sessionTimeoutMs: 1800000`, confirm long jobs complete without premature timeout
- [ ] Trigger a Claude exit-1 condition, confirm Discord shows the actual error text instead of "Unknown error"