### PR TITLE
feat(discord): inline .txt and .md file attachments into the prompt

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -340,6 +340,12 @@ function isVoiceAttachment(a: DiscordAttachment): boolean {
   return Boolean(a.content_type?.startsWith("audio/"));
 }
 
+function isTextAttachment(a: DiscordAttachment): boolean {
+  if (a.content_type?.startsWith("text/")) return true;
+  const ext = extname(a.filename).toLowerCase();
+  return ext === ".txt" || ext === ".md";
+}
+
 async function downloadDiscordAttachment(
   attachment: DiscordAttachment,
   type: "image" | "voice",
@@ -475,10 +481,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   // Detect attachments
   const imageAttachments = message.attachments.filter(isImageAttachment);
   const voiceAttachments = message.attachments.filter(isVoiceAttachment);
+  const textAttachments = message.attachments.filter(isTextAttachment);
   const hasImage = imageAttachments.length > 0;
   const hasVoice = voiceAttachments.length > 0;
+  const hasText = textAttachments.length > 0;
 
-  if (!content.trim() && !hasImage && !hasVoice) return;
+  if (!content.trim() && !hasImage && !hasVoice && !hasText) return;
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;
@@ -487,7 +495,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   }
 
   const label = message.author.username;
-  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : ""].filter(Boolean);
+  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : "", hasText ? "text" : ""].filter(Boolean);
   const mediaSuffix = mediaParts.length > 0 ? ` [${mediaParts.join("+")}]` : "";
   console.log(
     `[${new Date().toLocaleTimeString()}] Discord ${label}${mediaSuffix}: "${cleanContent.slice(0, 60)}${cleanContent.length > 60 ? "..." : ""}"`,
@@ -502,6 +510,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     let imagePath: string | null = null;
     let voicePath: string | null = null;
     let voiceTranscript: string | null = null;
+    let textContent: string | null = null;
 
     if (hasImage) {
       try {
@@ -528,6 +537,18 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
         } catch (err) {
           console.error(`[Discord] Failed to transcribe voice for ${label}: ${err instanceof Error ? err.message : err}`);
         }
+      }
+    }
+
+    if (hasText) {
+      try {
+        const resp = await fetch(textAttachments[0].url);
+        if (resp.ok) {
+          const raw = await resp.text();
+          textContent = raw.length > 51200 ? raw.slice(0, 51200) + "\n...[truncated]" : raw;
+        }
+      } catch (err) {
+        console.error(`[Discord] Failed to fetch text attachment for ${label}: ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -633,6 +654,11 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       promptParts.push(
         "The user attached voice audio, but it could not be transcribed. Respond and ask them to resend a clearer clip.",
       );
+    }
+    if (textContent) {
+      promptParts.push(`Attached text file (${textAttachments[0].filename}):\n${textContent}`);
+    } else if (hasText) {
+      promptParts.push("The user attached a text file, but downloading it failed. Ask them to resend.");
     }
 
     const prefixedPrompt = promptParts.join("\n");


### PR DESCRIPTION
## What

Discord auto-converts large text pastes (> ~2000 characters) into `.txt` file attachments. Without this change those attachments were silently ignored — the bot would see an empty message and drop it. This PR detects and inlines them into the prompt as context.

## Changes

- `src/commands/discord.ts`
  - `isTextAttachment(a)` — detects attachments with `content_type: text/*` or extension `.txt` / `.md`
  - Early-return guard updated: `!hasText` added so text-only messages aren't dropped
  - `mediaParts` label updated to include `"text"` in the console log suffix
  - Fetch block downloads the first text attachment (capped at **50 KB** with a `...[truncated]` marker to avoid overflowing context)
  - Prompt part appends `Attached text file (<filename>):\n<content>` so the model sees the file inline

## Behaviour

- Only the first text attachment is inlined (consistent with how images and voice are handled).
- Network failures are caught and logged; the model is told "downloading failed, ask to resend" rather than silently missing the file.
- Files larger than 50 KB are truncated with a visible marker so the model knows content was cut.
- `.md` files are included — useful for sharing config/code snippets alongside a question.

## Testing locally

1. Update plugin: `bun run claudeclaw-plugin.json` content changes (no version bump needed)
2. Restart claudeclaw daemon
3. In Discord, paste any block of text > 2000 chars at the bot — Discord auto-attaches it as `message.txt`
4. Bot should respond with awareness of the file's contents

## PR Plugin updates

Does only and other non-shipped changes do this PR.