### PR TITLE
batch: merge config, statusline, env token, and jobs-dir fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,13 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.0",
-      "keywords": ["cron", "heartbeat", "scheduler", "daemon"],
+      "version": "1.0.1",
+      "keywords": [
+        "cron",
+        "heartbeat",
+        "scheduler",
+        "daemon"
+      ],
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -32,6 +32,18 @@ const DIM = "\\x1b[2m";
 const RED = "\\x1b[31m";
 const GREEN = "\\x1b[32m";
 
+function stripAnsi(s) { return s.replace(/\\x1b\\[[0-9;]*m/g, ""); }
+function visibleLen(s) {
+  var clean = stripAnsi(s);
+  var len = 0;
+  for (var i = 0; i < clean.length; i++) {
+    var code = clean.codePointAt(i);
+    if (code > 0xffff) { i++; len += 2; }
+    else { len++; }
+  }
+  return len;
+}
+
 function fmt(ms) {
   if (ms <= 0) return GREEN + "now!" + R;
   var s = Math.floor(ms / 1000);
@@ -51,20 +63,26 @@ function alive() {
 }
 
 var B = DIM + "\\u2502" + R;
-var TL = DIM + "\\u256d" + R;
-var TR = DIM + "\\u256e" + R;
-var BL = DIM + "\\u2570" + R;
-var BR = DIM + "\\u256f" + R;
-var H = DIM + "\\u2500" + R;
-var HEADER = TL + H.repeat(6) + " \\ud83e\\udd9e ClaudeClaw \\ud83e\\udd9e " + H.repeat(6) + TR;
-var FOOTER = BL + H.repeat(30) + BR;
+var TITLE = " \\ud83e\\udd9e ClaudeClaw \\ud83e\\udd9e ";
+var PAD = 6;
+var INNER_W = PAD + visibleLen(TITLE) + PAD;
+
+function render(content) {
+  var contentW = visibleLen(content);
+  var w = Math.max(contentW, INNER_W);
+  var titlePad = w - visibleLen(TITLE);
+  var leftPad = Math.floor(titlePad / 2);
+  var rightPad = titlePad - leftPad;
+  var H = DIM + "\\u2500" + R;
+  var header = DIM + "\\u256d" + R + H.repeat(leftPad) + TITLE + H.repeat(rightPad) + DIM + "\\u256e" + R;
+  var footer = DIM + "\\u2570" + R + H.repeat(w) + DIM + "\\u256f" + R;
+  var gap = w - contentW;
+  var padded = gap > 0 ? content + " ".repeat(gap) : content;
+  process.stdout.write(header + "\\n" + B + padded + B + "\\n" + footer);
+}
 
 if (!alive()) {
-  process.stdout.write(
-    HEADER + "\\n" +
-    B + "        " + RED + "\\u25cb offline" + R + "              " + B + "\\n" +
-    FOOTER
-  );
+  render("        " + RED + "\\u25cb offline" + R);
   process.exit(0);
 }
 
@@ -89,15 +107,9 @@ try {
     info.push(GREEN + "\\ud83c\\udfae" + R);
   }
 
-  var mid = " " + info.join(" " + B + " ") + " ";
-
-  process.stdout.write(HEADER + "\\n" + B + mid + B + "\\n" + FOOTER);
+  render(" " + info.join(" " + B + " ") + " ");
 } catch {
-  process.stdout.write(
-    HEADER + "\\n" +
-    B + DIM + "         waiting...         " + R + B + "\\n" +
-    FOOTER
-  );
+  render(DIM + "         waiting...         " + R);
 }
 `;
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,13 +1,13 @@
 import { join } from "path";
 import { readdir, readFile } from "fs/promises";
 import { homedir } from "os";
+import { getJobsDir } from "../config";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
 const PID_FILE = join(HEARTBEAT_DIR, "daemon.pid");
 const STATE_FILE = join(HEARTBEAT_DIR, "state.json");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
-const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 
 function formatCountdown(ms: number): string {
   if (ms <= 0) return "now!";
@@ -100,12 +100,12 @@ async function showStatus(): Promise<boolean> {
   } catch {}
 
   try {
-    const files = await readdir(JOBS_DIR);
+    const files = await readdir(getJobsDir());
     const mdFiles = files.filter((f) => f.endsWith(".md"));
     if (mdFiles.length > 0) {
       console.log(`  Jobs: ${mdFiles.length}`);
       for (const f of mdFiles) {
-        const content = await Bun.file(join(JOBS_DIR, f)).text();
+        const content = await Bun.file(join(getJobsDir(), f)).text();
         const match = content.match(/schedule:\s*["']?([^"'\n]+)/);
         const schedule = match ? match[1].trim() : "unknown";
         console.log(`    - ${f.replace(/\.md$/, "")} [${schedule}]`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,15 @@ import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone"
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
-const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
+const DEFAULT_JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
+
+export function getJobsDir(): string {
+  if (cached?.jobsDir) {
+    return isAbsolute(cached.jobsDir) ? cached.jobsDir : join(process.cwd(), cached.jobsDir);
+  }
+  return DEFAULT_JOBS_DIR;
+}
 
 const DEFAULT_SETTINGS: Settings = {
   model: "",
@@ -113,6 +120,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  jobsDir?: string;
 }
 
 export interface AgenticMode {
@@ -152,7 +160,7 @@ let cached: Settings | null = null;
 
 export async function initConfig(): Promise<void> {
   await mkdir(HEARTBEAT_DIR, { recursive: true });
-  await mkdir(JOBS_DIR, { recursive: true });
+  await mkdir(getJobsDir(), { recursive: true });
   await mkdir(LOGS_DIR, { recursive: true });
 
   if (!existsSync(SETTINGS_FILE)) {
@@ -217,7 +225,10 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(
+  raw: Record<string, any>,
+  discordUserIds?: string[],
+): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)
@@ -244,12 +255,14 @@ function parseSettings(raw: Record<string, any>): Settings {
       forwardToTelegram: raw.heartbeat?.forwardToTelegram ?? false,
     },
     telegram: {
-      token: raw.telegram?.token ?? "",
+      token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
     },
     discord: {
-      token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
-      allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
+      token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
+      allowedUserIds: Array.isArray(discordUserIds)
+        ? discordUserIds
+        : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)
@@ -274,6 +287,7 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }
 

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,7 +1,6 @@
 import { readdir } from "fs/promises";
 import { join } from "path";
-
-const JOBS_DIR = join(process.cwd(), ".claude", "claudeclaw", "jobs");
+import { getJobsDir } from "./config";
 
 export interface Job {
   name: string;
@@ -58,14 +57,14 @@ export async function loadJobs(): Promise<Job[]> {
   const jobs: Job[] = [];
   let files: string[];
   try {
-    files = await readdir(JOBS_DIR);
+    files = await readdir(getJobsDir());
   } catch {
     return jobs;
   }
 
   for (const file of files) {
     if (!file.endsWith(".md")) continue;
-    const content = await Bun.file(join(JOBS_DIR, file)).text();
+    const content = await Bun.file(join(getJobsDir(), file)).text();
     const job = parseJobFile(file.replace(/\.md$/, ""), content);
     if (job) jobs.push(job);
   }
@@ -73,7 +72,7 @@ export async function loadJobs(): Promise<Job[]> {
 }
 
 export async function clearJobSchedule(jobName: string): Promise<void> {
-  const path = join(JOBS_DIR, `${jobName}.md`);
+  const path = join(getJobsDir(), `${jobName}.md`);
   const content = await Bun.file(path).text();
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!match) return;

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -2,7 +2,6 @@ import { join } from "path";
 
 export const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 export const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
-export const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 export const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 export const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
 export const STATE_FILE = join(HEARTBEAT_DIR, "state.json");

--- a/src/ui/services/jobs.ts
+++ b/src/ui/services/jobs.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
-import { JOBS_DIR } from "../constants";
+import { getJobsDir } from "../../config";
 
 export interface QuickJobInput {
   time?: unknown;
@@ -35,10 +35,10 @@ export async function createQuickJob(input: QuickJobInput): Promise<{ name: stri
   const schedule = `${minute} ${hour} * * *`;
   const stamp = new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
   const name = `quick-${stamp}-${hour.toString().padStart(2, "0")}${minute.toString().padStart(2, "0")}`;
-  const path = join(JOBS_DIR, `${name}.md`);
+  const path = join(getJobsDir(), `${name}.md`);
   const content = `---\nschedule: "${schedule}"\nrecurring: ${recurring ? "true" : "false"}\n---\n${prompt}\n`;
 
-  await mkdir(JOBS_DIR, { recursive: true });
+  await mkdir(getJobsDir(), { recursive: true });
   await writeFile(path, content, "utf-8");
   return { name, schedule, recurring };
 }
@@ -48,6 +48,6 @@ export async function deleteJob(name: string): Promise<void> {
   if (!/^[a-zA-Z0-9._-]+$/.test(jobName)) {
     throw new Error("Invalid job name.");
   }
-  const path = join(JOBS_DIR, `${jobName}.md`);
+  const path = join(getJobsDir(), `${jobName}.md`);
   await Bun.file(path).delete();
 }


### PR DESCRIPTION
## Summary

Batch integration branch for the current clean versions of:
- #119 — parseSettings discordUserIds fix
- #91 — env var token precedence fix
- #86 — statusline width/rendering fix
- #113 — configurable jobs directory fix

This branch intentionally applies the functional changes together on top of current `master` and regenerates the plugin metadata bump once, rather than carrying each PR's separate bump commit.

## Included changes

- accept `discordUserIds?: string[]` in `parseSettings()` and preserve raw Discord snowflake IDs
- trim `DISCORD_TOKEN` / `TELEGRAM_TOKEN` env vars before precedence is applied
- dynamically size the statusline box to the widest rendered row
- support `jobsDir` outside `.claude/` and resolve `getJobsDir()` at point of use in job/status/UI paths

## Validation

- `bunx tsc --noEmit`
