### PR TITLE
fix(status): load settings before resolving runtime config helpers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { readdir, readFile } from "fs/promises";
 import { homedir } from "os";
-import { getJobsDir } from "../config";
+import { getJobsDir, loadSettings } from "../config";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -133,6 +133,11 @@ async function showStatus(): Promise<boolean> {
 }
 
 export async function status(args: string[]) {
+  // Populate the settings cache so that runtime-resolved helpers (e.g. getJobsDir())
+  // return the configured values rather than their compile-time defaults. Any future
+  // setting that is resolved via getSettings() will benefit from this automatically.
+  try { await loadSettings(); } catch {}
+
   if (args.includes("--all")) {
     await showAll();
   } else {


### PR DESCRIPTION
Follow-up to #113.

## Problem

`claudeclaw status` (standalone CLI) never called `loadSettings()`, so `getJobsDir()` and any other helper that depends on the settings cache always returned compile-time defaults, ignoring values configured in `settings.json`.

This was flagged as a pre-existing limitation during review of #113 — out of scope for that PR but worth addressing separately.

## Fix

One `try/catch`-wrapped `loadSettings()` call at the entry point of `status()`, before the command dispatches to `showAll()` or `showStatus()`.

The try/catch means a missing or malformed `settings.json` degrades gracefully — `status` still works, helpers just fall back to their defaults, same as today.

## Why this is a general fix, not a jobsDir-specific one

The comment in the code explains the intent: any future setting resolved via `getSettings()` or a helper like `getJobsDir()` will now work correctly in the status command without any further changes. This is architectural future-proofing, not a patch for one specific field.