### PR TITLE
feat(telegram): add listenChats — respond in group chats without @mention

### DIFF
--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -419,6 +419,9 @@ function groupTriggerReason(message: TelegramMessage): string | null {
     }
   }
 
+  const { telegram } = getSettings();
+  if (telegram.listenChats?.includes(message.chat.id)) return "listen_chat";
+
   return null;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [] },
+  telegram: { token: "", allowedUserIds: [], listenChats: [] },
   discord: { token: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
@@ -87,6 +87,7 @@ export interface HeartbeatConfig {
 export interface TelegramConfig {
   token: string;
   allowedUserIds: number[];
+  listenChats: number[];
 }
 
 export interface DiscordConfig {
@@ -257,6 +258,7 @@ function parseSettings(
     telegram: {
       token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
+      listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),


### PR DESCRIPTION
## What

Adds a `listenChats` array to the Telegram config. Any chat ID listed there is treated as a
"listening" chat: every message triggers a response, no @mention required.

This is distinct from `allowedUserIds`, which gates *who* can interact — `listenChats` gates
*which chats* are always-on.

## Config

```json
{
  "telegram": {
    "token": "...",
    "allowedUserIds": [123456789],
    "listenChats": [-100123456789]
  }
}
```

Negative IDs are group/supergroup chats. Obtain a chat ID by forwarding a message to `@userinfobot` or checking the URL in Telegram Web.

## Changes

- `src/config.ts` — `listenChats: number[]` added to `TelegramConfig` interface and `DEFAULT_SETTINGS`; parsed via `parseSettings` with safe `Array.map(Number)` coercion
- `src/commands/telegram.ts` — `groupTriggerReason` returns `"listen_chat"` for any message in a listed chat, before the existing `return null` fallthrough

## Behaviour

- Messages from users *not* in `allowedUserIds` in a `listenChats` chat are still gated — the user-ID check runs before `groupTriggerReason`.
- An empty `listenChats: []` (the default) is a no-op; existing behaviour is unchanged.