### PR TITLE
fix: surface real Claude CLI errors instead of Unknown error

### DIFF
--- a/docs/handoffs/pr58-recreation.md
+++ b/docs/handoffs/pr58-recreation.md
@@ -1,0 +1,66 @@
+# Handoff: Recreate Closed PR #58
+
+## Goal
+Recreate the useful part of closed PR `#58` on top of current `master` without carrying over the stale or unused parts of the original branch.
+
+## Branch
+`fix/surface-real-cli-errors`
+
+## Original PR
+- Closed PR: `#58`
+- Original commit: `2bc524e`
+- Problem statement: Claude CLI sometimes exits non-zero with the human-readable error message in JSON stdout rather than stderr, causing chat bridges to show `Unknown error`.
+
+## Scope Chosen
+Keep only the narrow behaviour that is still useful today:
+- add `extractErrorDetail()` in `src/messaging.ts`
+- use it in:
+  - `src/commands/start.ts`
+  - `src/commands/telegram.ts`
+  - `src/commands/discord.ts`
+- add a focused Bun test file:
+  - `src/messaging.test.ts`
+
+Explicitly dropped from the old PR:
+- `describeProvider()`
+- `isProviderStatusQuery()`
+- `isModelChangeRequest()`
+- `authoritativeProviderReply()`
+- `extractReactionDirective()`
+
+Those were unused in the original PR and were part of the review feedback asking for a narrower branch.
+
+## Changes Already Made
+- Added `src/messaging.ts` with `extractErrorDetail()`
+- Updated the three error-reporting call sites to use `extractErrorDetail()`
+- Added `src/messaging.test.ts` covering:
+  - `stderr` present
+  - JSON stdout with `is_error/result`
+  - raw stdout fallback
+- Folded in the minimal `parseSettings(raw, discordUserIds?)` signature fix from the known config issue so `bunx tsc --noEmit` can pass on this branch
+
+## Validation To Run
+From repo root:
+
+```bash
+bun install
+bun test src/messaging.test.ts
+bunx tsc --noEmit
+```
+
+If anything else fails, check whether it is unrelated existing repo noise or caused by this branch.
+
+## Suggested PR Title
+`fix: surface real Claude CLI errors instead of Unknown error`
+
+## Suggested PR Description
+This supersedes closed PR `#58`.
+
+Claude CLI sometimes exits non-zero with the real human-readable error detail in JSON stdout rather than stderr. This branch adds a small shared helper, `extractErrorDetail()`, and uses it in the Telegram, Discord, and daemon forwarding error paths so auth/quota/runtime failures surface the actual message instead of `Unknown error`.
+
+The branch is intentionally narrower than the original PR: it keeps only the error-detail extraction behaviour that is used today and drops the unused shared messaging helpers from the abandoned branch.
+
+## Suggested Follow-up Checks
+- Confirm Telegram auth/quota errors now surface the parsed message
+- Confirm Discord auth/quota errors now surface the parsed message
+- Confirm forwarded daemon heartbeat/job failures use the parsed message

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -9,6 +9,7 @@ import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
+import { extractErrorDetail } from "../messaging";
 
 // --- Discord API constants ---
 
@@ -641,7 +642,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt, threadId);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -9,6 +9,7 @@ import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
 import { getDayAndMinuteAtOffset } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
+import { extractErrorDetail } from "../messaging";
 import type { Job } from "../jobs";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
@@ -502,7 +503,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -514,7 +515,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -8,6 +8,7 @@ import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt, listSkills } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
+import { extractErrorDetail } from "../messaging";
 
 // --- Markdown → Telegram HTML conversion (ported from nanobot) ---
 
