### PR TITLE
feat: session management — null guard, 30-min timeout, pre-compact hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# ClaudeClaw — Claude Instructions
+
+## Session Continuity
+
+On every session start, check for a handoff file:
+
+```bash
+ls "${CLAUDECLAW_PROJECT_DIR:-$PWD}/PRIOR_SESSION_STATE.md" 2>/dev/null
+```
+
+If it exists:
+1. Read it immediately
+2. Read your MEMORY.md
+3. Fill in the "Active Work Summary" and "Key Facts" sections
+4. Tell the user you have resumed and state what was in progress
+5. Delete the file after reading — it is consumed, not persistent
+
+This file is written automatically by the bundled hooks when:
+- Turn count reaches threshold (default: 40 turns, configurable via `CLAUDECLAW_TURN_THRESHOLD`)
+- A `/compact` runs (PreCompact hook)

--- a/README.md
+++ b/README.md
@@ -59,11 +59,21 @@ The setup wizard walks you through model, heartbeat, Telegram, Discord, and secu
 
 ### Session Continuity Hooks (Optional but Recommended)
 
-Wire two hooks in `~/.claude/settings.json` to enable automatic session handoffs — saving state on `/compact` and resetting proactively at turn 40:
+Wire three hooks in `~/.claude/settings.json` so Claw orients itself on startup, saves state before compaction, and resets proactively at turn 40:
 
 ```json
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claudeclaw/hooks/claw-session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "hooks": [
@@ -90,6 +100,11 @@ Wire two hooks in `~/.claude/settings.json` to enable automatic session handoffs
 
 Replace `/path/to/claudeclaw` with your install path (e.g. `~/.claude/plugins/marketplaces/moazbuilds/plugin`).
 
+**How it works:**
+- **SessionStart** — outputs the paths of IDENTITY.md, USER.md, SOUL.md, and CLAUDE.md so Claw reads them immediately; also flags any `PRIOR_SESSION_STATE.md` handoff file from the previous session
+- **PreCompact** — writes `PRIOR_SESSION_STATE.md` with session metadata before `/compact` runs, then resets `session.json` to null so the next session starts clean
+- **UserPromptSubmit** — proactively writes handoff and resets at turn threshold to avoid context wall surprises
+
 Also add the handoff file to your project's `.gitignore` to avoid accidental commits:
 
 ```
@@ -98,6 +113,7 @@ PRIOR_SESSION_STATE.md
 
 **Optional env vars:**
 - `CLAUDECLAW_PROJECT_DIR` — project root (defaults to `$PWD`)
+- `CLAUDECLAW_INSTALL_DIR` — claudeclaw install path (auto-detected from hook script location if unset)
 - `CLAUDECLAW_TURN_THRESHOLD` — turns before proactive reset (default: `40`)
 
 ## What Would Be Built Next?

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Wire two hooks in `~/.claude/settings.json` to enable automatic session handoffs
 
 Replace `/path/to/claudeclaw` with your install path (e.g. `~/.claude/plugins/marketplaces/moazbuilds/plugin`).
 
+Also add the handoff file to your project's `.gitignore` to avoid accidental commits:
+
+```
+PRIOR_SESSION_STATE.md
+```
+
 **Optional env vars:**
 - `CLAUDECLAW_PROJECT_DIR` — project root (defaults to `$PWD`)
 - `CLAUDECLAW_TURN_THRESHOLD` — turns before proactive reset (default: `40`)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,43 @@ Then open a Claude Code session and run:
 ```
 The setup wizard walks you through model, heartbeat, Telegram, Discord, and security, then your daemon is live with a web dashboard.
 
+### Session Continuity Hooks (Optional but Recommended)
+
+Wire two hooks in `~/.claude/settings.json` to enable automatic session handoffs — saving state on `/compact` and resetting proactively at turn 40:
+
+```json
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claudeclaw/hooks/claw-pre-compact.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/path/to/claudeclaw/hooks/claw-state-handoff.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Replace `/path/to/claudeclaw` with your install path (e.g. `~/.claude/plugins/marketplaces/moazbuilds/plugin`).
+
+**Optional env vars:**
+- `CLAUDECLAW_PROJECT_DIR` — project root (defaults to `$PWD`)
+- `CLAUDECLAW_TURN_THRESHOLD` — turns before proactive reset (default: `40`)
+
 ## What Would Be Built Next?
 
 > **Mega Post:** Help shape the next ClaudeClaw features.

