### PR TITLE
fix(config): fall back when extracted Discord ids are empty

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,7 +260,7 @@ function parseSettings(
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
-      allowedUserIds: Array.isArray(discordUserIds)
+      allowedUserIds: Array.isArray(discordUserIds) && discordUserIds.length > 0
         ? discordUserIds
         : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)


### PR DESCRIPTION
## Summary

Hotfix for the `parseSettings()` Discord ID guard merged via the recent batch branch.

## Problem

`allowedUserIds: Array.isArray(discordUserIds) ? discordUserIds : ...` is too broad because `Array.isArray([])` is still true. If `extractDiscordUserIds()` fails to find IDs in the raw text, the empty extracted array suppresses the JSON-parsed fallback and silently produces `[]`.

## Fix

Only prefer the extracted raw IDs when the extracted array is non-empty:

```ts
Array.isArray(discordUserIds) && discordUserIds.length > 0
```

Otherwise, fall back to the parsed JSON values.

## Why

This preserves the intended snowflake-safety behaviour without turning an extraction miss into an empty allowlist.

## Validation

- `bunx tsc --noEmit`
