### PR TITLE
feat(jobs): make jobs directory configurable outside .claude/

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -9,6 +9,7 @@ const PID_FILE = join(HEARTBEAT_DIR, "daemon.pid");
 const STATE_FILE = join(HEARTBEAT_DIR, "state.json");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 
+
 function formatCountdown(ms: number): string {
   if (ms <= 0) return "now!";
   const s = Math.floor(ms / 1000);

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,5 +1,4 @@
 import { join } from "path";
-import { getJobsDir } from "../config";
 
 export const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 export const LOGS_DIR = join(HEARTBEAT_DIR, "logs");

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -1,7 +1,9 @@
 import { join } from "path";
+import { getJobsDir } from "../config";
 
 export const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 export const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
+
 export const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 export const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
 export const STATE_FILE = join(HEARTBEAT_DIR, "state.json");


### PR DESCRIPTION
## Problem

Claude Code hard-codes `.claude/` as a sensitive directory. The permissions whitelist does not override this — `"allow": ["Write(.claude/claudeclaw/jobs/**)"]` is silently ignored.

This means `CronCreate` is blocked from creating job files when a Claude Code session is managing jobs on behalf of a user (e.g. a Discord or Telegram bot that lets users schedule tasks). The jobs directory is unreachable through the standard permission grant mechanism.

## Solution

Add a `jobsDir` setting that relocates the jobs directory to any path outside `.claude/`. When unset, the default (`<cwd>/.claude/claudeclaw/jobs/`) is preserved for full backward compatibility.

```json
{
  "jobsDir": "/home/jack/myproject/jobs"
}
```

Absolute paths are used as-is. Relative paths are resolved from `process.cwd()`.

## Changes

- `config.ts`: export `getJobsDir()` helper; add `jobsDir?: string` to `Settings`; parse `jobsDir` in `parseSettings`; use `getJobsDir()` in `initConfig()`
- `jobs.ts`: replace hard-coded path constant with `getJobsDir()` (called at runtime, not module-load)
- `ui/constants.ts`: same
- `commands/status.ts`: same

## Backward compatibility

No existing behaviour changes when `jobsDir` is absent from settings.