@@ -835,7 +836,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const result = await runUserMessage("telegram", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`, threadId);
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
       const { cleanedText, filePaths } = extractSendFileDirectives(afterReact);

--- a/src/config.ts
+++ b/src/config.ts
@@ -217,7 +217,7 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)
@@ -249,7 +249,9 @@ function parseSettings(raw: Record<string, any>): Settings {
     },
     discord: {
       token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
-      allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
+      allowedUserIds: Array.isArray(discordUserIds) && discordUserIds.length > 0
+        ? discordUserIds
+        : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)

--- a/src/messaging.test.ts
+++ b/src/messaging.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { extractErrorDetail } from "./messaging";
+
+describe("extractErrorDetail", () => {
+  it("prefers stderr when present", () => {
+    expect(
+      extractErrorDetail({
+        stdout: '{"is_error":true,"result":"Not logged in · Please run /login"}',
+        stderr: "Permission denied",
+      })
+    ).toBe("Permission denied");
+  });
+
+  it("extracts the result field from JSON stdout errors", () => {
+    expect(
+      extractErrorDetail({
+        stdout: '{"is_error":true,"result":"Not logged in · Please run /login"}',
+        stderr: "",
+      })
+    ).toBe("Not logged in · Please run /login");
+  });
+
+  it("falls back to raw stdout when stdout is not JSON", () => {
+    expect(
+      extractErrorDetail({
+        stdout: "Quota exceeded",
+        stderr: "",
+      })
+    ).toBe("Quota exceeded");
+  });
+});

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,23 @@
+/**
+ * Extract a user-facing error detail from a Claude CLI run result.
+ *
+ * Claude CLI sometimes returns human-readable auth/quota failures in JSON
+ * stdout instead of stderr. Prefer stderr when present, otherwise parse the
+ * JSON stdout payload and fall back to raw stdout text.
+ */
+export function extractErrorDetail(result: { stdout: string; stderr: string }): string {
+  const stderr = result.stderr?.trim() || "";
+  if (stderr) return stderr;
+
+  const stdout = result.stdout?.trim() || "";
+  if (!stdout) return "";
+
+  try {
+    const parsed = JSON.parse(stdout);
+    if (parsed?.is_error && parsed?.result) return String(parsed.result).trim();
+    if (parsed?.error?.message) return String(parsed.error.message).trim();
+    if (typeof parsed?.error === "string") return parsed.error.trim();
+  } catch {}
+
+  return stdout;
+}


### PR DESCRIPTION
Supersedes closed PR `#58`.

## Problem

Claude CLI sometimes exits non-zero with the real human-readable error detail in JSON stdout rather than stderr. In those cases, ClaudeClaw was surfacing generic fallback text such as `Unknown error` instead of the actual failure reason.

Example:

Before:
```text
Error (exit 1): Unknown error
```

After:
```text
Error (exit 1): Not logged in · Please run /login
```

## What this PR changes

This PR adds a small shared helper, `extractErrorDetail()`, in `src/messaging.ts` and uses it in the existing error-reporting paths for:
- daemon forwarding in `src/commands/start.ts`
- Telegram message handling in `src/commands/telegram.ts`
- Discord message handling in `src/commands/discord.ts`

The helper:
- prefers trimmed `stderr` when present
- otherwise tries to parse JSON `stdout`
- extracts Claude CLI error detail from:
  - `is_error/result`
  - `error.message`
  - string `error`
- falls back to raw `stdout` if parsing does not apply

This branch is intentionally narrower than the abandoned `#58` branch. It keeps only the shared error-detail extraction that is actually used today and drops the unused extra messaging helpers from the original PR.

## Additional cleanup included

I also folded in the small `parseSettings(raw, discordUserIds?)` signature fix in `src/config.ts` so the branch typechecks cleanly on current `master`. That is not the main purpose of this PR, but it was necessary to validate the branch properly.

## Testing

Validated with:
```bash
bun test src/messaging.test.ts
bunx tsc --noEmit
```

Added focused coverage for:
- `stderr` populated
- `stderr` empty with JSON stdout containing `is_error/result`
- non-JSON stdout fallback

## Notes

This PR recreates the useful part of closed PR `#58` on top of current `master`, with the scope narrowed to the actual runtime behaviour needed now.
