### PR TITLE
fix(runner): strip parent OAuth + host-managed env from spawned claude

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -54,13 +54,17 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * resolves credentials using its own per-platform code path.
  */
 function cleanSpawnEnv(): Record<string, string> {
-  const {
-    CLAUDECODE: _cc,
-    CLAUDE_CODE_OAUTH_TOKEN: _tok,
-    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: _mgr,
-    ...rest
-  } = process.env;
-  return rest as Record<string, string>;
+  const stripped = new Set([
+    "CLAUDECODE",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+  ]);
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (stripped.has(key)) continue;
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
 }
 
 export type CompactEvent =

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -31,6 +31,38 @@ const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
 const COMPACT_WARN_THRESHOLD = 25;
 const COMPACT_TIMEOUT_ENABLED = true;
 
+/**
+ * Build a sanitized env for spawning the `claude` CLI as a long-running daemon
+ * subprocess. Drops env vars injected by a parent Claude Code / Claude Desktop
+ * session that break detached child auth:
+ *
+ * - `CLAUDECODE`: marks "we're nested inside Claude Code" — confuses the CLI's
+ *   reentry detection and triggers transcript-aware behaviour we don't want.
+ * - `CLAUDE_CODE_OAUTH_TOKEN`: the parent's frozen OAuth access token. Without
+ *   the matching refresh token (which lives in the platform-native credential
+ *   store, not the env), it expires after ~8h and the daemon's spawned `claude`
+ *   processes start returning HTTP 401 silently. Stripping it lets the CLI
+ *   fall back to the credential store on each platform — Keychain on macOS,
+ *   `~/.claude/.credentials.json` on Linux/WSL2, Credential Manager on Windows
+ *   — which handles refresh automatically.
+ * - `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`: tells the CLI "the host process
+ *   manages provider auth — don't read local credentials." In a detached
+ *   daemon there is no host to consult; the CLI errors with `Not logged in`.
+ *
+ * Cross-platform note: the helper just deletes keys from the inherited env
+ * object — no shell, no OS-specific calls. The `claude` CLI it spawns then
+ * resolves credentials using its own per-platform code path.
+ */
+function cleanSpawnEnv(): Record<string, string> {
+  const {
+    CLAUDECODE: _cc,
+    CLAUDE_CODE_OAUTH_TOKEN: _tok,
+    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: _mgr,
+    ...rest
+  } = process.env;
+  return rest as Record<string, string>;
+}
+
 export type CompactEvent =
   | { type: "warn"; turnCount: number }
   | { type: "auto-compact-start" }
@@ -325,8 +357,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
 
   const settings = getSettings();
   const securityArgs = buildSecurityArgs(settings.security);
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const baseEnv = cleanSpawnEnv();
   const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
@@ -417,9 +448,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     args.push("--append-system-prompt", appendParts.join("\n\n"));
   }
 
-  // Strip CLAUDECODE env var so child claude processes don't think they're nested
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const baseEnv = cleanSpawnEnv();
 
   let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