--- a/hooks/claw-pre-compact.sh
+++ b/hooks/claw-pre-compact.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# claw-pre-compact.sh — ClaudeClaw PreCompact hook
+# Saves session context to PRIOR_SESSION_STATE.md and resets session.json.
+# Wire in ~/.claude/settings.json under hooks.PreCompact.
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDECLAW_PROJECT_DIR:-$PWD}"
+CLAW_SESSION="$PROJECT_DIR/.claude/claudeclaw/session.json"
+OUTPUT_FILE="$PROJECT_DIR/PRIOR_SESSION_STATE.md"
+
+SESSION_ID="" ; TURN_COUNT=0 ; CREATED_AT="unknown"
+if [ -f "$CLAW_SESSION" ]; then
+  SESSION_ID=$(jq -r '.sessionId // ""' "$CLAW_SESSION" 2>/dev/null || echo "")
+  TURN_COUNT=$(jq -r '.turnCount // 0' "$CLAW_SESSION" 2>/dev/null || echo "0")
+  CREATED_AT=$(jq -r '.createdAt // "unknown"' "$CLAW_SESSION" 2>/dev/null || echo "unknown")
+fi
+
+cat > "$OUTPUT_FILE" << STATEEOF
+# Claw Prior Session State — Compact Handoff
+**Generated:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+**Reason:** /compact ran
+**Session:** $SESSION_ID | **Turns:** $TURN_COUNT | **Created:** $CREATED_AT
+---
+## Instructions for Claude on Next Session Start
+Read CLAUDE.md and MEMORY.md. Summarise what was in progress and confirm resumption.
+## Active Work Summary
+*(Claude: fill in from compact summary)*
+## Key Facts to Carry Forward
+*(Claude: record critical context)*
+STATEEOF
+
+echo "[claw-pre-compact] Wrote PRIOR_SESSION_STATE.md"
+
+if [ -f "$CLAW_SESSION" ]; then
+  echo '{"sessionId":null,"createdAt":null,"lastUsedAt":null,"turnCount":0,"compactWarned":false}' > "$CLAW_SESSION"
+  echo "[claw-pre-compact] Session reset"
+fi

--- a/hooks/claw-session-start.sh
+++ b/hooks/claw-session-start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# claw-session-start.sh — ClaudeClaw SessionStart hook
+# Injects orientation context at the start of every session.
+# Wire in ~/.claude/settings.json under hooks.SessionStart.
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDECLAW_PROJECT_DIR:-$PWD}"
+
+# Locate prompts/ relative to this script (hooks/ sits next to prompts/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAW_PROMPTS="${CLAUDECLAW_INSTALL_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}/prompts"
+
+PRIOR_STATE="$PROJECT_DIR/PRIOR_SESSION_STATE.md"
+
+# Exit silently if prompts dir doesn't exist (non-Claw install)
+if [ ! -d "$CLAW_PROMPTS" ]; then
+  exit 0
+fi
+
+echo "CLAW SESSION START — read these files before anything else:"
+echo ""
+echo "1. $CLAW_PROMPTS/IDENTITY.md"
+echo "2. $CLAW_PROMPTS/USER.md"
+echo "3. $CLAW_PROMPTS/SOUL.md"
+echo "4. $PROJECT_DIR/CLAUDE.md"
+
+if [ -f "$PRIOR_STATE" ]; then
+  echo ""
+  echo "*** PRIOR SESSION HANDOFF — read this before IDENTITY/USER/SOUL: $PRIOR_STATE ***"
+fi
+
+echo ""
+echo "Read MEMORY.md if present in the project directory."
+echo "Confirm ready and state what was in progress (if resuming)."

