### PR TITLE
fix(runner): auto-recover from stale --resume session IDs

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,12 +1,13 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
+import { getSession, createSession, incrementTurn, markCompactWarned, backupSession } from "./sessions";
 import {
   getThreadSession,
   createThreadSession,
   incrementThreadTurn,
   markThreadCompactWarned,
+  removeThreadSession,
 } from "./sessionManager";
 import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
@@ -58,6 +59,37 @@ export interface RunResult {
 }
 
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
+
+// Claude Code prints this when --resume references a session it no longer
+// has on disk (cleared, expired, compacted away, or moved to another machine).
+// When we see it, the cached session ID is dead and the only recovery is to
+// drop --resume and start fresh.
+const STALE_SESSION_PATTERN = /No conversation found with session ID/i;
+
+function isStaleSessionError(stdout: string, stderr: string): boolean {
+  return STALE_SESSION_PATTERN.test(stderr) || STALE_SESSION_PATTERN.test(stdout);
+}
+
+/** Strip --resume <id> from a claude argv list so it runs as a brand-new session. */
+function stripResume(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--resume") {
+      i += 1; // skip the session id that follows
+      continue;
+    }
+    out.push(args[i]!);
+  }
+  return out;
+}
+
+/** Replace the value following --output-format (mutates a copy and returns it). */
+function withOutputFormat(args: string[], format: string): string[] {
+  const out = [...args];
+  const idx = out.indexOf("--output-format");
+  if (idx >= 0 && idx + 1 < out.length) out[idx + 1] = format;
+  return out;
+}
 
 // Serial queue — prevents concurrent --resume on the same session
 // Global queue for non-thread messages (backward compatible)
@@ -433,19 +465,62 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     usedFallback = true;
   }
 
-  const rawStdout = exec.rawStdout;
-  const stderr = exec.stderr;
-  const exitCode = exec.exitCode;
+  let rawStdout = exec.rawStdout;
+  let stderr = exec.stderr;
+  let exitCode = exec.exitCode;
   let stdout = rawStdout;
   let sessionId = existing?.sessionId ?? "unknown";
+  let recoveredFromStale = false;
   const rateLimitMessage = extractRateLimitMessage(rawStdout, stderr);
 
   if (rateLimitMessage) {
     stdout = rateLimitMessage;
   }
 
-  // For new sessions, parse the JSON to extract session_id and result text
-  if (!rateLimitMessage && isNew && exitCode === 0) {
+  // --- Stale session recovery ---
+  // Claude Code returns "No conversation found with session ID: <id>" when
+  // --resume points at a session it no longer has (cleared, expired, etc.).
+  // The cached ID is dead; back it up, drop --resume, and retry as a new
+  // session so the user isn't permanently stuck.
+  if (
+    !rateLimitMessage &&
+    !isNew &&
+    exitCode !== 0 &&
+    existing &&
+    isStaleSessionError(rawStdout, stderr)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name}; recovering with a new session...`
+    );
+
+    if (threadId) {
+      await removeThreadSession(threadId);
+    } else {
+      await backupSession();
+    }
+
+    const retryArgs = withOutputFormat(stripResume(args), "json");
+    const retryConfig = usedFallback ? fallbackConfig : primaryConfig;
+    const retryExec = await runClaudeOnce(
+      retryArgs,
+      retryConfig.model,
+      retryConfig.api,
+      baseEnv,
+      timeoutMs
+    );
+
+    rawStdout = retryExec.rawStdout;
+    stderr = retryExec.stderr;
+    exitCode = retryExec.exitCode;
+    stdout = rawStdout;
+    recoveredFromStale = true;
+  }
+
+  // For new sessions, parse the JSON to extract session_id and result text.
+  // After a stale-session recovery, the retry was forced to JSON output too,
+  // so reuse the same parsing branch by treating it as a "new" session.
+  const parseAsNew = (isNew || recoveredFromStale);
+  if (!rateLimitMessage && parseAsNew && exitCode === 0) {
     try {
       const json = JSON.parse(rawStdout);
       sessionId = json.session_id;
@@ -487,7 +562,9 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
 
   // --- Auto-compact on timeout (exit 124) ---
-  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {
+  // Skip after a stale-session recovery: `existing` references the dead
+  // session ID, so /compact would fail the same way --resume just did.
+  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing && !recoveredFromStale) {
     emitCompactEvent({ type: "auto-compact-start" });
     const compactOk = await runCompact(
       existing.sessionId,
@@ -524,7 +601,9 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   }
 
   // --- Turn tracking & compact warning ---
-  if (exitCode === 0 && !isNew) {
+  // Recovered sessions were just created (turnCount = 0); the next call will
+  // resume normally and start counting from there.
+  if (exitCode === 0 && !isNew && !recoveredFromStale) {
     const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
     console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${threadId ? ` (thread ${threadId.slice(0, 8)})` : ""}`);
 
