### PR TITLE
chore(ci): enforce marketplace version bumps

### DIFF
--- a/.github/workflows/marketplace-version-guard.yml
+++ b/.github/workflows/marketplace-version-guard.yml
@@ -1,0 +1,63 @@
+name: Marketplace Version Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  marketplace-version-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require marketplace version bump for shipped plugin changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changed files detected."
+            exit 0
+          fi
+
+          shipped_pattern='^(src/|commands/|prompts/|\.claude-plugin/)'
+
+          if ! printf '%s\n' "$changed_files" | grep -Eq "$shipped_pattern"; then
+            echo "Docs-only or non-shipped changes detected; marketplace version bump not required."
+            exit 0
+          fi
+
+          if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/marketplace.json"; then
+            echo "Shipped plugin files changed but .claude-plugin/marketplace.json was not updated."
+            echo "Run: bun run bump:marketplace-version"
+            exit 1
+          fi
+
+          base_version="$(
+            git show "$BASE_SHA:.claude-plugin/marketplace.json" | \
+            python3 -c 'import json,sys; data=json.load(sys.stdin); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
+          )"
+          head_version="$(
+            python3 -c 'import json; data=json.load(open(".claude-plugin/marketplace.json")); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
+          )"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "Shipped plugin files changed but marketplace version did not change ($head_version)."
+            echo "Run: bun run bump:marketplace-version"
+            exit 1
+          fi
+
+          echo "Marketplace version changed: $base_version -> $head_version"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "telegram": "bun run src/index.ts telegram",
     "discord": "bun run src/index.ts discord",
     "status": "bun run src/index.ts status",
-    "bump:plugin-version": "bun run scripts/bump-plugin-version.ts"
+    "bump:plugin-version": "bun run scripts/bump-plugin-version.ts",
+    "bump:marketplace-version": "bun run scripts/bump-marketplace-version.ts"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9"

--- a/scripts/bump-marketplace-version.ts
+++ b/scripts/bump-marketplace-version.ts
@@ -1,0 +1,66 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const MARKETPLACE_JSON = ".claude-plugin/marketplace.json";
+const VALID_BUMP_TYPES = new Set(["patch", "minor", "major"]);
+
+type BumpType = "patch" | "minor" | "major";
+
+function bumpVersion(version: string, bumpType: BumpType): string {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Unsupported marketplace version format: ${version}`);
+  }
+
+  let [, major, minor, patch] = match;
+  let nextMajor = Number(major);
+  let nextMinor = Number(minor);
+  let nextPatch = Number(patch);
+
+  switch (bumpType) {
+    case "major":
+      nextMajor += 1;
+      nextMinor = 0;
+      nextPatch = 0;
+      break;
+    case "minor":
+      nextMinor += 1;
+      nextPatch = 0;
+      break;
+    case "patch":
+      nextPatch += 1;
+      break;
+  }
+
+  return `${nextMajor}.${nextMinor}.${nextPatch}`;
+}
+
+async function main(): Promise<void> {
+  const rawBumpType = process.argv[2] ?? "patch";
+  if (!VALID_BUMP_TYPES.has(rawBumpType)) {
+    throw new Error(`Unsupported bump type: ${rawBumpType}. Use patch, minor, or major.`);
+  }
+
+  const bumpType = rawBumpType as BumpType;
+  const raw = await readFile(MARKETPLACE_JSON, "utf8");
+  const marketplace = JSON.parse(raw) as { plugins?: Array<{ name?: string; version?: string }> };
+
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+    throw new Error(`${MARKETPLACE_JSON} does not contain any plugins.`);
+  }
+
+  const plugin = marketplace.plugins.find((entry) => entry.name === "claudeclaw") ?? marketplace.plugins[0];
+  if (!plugin || typeof plugin.version !== "string" || plugin.version.trim() === "") {
+    throw new Error(`${MARKETPLACE_JSON} is missing a valid plugin version string.`);
+  }
+
+  const nextVersion = bumpVersion(plugin.version, bumpType);
+  plugin.version = nextVersion;
+
+  await writeFile(MARKETPLACE_JSON, `${JSON.stringify(marketplace, null, 2)}\n`, "utf8");
+  console.log(`${MARKETPLACE_JSON}: ${nextVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Addresses the corresponding marketplace side of #81 by adding lightweight automation around `.claude-plugin/marketplace.json` versioning so marketplace metadata changes are not forgotten when shipped plugin content changes.

## What this PR does

- adds a CI guard workflow that fails a PR when shipped plugin files change without a corresponding version bump in `.claude-plugin/marketplace.json`
- adds a small release helper script that bumps the marketplace plugin version, defaulting to a patch increment
- exempts docs-only and other non-shipped changes from the marketplace version-bump requirement

## Guard behaviour

The workflow requires a marketplace version bump when a PR changes shipped plugin files under:
- `src/**`
- `commands/**`
- `prompts/**`
- `.claude-plugin/**`

If a PR only changes docs or other non-shipped repo files, the guard exits cleanly and does not require a marketplace version update.

## Helper script

```bash
bun run bump:marketplace-version
```

Defaults to a patch bump. Also supports:

```bash
bun run bump:marketplace-version minor
bun run bump:marketplace-version major
```

## Why

If marketplace consumers rely on `.claude-plugin/marketplace.json` metadata, that version needs the same discipline as `.claude-plugin/plugin.json`: shipped plugin content changes should be accompanied by a corresponding marketplace metadata version change, and maintainers should not need to edit the JSON manually each time.

## Validation

- ran the marketplace bump helper locally and confirmed it updates the `claudeclaw` plugin version inside `.claude-plugin/marketplace.json`
- sanity-checked the guard pattern against docs-only and shipped-file examples