--- a/hooks/claw-state-handoff.sh
+++ b/hooks/claw-state-handoff.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# claw-state-handoff.sh — ClaudeClaw UserPromptSubmit hook
+# Proactively resets session at TURN_RESET_THRESHOLD turns.
+# Wire in ~/.claude/settings.json under hooks.UserPromptSubmit.
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDECLAW_PROJECT_DIR:-$PWD}"
+CLAW_SESSION="$PROJECT_DIR/.claude/claudeclaw/session.json"
+OUTPUT_FILE="$PROJECT_DIR/PRIOR_SESSION_STATE.md"
+TURN_RESET_THRESHOLD="${CLAUDECLAW_TURN_THRESHOLD:-40}"
+
+if [ ! -f "$CLAW_SESSION" ]; then exit 0; fi
+
+SESSION_ID=$(jq -r '.sessionId // ""' "$CLAW_SESSION" 2>/dev/null || echo "")
+TURN_COUNT=$(jq -r '.turnCount // 0' "$CLAW_SESSION" 2>/dev/null || echo "0")
+CREATED_AT=$(jq -r '.createdAt // "unknown"' "$CLAW_SESSION" 2>/dev/null || echo "unknown")
+COMPACT_WARNED=$(jq -r '.compactWarned // false' "$CLAW_SESSION" 2>/dev/null || echo "false")
+
+if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then exit 0; fi
+if [ "$TURN_COUNT" -lt "$TURN_RESET_THRESHOLD" ]; then exit 0; fi
+
+echo "[claw-state-handoff] Turn $TURN_COUNT >= $TURN_RESET_THRESHOLD — writing handoff + resetting"
+
+cat > "$OUTPUT_FILE" << STATEEOF
+# Claw Prior Session State — Handoff
+**Generated:** $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+**Reason:** Turn count $TURN_COUNT reached threshold ($TURN_RESET_THRESHOLD) — proactive reset
+**Session:** $SESSION_ID | **Created:** $CREATED_AT | **CompactWarned:** $COMPACT_WARNED
+---
+## Instructions for Claude on Next Session Start
+This is a planned handoff. No work was lost.
+1. Read CLAUDE.md
+2. Read MEMORY.md
+3. Fill in Active Work Summary and Key Facts below
+4. Tell the user you have resumed and state what was in progress
+5. Delete this file after reading (it is consumed, not persistent)
+## Active Work Summary
+*(Claude: fill this in when you read this file)*
+## Key Facts to Carry Forward
+*(Claude: record decisions, configs, context that should survive the reset)*
+STATEEOF
+
+echo "[claw-state-handoff] Wrote PRIOR_SESSION_STATE.md"
+echo '{"sessionId":null,"createdAt":null,"lastUsedAt":null,"turnCount":0,"compactWarned":false}' > "$CLAW_SESSION"
+echo "[claw-state-handoff] Session reset — next message starts fresh"

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  sessionTimeoutMs: 30 * 60 * 1000,
 };
 
 export interface HeartbeatExcludeWindow {
@@ -113,6 +114,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  sessionTimeoutMs: number;
 }
 
 export interface AgenticMode {
@@ -274,6 +276,9 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    sessionTimeoutMs: Number.isFinite(raw.sessionTimeoutMs) && raw.sessionTimeoutMs > 0
+      ? Number(raw.sessionTimeoutMs)
+      : DEFAULT_SETTINGS.sessionTimeoutMs,
   };
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -327,7 +327,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
   const securityArgs = buildSecurityArgs(settings.security);
   const { CLAUDECODE: _, ...cleanEnv } = process.env;
   const baseEnv = { ...cleanEnv } as Record<string, string>;
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
     existing.sessionId,