@@ -599,6 +678,9 @@ async function streamClaude(
   let buf = "";
   let unblocked = false;
   let textEmitted = false;
+  // Drain stderr concurrently so we can detect stale-session errors and
+  // avoid backpressure if Claude prints a lot to stderr (verbose/--debug).
+  const stderrPromise = new Response(proc.stderr).text();
 
   const maybeUnblock = () => {
     if (!unblocked) {
@@ -661,6 +743,28 @@ async function streamClaude(
   }
 
   await proc.exited;
+  const stderrText = await stderrPromise;
+
+  // --- Stale session recovery (stream path) ---
+  // Same situation as execClaude: --resume hit a session Claude no longer
+  // has. Back up the dead ID and re-stream as a brand-new session so the
+  // user gets a real reply instead of a silent error.
+  if (
+    existing &&
+    !textEmitted &&
+    (proc.exitCode ?? 0) !== 0 &&
+    isStaleSessionError("", stderrText)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name} (stream); recovering with a new session...`
+    );
+    await backupSession();
+    // Recurse without pre-firing onUnblock: the recursive call manages its
+    // own unblock so the UI keeps showing "typing" until the real reply lands.
+    await streamClaude(name, prompt, onChunk, onUnblock);
+    return;
+  }
+
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
 


### PR DESCRIPTION
## Summary

When Claude Code's CLI returns `Error: No conversation found with session ID: <id>` (because the cached session was cleared, expired, compacted away, or moved to another machine via sync), claudeclaw currently keeps that dead ID in `session.json` and every subsequent message produces the same error. The only recovery today is to manually delete the session file or run a reset command — Telegram/Discord users typically just see `Error (exit 1): No conversation found with session ID: …` and have no way out.

This PR teaches `runner.ts` to detect that error in both code paths and recover automatically.

## What it does

In both `execClaude` (print mode) and `streamClaude` (stream-json mode), after the spawned `claude` process exits non-zero, scan stderr (and stdout for the print path) for the pattern `No conversation found with session ID`. When matched:

1. Backup or remove the dead session
   - Global session → `backupSession()` (preserves the dead ID under `session_<n>.backup`).
   - Thread session → `removeThreadSession(threadId)` (drops the dead entry from `sessions.json`).
2. Rebuild the argv: strip `--resume <id>` and (in the print path) force `--output-format json` so we capture the brand-new `session_id` Claude returns.
3. Retry once with the same model/security config. If it succeeds, persist the new session via `createSession()` / `createThreadSession()` and return its output as the normal reply.

Two small bookkeeping fixes guard against double-counting after recovery:
- The auto-compact-on-timeout block is skipped when `recoveredFromStale` is true (otherwise `/compact` would target the dead ID and fail the same way).
- Turn-count increment is skipped after recovery (the new session was just created with `turnCount = 0`; the next call resumes normally and counts from there).

No new dependencies, no behavior changes for the normal happy path or for rate-limit handling.

## Repro before the fix

\`\`\`bash
cat > .claude/claudeclaw/session.json <<JSON
{\"sessionId\":\"deadbeef-dead-dead-dead-deaddeaddead\",\"createdAt\":\"2026-04-25T04:08:36.853Z\",\"lastUsedAt\":\"2026-04-25T06:56:34.288Z\",\"turnCount\":5,\"compactWarned\":false}
JSON
# Then send any message via Telegram/Discord/CLI:
#   → \"Error (exit 1): No conversation found with session ID: deadbeef-...\"
# And every subsequent message gets the same error until session.json is hand-deleted.
\`\`\`

After the fix, the same message should log `Stale session deadbeef for <name>; recovering with a new session...`, move the dead ID to `session_<n>.backup`, and return a normal reply from a freshly created session — all in one turn.

## Test plan

- [x] \`bunx tsc --noEmit\` — no new type errors introduced (pre-existing errors in \`config.ts\`, \`ui/server.ts\`, \`whisper.ts\` and the Bun/DOM \`WebAssembly\` clash are unchanged).
- [ ] Manual repro: I'll add a screenshot/log once I've verified locally — patch was authored against my live install but not yet exercised end-to-end at PR-open time.
- [ ] Reviewers: please double-check that the recovery path interaction with auto-compact retry is what you want (currently gated by \`!recoveredFromStale\` so we don't loop on a dead ID).