### PR TITLE
feat(config): substitute $VAR env-var references in settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,37 @@ Then open a Claude Code session and run:
 ```
 The setup wizard walks you through model, heartbeat, Telegram, Discord, and security, then your daemon is live with a web dashboard.
 
+### Env-var references in `settings.json`
+
+Any string field in `.claude/claudeclaw/settings.json` can reference an
+environment variable instead of inlining the value — useful for keeping
+the file committable while secrets stay in a gitignored shell env file,
+a keychain, or a secrets manager.
+
+```jsonc
+{
+  "model": "opus",
+  "api": "$ANTHROPIC_API_KEY",
+  "fallback": { "model": "glm", "api": "${GLM_API_KEY}" },
+  "telegram": { "token": "${TELEGRAM_BOT_TOKEN:-}" },
+  "discord":  { "token": "$DISCORD_BOT_TOKEN" }
+}
+```
+
+Supported syntax (shell-like):
+
+| Form | Meaning |
+|---|---|
+| `$VAR` | Substitute `process.env.VAR`, or leave literal if unset |
+| `${VAR}` | Same, useful for embedding: `"pre-${VAR}-post"` |
+| `${VAR:-default}` | Use `default` when `VAR` is unset |
+| `$$` | Literal `$` character |
+
+Applies to **every** string leaf — object keys, numbers, arrays of
+numbers, and booleans are never rewritten. Unresolved references with no
+default are left literal and logged once per variable name so
+misconfiguration is visible at startup.
+
 ## What Would Be Built Next?
 
 > **Mega Post:** Help shape the next ClaudeClaw features.

--- a/src/config.ts
+++ b/src/config.ts
@@ -362,11 +362,16 @@ const ENV_VAR_PATTERN = /\$(?:\$|\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}|([A-
  * string field — telegram.token, discord.token, api, fallback.api, future
  * additions — with zero per-field plumbing.
  */
-export function substituteEnvVars(
-  value: unknown,
-  env: Record<string, string | undefined> = process.env,
-  warned: Set<string> = new Set()
-): any {
+const warnedEnvVars = new Set<string>();
+
+export function substituteEnvVars<T>(
+  value: T,
+  env: Record<string, string | undefined> = process.env
+): T {
+  return substitute(value, env) as T;
+}
+
+function substitute(value: unknown, env: Record<string, string | undefined>): unknown {
   if (typeof value === "string") {
     return value.replace(ENV_VAR_PATTERN, (match, braceName, braceDefault, bareName) => {
       if (match === "$$") return "$";
@@ -374,18 +379,18 @@ export function substituteEnvVars(
       const resolved = env[name];
       if (resolved !== undefined) return resolved;
       if (braceDefault !== undefined) return braceDefault;
-      if (!warned.has(name)) {
+      if (!warnedEnvVars.has(name)) {
         console.warn(`[config] Env var "$${name}" not set — leaving placeholder in settings`);
-        warned.add(name);
+        warnedEnvVars.add(name);
       }
       return match;
     });
   }
-  if (Array.isArray(value)) return value.map((v) => substituteEnvVars(v, env, warned));
+  if (Array.isArray(value)) return value.map((v) => substitute(v, env));
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = substituteEnvVars(v, env, warned);
+      out[k] = substitute(v, env);
     }
     return out;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -331,10 +331,71 @@ function extractDiscordUserIds(rawText: string): string[] {
   return items;
 }
 
+/**
+ * Matches `$VAR`, `${VAR}`, or `${VAR:-default}` env-var references.
+ * VAR is a standard POSIX-ish identifier: `[A-Za-z_][A-Za-z0-9_]*`.
+ *
+ * Capture groups:
+ *   1. VAR  (from `${VAR}` / `${VAR:-default}`)
+ *   2. default value  (from `${VAR:-default}`, may be empty)
+ *   3. VAR  (from bare `$VAR`)
+ *
+ * Escape sequence: `$$` → literal `$`.
+ */
+const ENV_VAR_PATTERN = /\$(?:\$|\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+/**
+ * Recursively substitute env-var references in every string leaf of a
+ * JSON-shaped value. Object keys and non-string leaves are left alone, so
+ * numeric fields (`allowedUserIds`), booleans, and arrays of numbers are
+ * untouched. Unresolved references with no `:-default` are left literal and
+ * logged once per unique variable name so misconfiguration is visible.
+ *
+ * Syntax supported in any string value:
+ *   $VAR                 — bare reference
+ *   ${VAR}               — braced reference (lets you embed: "pre-${VAR}-post")
+ *   ${VAR:-default}      — fallback if VAR is unset
+ *   $$                   — literal `$`
+ *
+ * Use case: keep `settings.json` committable / template-able by referencing
+ * secrets from the environment instead of inlining them. Works for any
+ * string field — telegram.token, discord.token, api, fallback.api, future
+ * additions — with zero per-field plumbing.
+ */
+export function substituteEnvVars(
+  value: unknown,
+  env: Record<string, string | undefined> = process.env,
+  warned: Set<string> = new Set()
+): any {
+  if (typeof value === "string") {
+    return value.replace(ENV_VAR_PATTERN, (match, braceName, braceDefault, bareName) => {
+      if (match === "$$") return "$";
+      const name: string = braceName ?? bareName;
+      const resolved = env[name];
+      if (resolved !== undefined) return resolved;
+      if (braceDefault !== undefined) return braceDefault;
+      if (!warned.has(name)) {
+        console.warn(`[config] Env var "$${name}" not set — leaving placeholder in settings`);
+        warned.add(name);
+      }
+      return match;
+    });
+  }
+  if (Array.isArray(value)) return value.map((v) => substituteEnvVars(v, env, warned));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = substituteEnvVars(v, env, warned);
+    }
+    return out;
+  }
+  return value;
+}
+
 export async function loadSettings(): Promise<Settings> {
   if (cached) return cached;
   const rawText = await Bun.file(SETTINGS_FILE).text();
-  const raw = JSON.parse(rawText);
+  const raw = substituteEnvVars(JSON.parse(rawText));
   cached = parseSettings(raw, extractDiscordUserIds(rawText));
   return cached;
 }
@@ -342,7 +403,7 @@ export async function loadSettings(): Promise<Settings> {
 /** Re-read settings from disk, bypassing cache. */
 export async function reloadSettings(): Promise<Settings> {
   const rawText = await Bun.file(SETTINGS_FILE).text();
-  const raw = JSON.parse(rawText);
+  const raw = substituteEnvVars(JSON.parse(rawText));
   cached = parseSettings(raw, extractDiscordUserIds(rawText));
   return cached;
 }


### PR DESCRIPTION
## Why

Today every value in `.claude/claudeclaw/settings.json` is inlined — including the Telegram bot token, Discord bot token, and any GLM API key. That forces a tradeoff: either commit the file (and leak the secrets) or gitignore it (and lose the ability to template / reproduce the config across machines).

A tiny env-var substitution pass solves both cases:

```jsonc
{
  "model": "opus",
  "api": "$ANTHROPIC_API_KEY",
  "fallback": { "model": "glm", "api": "${GLM_API_KEY}" },
  "telegram": { "token": "${TELEGRAM_BOT_TOKEN:-}" }
}
```

…then secrets come from the shell env, a dotfiles `.env`, `direnv`, a launchd plist, `op` / `pass`, Kubernetes secrets, whatever. `settings.json` is committable.

## Scope

**Generic** — not telegram-specific. Works on every string leaf of the parsed settings object, so future fields automatically participate without any extra wiring.

## Design

- New exported helper `substituteEnvVars(value, env = process.env)` in `src/config.ts`. Recursive, pure — takes a JSON-shaped value, returns a new one.
- Hooked into `loadSettings()` and `reloadSettings()` after `JSON.parse`, before `parseSettings` runs.
- **Only** rewrites string leaves. Object keys, numbers, booleans, and arrays of numbers (e.g. `discord.allowedUserIds` snowflakes) pass through unchanged. The `extractDiscordUserIds` regex still reads the untouched raw text, so its large-integer workaround is unaffected.

Syntax (shell-like, no surprises):

| Form | Meaning |
|---|---|
| `$VAR` | Substitute `process.env.VAR`, or leave literal if unset |
| `${VAR}` | Same, useful for embedding: `"pre-${VAR}-post"` |
| `${VAR:-default}` | Use `default` when `VAR` is unset or absent |
| `$$` | Literal `$` character |

Unresolved references with no default are **left literal** (not replaced with `undefined` or blanked), and a one-per-variable warning is logged at startup — so a missing env var is visible but non-fatal.

## Backward compatibility

Any settings file without `$` references behaves identically. Users who happen to have a literal `$` inside a string value (unlikely for OAuth tokens, but possible in prompts) can escape it with `$$`.

## Test plan

No test harness exists in the repo today, so the coverage here is the 9-case smoke I ran manually via `bun -e`:

| Case | Input | Expected | Result |
|---|---|---|---|
| bare | `bare $FOO` + `FOO=x` | `bare x` | ✅ |
| braced | `braced ${FOO}` + `FOO=y` | `braced y` | ✅ |
| embedded | `pre-${FOO}-post` + `FOO=Z` | `pre-Z-post` | ✅ |
| default used | `${MISSING:-fallback}` + no env | `fallback` | ✅ |
| default skipped | `${HAS:-fb}` + `HAS=here` | `here` | ✅ |
| escape | `escape $$ sign` | `escape $ sign` | ✅ |
| unresolved | `unresolved $NOPE leaves` | `unresolved $NOPE leaves` (+ warn) | ✅ |
| nested object | `{nested:{deep:"$FOO"},arr:["$FOO",42,true]}` | numbers/booleans intact | ✅ |
| key untouched | `{"$KEY":"$FOO"}` | key stays literal | ✅ |

## Changes

- `src/config.ts` — `ENV_VAR_PATTERN`, `substituteEnvVars()`, hook into load/reload (~65 lines added)
- `README.md` — new "Env-var references in settings.json" subsection with the syntax table and example

No dependency changes. TypeScript checks clean on the touched file (the pre-existing errors in `ui/server.ts` and `whisper.ts` are unrelated).

## Related

This composes well with #102 (env-strip fix) — after both land, the full story for daemons spawned from Claude Desktop is: *spawned claude uses the platform credential store for OAuth*, and *daemon config references secrets via env vars*. No plaintext tokens anywhere that shouldn't have them.