### PR TITLE
docs(ci): improve version bump guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Validation
+
+- [ ] I ran the relevant checks locally
+- [ ] I updated any docs or setup guidance affected by this change
+
+## Plugin Versioning
+
+If this PR changes shipped plugin files under `src/`, `commands/`, `prompts/`, or `.claude-plugin/`, version metadata may also need to be bumped.
+
+Run as needed:
+
+```bash
+bun run bump:plugin-version
+bun run bump:marketplace-version
+```
+
+Typical rule:
+- bump `.claude-plugin/plugin.json` when shipped plugin content changes
+- bump `.claude-plugin/marketplace.json` when marketplace metadata should reflect the new shipped version
+
+Docs-only and other non-shipped changes do not require these bumps.

--- a/.github/workflows/marketplace-version-guard.yml
+++ b/.github/workflows/marketplace-version-guard.yml
@@ -43,6 +43,8 @@ jobs:
           if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/marketplace.json"; then
             echo "Shipped plugin files changed but .claude-plugin/marketplace.json was not updated."
             echo "Run: bun run bump:marketplace-version"
+            echo "If your PR also changes the plugin manifest, you may also need:"
+            echo "  bun run bump:plugin-version"
             exit 1
           fi
 
@@ -57,6 +59,8 @@ jobs:
           if [ "$base_version" = "$head_version" ]; then
             echo "Shipped plugin files changed but marketplace version did not change ($head_version)."
             echo "Run: bun run bump:marketplace-version"
+            echo "If your PR also changes the plugin manifest, you may also need:"
+            echo "  bun run bump:plugin-version"
             exit 1
           fi
 

--- a/.github/workflows/plugin-version-guard.yml
+++ b/.github/workflows/plugin-version-guard.yml
@@ -43,6 +43,8 @@ jobs:
           if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/plugin.json"; then
             echo "Shipped plugin files changed but .claude-plugin/plugin.json was not updated."
             echo "Run: bun run bump:plugin-version"
+            echo "If your PR also touches marketplace metadata expectations, you may also need:"
+            echo "  bun run bump:marketplace-version"
             exit 1
           fi
 
@@ -52,6 +54,8 @@ jobs:
           if [ "$base_version" = "$head_version" ]; then
             echo "Shipped plugin files changed but plugin version did not change ($head_version)."
             echo "Run: bun run bump:plugin-version"
+            echo "If your PR also touches marketplace metadata expectations, you may also need:"
+            echo "  bun run bump:marketplace-version"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Then open a Claude Code session and run:
 ```
 The setup wizard walks you through model, heartbeat, Telegram, Discord, and security, then your daemon is live with a web dashboard.
 
+### Contributor Note: Plugin Version Metadata
+
+If you change shipped plugin files under `src/`, `commands/`, `prompts/`, or `.claude-plugin/`, the plugin metadata version may also need to be bumped so Claude Code and marketplace consumers detect the update correctly.
+
+Helpers:
+
+```bash
+bun run bump:plugin-version
+bun run bump:marketplace-version
+```
+
+Docs-only and other non-shipped changes do not require these bumps.
+
 ## What Would Be Built Next?
 
 > **Mega Post:** Help shape the next ClaudeClaw features.


### PR DESCRIPTION
## Summary

Improves the contributor guidance around the new plugin and marketplace version guards.

## What this PR does

- makes both version-guard workflows more explicit about which helper command(s) contributors should run when a check fails
- adds a pull request template section covering plugin/marketplace version metadata expectations
- adds a short README contributor note with the same guidance

## Why

The guards are working, but their failure mode should be easier to act on immediately. This change makes it clearer that:
- the helper scripts are the intended fix path
- some PRs may need one bump
- some PRs may need both
- docs-only and other non-shipped changes remain exempt
