### PR TITLE
fix(config): accept extracted Discord user ids

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -217,7 +217,10 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(
+  raw: Record<string, any>,
+  discordUserIds?: string[],
+): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)
@@ -249,7 +252,9 @@ function parseSettings(raw: Record<string, any>): Settings {
     },
     discord: {
       token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
-      allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
+      allowedUserIds: Array.isArray(discordUserIds)
+        ? discordUserIds
+        : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)


### PR DESCRIPTION
## Summary

Fix the `parseSettings()` signature so it accepts the extracted raw Discord user IDs from `settings.json`.

This keeps `loadSettings()` and `reloadSettings()` aligned with the actual function signature and preserves Discord snowflake IDs as raw strings from the original file text instead of relying only on parsed JSON values.

## What changed

- update `parseSettings()` to accept an optional `discordUserIds?: string[]`
- use `discordUserIds` for `discord.allowedUserIds` when provided
- fall back to the existing parsed JSON path when extracted IDs are not provided

## Why

Discord snowflake IDs can exceed JavaScript's safe integer precision. Threading the extracted raw IDs through the parser preserves them as strings and fixes the existing `parseSettings(raw, extractDiscordUserIds(rawText))` arity mismatch.

## Validation

- `bunx tsc --noEmit`