@@ -583,8 +612,7 @@ async function streamClaude(
   const normalizedModel = model.trim().toLowerCase();
   if (model.trim() && normalizedModel !== "glm") args.push("--model", model.trim());
 
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const childEnv = buildChildEnv(cleanEnv as Record<string, string>, model, api);
+  const childEnv = buildChildEnv(cleanSpawnEnv(), model, api);
 
   console.log(`[${new Date().toLocaleTimeString()}] Running: ${name} (stream-json, session: ${existing?.sessionId?.slice(0, 8) ?? "new"})`);
 


### PR DESCRIPTION
## Why

When ClaudeClaw is launched from inside Claude Code or Claude Desktop (i.e. via the bundled `/claudeclaw:start` slash command), the daemon process inherits two env vars from the parent session:

| Var | Source | Effect when forwarded to a spawned `claude` |
|---|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` | Claude Desktop / Code injects per session | Frozen access token. Refresh token is not in env (lives in OS credential store), so when this token expires (~8 h) the spawned `claude` returns HTTP 401 silently — heartbeat + Telegram + Discord all fall over with no user-visible error. |
| `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1` | Same | Tells the CLI "host process manages provider auth — do not consult local credentials." In a detached daemon there is no host to consult, so the CLI cannot fall back to its own credential store either. |

Today `runner.ts` strips `CLAUDECODE` from spawned subprocess env (correctly, to prevent re-entry detection) but lets both of the above leak through. After ~8 h, every heartbeat / chat reply silently 401s and the daemon looks alive but is fully broken.

## Repro

1. Launch `/claudeclaw:start` from a Claude Code session
2. Restart Claude Desktop (this rotates the parent OAuth token in env)
3. Wait until the daemon's frozen token expires (~8 h after launch)
4. `heartbeat-*.log` shows `API Error: 401 {"type":"authentication_error","message":"Invalid authentication credentials"}` on every tick
5. Telegram messages get no reply

I hit this naturally yesterday after a Desktop restart. Before the diagnosis I was confused why heartbeats appeared "Done" in `daemon.log` but produced no output — the per-run log files all had the 401.

## Fix

Extract a `cleanSpawnEnv()` helper that strips all three vars, use it at every spawn site:

- `compactCurrentSession` (line 358 before, single call)
- `execClaude` (line 421 before)
- `streamClaude` (line 612 before, also passes through `buildChildEnv`)

```ts
function cleanSpawnEnv(): Record<string, string> {
  const stripped = new Set([
    "CLAUDECODE",
    "CLAUDE_CODE_OAUTH_TOKEN",
    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
  ]);
  const out: Record<string, string> = {};
  for (const [key, value] of Object.entries(process.env)) {
    if (stripped.has(key)) continue;
    if (typeof value === "string") out[key] = value;
  }
  return out;
}
```

After the strip, the `claude` CLI falls back to its platform-native credential store (Keychain on macOS, `~/.claude/.credentials.json` on Linux/WSL2, Credential Manager on Windows), which holds the refresh token and rotates the access token automatically — daemon survives parent-token rotation indefinitely.

## Cross-platform

The helper is pure JS env-key deletion — no shell, no OS-specific calls. The same code path runs on every platform claudeclaw supports; the per-OS credential resolution happens inside `claude` itself.

## Test plan

- [x] **Type-check**: `bunx tsc --noEmit` — clean for `src/runner.ts`. Remaining errors live in `lib.dom.d.ts` / `bun-types/wasm.d.ts` (toolchain) and `src/ui/server.ts`, `src/whisper.ts` (pre-existing, unrelated).
- [x] **Live verification on macOS**:
  - Reproduced the failure mode (daemon launched from Claude Code, OAuth token in parent env, all heartbeats hitting 401 in per-run logs)
  - Patched in this branch
  - Re-launched the daemon from the same poisoned parent env
  - Spawned `claude` subprocesses now resolve credentials via Keychain and succeed (`PONG` round-trip via `env -u CLAUDE_CODE_OAUTH_TOKEN -u CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST claude --print "say PONG"` — same env shape the helper produces)
- [ ] **Linux / WSL2**: not retested locally; the helper is environment-only so behaviour should be identical, but please flag if your CI covers that path.

## Scope of the behaviour change

This is a **deliberate auth-behaviour change** for spawned subprocesses, not a neutral refactor — flagging it explicitly per [@TerrysPOV](https://github.com/TerrysPOV)'s review.

What changes:
- Spawned `claude` invocations no longer see `CLAUDE_CODE_OAUTH_TOKEN` or `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` from the parent session, so they resolve credentials from the platform credential store instead of inheriting the host's frozen token. This is the intended fix.
- The explicit API-token path via `buildChildEnv()` / `ANTHROPIC_AUTH_TOKEN` is preserved, so users pinning a token via settings are unaffected.
- Users who deliberately set `CLAUDE_CODE_OAUTH_TOKEN` in their shell environment (rare — `ANTHROPIC_API_KEY` is the documented path) will see the daemon fall back to keychain auth instead. In a daemon context that is almost certainly what they want, but it is not "no behaviour change."

Worth a maintainer eyeball on whether the policy ("treat spawned `claude` as detached, never host-managed") is the right default; if there's a use case for honouring an explicitly-set parent OAuth token, this could be gated by an opt-in setting.
