### PR TITLE
feat(jobs): per-job model override via frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,13 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.0",
-      "keywords": ["cron", "heartbeat", "scheduler", "daemon"],
+      "version": "1.0.1",
+      "keywords": [
+        "cron",
+        "heartbeat",
+        "scheduler",
+        "daemon"
+      ],
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -699,7 +699,7 @@ export async function start(args: string[] = []) {
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt))
+          .then((prompt) => run(job.name, prompt, undefined, job.model))
           .then((r) => {
             if (job.notify === false) return;
             if (job.notify === "error" && r.exitCode === 0) return;

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -9,6 +9,8 @@ export interface Job {
   prompt: string;
   recurring: boolean;
   notify: true | false | "error";
+  /** When set, overrides the global model for this job. Useful for routing cheap tasks to haiku. */
+  model?: string;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -51,7 +53,10 @@ function parseJobFile(name: string, content: string): Job | null {
     : notifyRaw === "error" ? "error"
     : true;
 
-  return { name, schedule, prompt, recurring, notify };
+  const modelLine = lines.find((l) => l.startsWith("model:"));
+  const model = modelLine ? parseFrontmatterValue(modelLine.replace("model:", "")) || undefined : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model };
 }
 
 export async function loadJobs(): Promise<Job[]> {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -343,7 +343,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string): Promise<RunResult> {
+async function execClaude(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
   const existing = threadId
@@ -361,7 +361,10 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   let taskType = "unknown";
   let routingReasoning = "";
 
-  if (agentic.enabled) {
+  if (modelOverride) {
+    primaryConfig = { model: modelOverride, api };
+    console.log(`[${new Date().toLocaleTimeString()}] Job model override: ${modelOverride}`);
+  } else if (agentic.enabled) {
     const routing = selectModel(prompt, agentic.modes, agentic.defaultMode);
     primaryConfig = { model: routing.model, api };
     taskType = routing.taskType;
@@ -541,8 +544,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId), threadId);
+export async function run(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt, threadId, modelOverride), threadId);
 }
 
 async function streamClaude(


### PR DESCRIPTION
## What this does

Adds a `model` frontmatter field to job files. When set, it overrides the global model (and agentic routing) for that specific job.

```markdown
---
schedule: "0 * * * *"
model: haiku
---
Check disk usage and alert if above 90%.
```

```markdown
---
schedule: "0 9 * * 1"
model: opus
---
Write a detailed weekly strategy review based on last week's logs.
```

## Why

Scheduled jobs vary widely in complexity. Routing all of them through the same model wastes money on simple tasks (monitoring, digests, quick summaries) that haiku handles fine, and may underserve complex tasks that benefit from opus. A per-job override gives fine-grained control without separate daemon instances or settings files.

## Behaviour

- `model` present in frontmatter → uses that model, **skips** agentic routing
- `model` absent → existing behaviour unchanged (global setting + agentic routing if enabled)

## Changes

| File | Change |
|------|--------|
| `src/jobs.ts` | Add `model?: string` to `Job` interface; parse `model:` from frontmatter |
| `src/runner.ts` | Add `modelOverride?` param to `execClaude()` and `run()`; apply before agentic routing check |
| `src/commands/start.ts` | Pass `job.model` to `run()` at the cron fire site |

## Validation

Added `model: haiku` to a production job file and confirmed:
- Daemon loads the job correctly (`Jobs loaded: N` in startup log, job listed with correct schedule)
- At fire time: `Job model override: haiku` appears in log before the claude invocation
- `--model haiku` is passed to the claude CLI subprocess

Backward compatible: existing job files without `model:` behave identically.