@@ -378,7 +378,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -14,10 +14,14 @@ export interface GlobalSession {
 
 let current: GlobalSession | null = null;
 
+const validSession = (s: GlobalSession | null): GlobalSession | null =>
+  s && typeof s.sessionId === "string" && s.sessionId ? s : null;
+
 async function loadSession(): Promise<GlobalSession | null> {
-  if (current) return current;
+  if (current) return validSession(current);
   try {
     current = await Bun.file(SESSION_FILE).json();
+    if (!validSession(current)) { current = null; return null; }
     return current;
   } catch {
     return null;
@@ -32,15 +36,16 @@ async function saveSession(session: GlobalSession): Promise<void> {
 /** Returns the existing session or null. Never creates one. */
 export async function getSession(): Promise<{ sessionId: string; turnCount: number; compactWarned: boolean } | null> {
   const existing = await loadSession();
-  if (existing) {
-    // Backfill missing fields from older session.json files
-    if (typeof existing.turnCount !== "number") existing.turnCount = 0;
-    if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
-    existing.lastUsedAt = new Date().toISOString();
-    await saveSession(existing);
-    return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
+  if (!existing || typeof existing.sessionId !== "string" || !existing.sessionId) {
+    current = null;
+    return null;
   }
-  return null;
+  // Backfill missing fields from older session.json files
+  if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+  if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
+  existing.lastUsedAt = new Date().toISOString();
+  await saveSession(existing);
+  return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
 }
 
 /** Save a session ID obtained from Claude Code's output. */


### PR DESCRIPTION
## Summary

Backports three production fixes from a live Hetzner ClaudeClaw deployment as out-of-box defaults. Any fresh install now gets these automatically.

- **Null sessionId guard** (`src/sessions.ts`): `loadSession` / `getSession` now reject sessions where `sessionId` is `null` or empty, preventing `null.slice()` crashes on every Discord message after a manual reset
- **30-minute default timeout** (`src/config.ts`, `src/runner.ts`): `sessionTimeoutMs` promoted to a first-class typed setting (was an untyped `(settings as any)` cast in `runner.ts`); default raised from 300 s → 1800 s so long-running tasks don't hit the wall
- **Bundled hooks** (`hooks/claw-pre-compact.sh`, `hooks/claw-state-handoff.sh`, `hooks/claw-session-start.sh`): three new opt-in hooks that write a `PRIOR_SESSION_STATE.md` handoff on `/compact` or turn-count threshold, and announce identity/soul/CLAUDE.md on session start; paths use `${CLAUDECLAW_PROJECT_DIR:-$PWD}` for portability
- **CLAUDE.md + README**: session-continuity instructions for Claude, hook wiring docs, and `.gitignore` guidance for `PRIOR_SESSION_STATE.md`

## Independence from open PRs

Existing PRs (#71–#77) touch: gateway, governance, orchestrator, policy engine, memory system, UI security, core fixes.  
This PR touches only: `sessions.ts` (null guard), `config.ts` / `runner.ts` (new typed field), `hooks/` (new files), `CLAUDE.md`, `README.md`.  
No shared modified lines — can be reviewed and merged independently.

## Test plan

- [ ] Set `session.json` to `{"sessionId":null,...}` → start daemon → send Discord message → confirm no `TypeError: Cannot read properties of null` crash
- [ ] Set `CLAUDECLAW_TURN_THRESHOLD=2`, send 3 messages → confirm `PRIOR_SESSION_STATE.md` is written and session resets
- [ ] Run `/compact` → confirm `PRIOR_SESSION_STATE.md` is written and `session.json` is reset
- [ ] `bun tsc --noEmit` passes (no type errors from new `sessionTimeoutMs` field)
- [ ] Confirm `sessionTimeoutMs: 1800000` appears in freshly generated `settings.json`
- [ ] Wire `claw-session-start.sh` as a `SessionStart` hook → confirm identity files are announced at session open

🤖 Generated with [Claude Code](https://claude.com/claude-code)