### PR TITLE
chore(ci): enforce plugin version bumps

### DIFF
--- a/.github/workflows/plugin-version-guard.yml
+++ b/.github/workflows/plugin-version-guard.yml
@@ -1,0 +1,58 @@
+name: Plugin Version Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  plugin-version-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require plugin version bump for shipped plugin changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changed files detected."
+            exit 0
+          fi
+
+          shipped_pattern='^(src/|commands/|prompts/|\.claude-plugin/)'
+
+          if ! printf '%s\n' "$changed_files" | grep -Eq "$shipped_pattern"; then
+            echo "Docs-only or non-shipped changes detected; plugin version bump not required."
+            exit 0
+          fi
+
+          if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/plugin.json"; then
+            echo "Shipped plugin files changed but .claude-plugin/plugin.json was not updated."
+            echo "Run: bun run bump:plugin-version"
+            exit 1
+          fi
+
+          base_version="$(git show "$BASE_SHA:.claude-plugin/plugin.json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+          head_version="$(python3 -c 'import json; print(json.load(open(".claude-plugin/plugin.json"))["version"])')"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "Shipped plugin files changed but plugin version did not change ($head_version)."
+            echo "Run: bun run bump:plugin-version"
+            exit 1
+          fi
+
+          echo "Plugin version changed: $base_version -> $head_version"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:web": "bun --watch src/index.ts start --web --replace-existing",
     "telegram": "bun run src/index.ts telegram",
     "discord": "bun run src/index.ts discord",
-    "status": "bun run src/index.ts status"
+    "status": "bun run src/index.ts status",
+    "bump:plugin-version": "bun run scripts/bump-plugin-version.ts"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9"

--- a/scripts/bump-plugin-version.ts
+++ b/scripts/bump-plugin-version.ts
@@ -1,0 +1,61 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const PLUGIN_JSON = ".claude-plugin/plugin.json";
+const VALID_BUMP_TYPES = new Set(["patch", "minor", "major"]);
+
+type BumpType = "patch" | "minor" | "major";
+
+function bumpVersion(version: string, bumpType: BumpType): string {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Unsupported plugin version format: ${version}`);
+  }
+
+  let [, major, minor, patch] = match;
+  let nextMajor = Number(major);
+  let nextMinor = Number(minor);
+  let nextPatch = Number(patch);
+
+  switch (bumpType) {
+    case "major":
+      nextMajor += 1;
+      nextMinor = 0;
+      nextPatch = 0;
+      break;
+    case "minor":
+      nextMinor += 1;
+      nextPatch = 0;
+      break;
+    case "patch":
+      nextPatch += 1;
+      break;
+  }
+
+  return `${nextMajor}.${nextMinor}.${nextPatch}`;
+}
+
+async function main(): Promise<void> {
+  const rawBumpType = process.argv[2] ?? "patch";
+  if (!VALID_BUMP_TYPES.has(rawBumpType)) {
+    throw new Error(`Unsupported bump type: ${rawBumpType}. Use patch, minor, or major.`);
+  }
+
+  const bumpType = rawBumpType as BumpType;
+  const raw = await readFile(PLUGIN_JSON, "utf8");
+  const plugin = JSON.parse(raw) as { version?: string };
+
+  if (typeof plugin.version !== "string" || plugin.version.trim() === "") {
+    throw new Error(`${PLUGIN_JSON} is missing a valid version string.`);
+  }
+
+  const nextVersion = bumpVersion(plugin.version, bumpType);
+  plugin.version = nextVersion;
+
+  await writeFile(PLUGIN_JSON, `${JSON.stringify(plugin, null, 2)}\n`, "utf8");
+  console.log(`${PLUGIN_JSON}: ${nextVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses part of #81 by adding lightweight automation around ClaudeClaw plugin versioning so plugin updates are actually detectable by Claude Code.

## What this PR does

- adds a CI guard workflow that fails a PR when shipped plugin files change without a corresponding version bump in `.claude-plugin/plugin.json`
- adds a small release helper script that bumps the plugin version, defaulting to a patch increment
- exempts docs-only and other non-shipped changes from the version-bump requirement

## Guard behaviour

The workflow requires a version bump when a PR changes shipped plugin files under:
- `src/**`
- `commands/**`
- `prompts/**`
- `.claude-plugin/**`

If a PR only changes docs or other non-shipped repo files, the guard exits cleanly and does not require a plugin version update.

## Helper script

```bash
bun run bump:plugin-version
```

Defaults to a patch bump. Also supports:

```bash
bun run bump:plugin-version minor
bun run bump:plugin-version major
```

## Why

Claude Code uses `.claude-plugin/plugin.json` version changes to detect plugin updates. If shipped plugin content changes but the manifest version stays the same, `claude plugin update` may treat newer commits as identical and skip the update.

This PR makes that easier to maintain correctly and harder to forget.

## Validation

- ran the bump helper locally and confirmed it updates `.claude-plugin/plugin.json`
- sanity-checked the guard pattern against docs-only and shipped-file examples
