### PR TITLE
feat(discord): upload local image paths as attachments

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -185,20 +185,30 @@ async function discordApi<T>(
 
 // --- Message sending ---
 
+const DISCORD_MAX_MESSAGE_LEN = 2000;
+
+function discordMessageChunks(text: string): string[] {
+  const normalized = text.replace(/\[react:[^\]\r\n]+\]/gi, "").trim();
+  if (!normalized) return [];
+  const chunks: string[] = [];
+  for (let i = 0; i < normalized.length; i += DISCORD_MAX_MESSAGE_LEN) {
+    chunks.push(normalized.slice(i, i + DISCORD_MAX_MESSAGE_LEN));
+  }
+  return chunks;
+}
+
 async function sendMessage(
   token: string,
   channelId: string,
   text: string,
   components?: unknown[],
 ): Promise<void> {
-  const normalized = text.replace(/\[react:[^\]\r\n]+\]/gi, "").trim();
-  if (!normalized) return;
-  const MAX_LEN = 2000;
-  for (let i = 0; i < normalized.length; i += MAX_LEN) {
-    const chunk = normalized.slice(i, i + MAX_LEN);
+  const chunks = discordMessageChunks(text);
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
     const body: Record<string, unknown> = { content: chunk };
     // Attach components only to the last chunk
-    if (components && i + MAX_LEN >= normalized.length) {
+    if (components && i === chunks.length - 1) {
       body.components = components;
     }
     await discordApi(token, "POST", `/channels/${channelId}/messages`, body);
@@ -300,10 +310,25 @@ async function sendMessageWithImages(
   channelId: string,
   text: string,
   imagePaths: string[],
+): Promise<void> {
+  const chunks = discordMessageChunks(text || "​");
+  const uploadText = chunks.pop() ?? "​";
+  for (const chunk of chunks) {
+    await discordApi(token, "POST", `/channels/${channelId}/messages`, { content: chunk });
+  }
+
+  await uploadImageMessage(token, channelId, uploadText, imagePaths);
+}
+
+async function uploadImageMessage(
+  token: string,
+  channelId: string,
+  text: string,
+  imagePaths: string[],
   attempt = 0,
 ): Promise<void> {
   const form = new FormData();
-  form.append("payload_json", JSON.stringify({ content: text || "​" }));
+  form.append("payload_json", JSON.stringify({ content: text }));
   for (let i = 0; i < imagePaths.length; i++) {
     const file = Bun.file(imagePaths[i]);
     form.append(`files[${i}]`, file, basename(imagePaths[i]));
@@ -322,7 +347,7 @@ async function sendMessageWithImages(
       ? Math.ceil(data.retry_after * 1000)
       : 5_000;
     await Bun.sleep(delay);
-    return sendMessageWithImages(token, channelId, text, imagePaths, attempt + 1);
+    return uploadImageMessage(token, channelId, text, imagePaths, attempt + 1);
   }
   if (!res.ok) {
     const errText = await res.text().catch(() => "");

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -148,6 +148,7 @@ async function discordApi<T>(
   method: string,
   endpoint: string,
   body?: unknown,
+  attempt = 0,
 ): Promise<T> {
   const res = await fetch(`${DISCORD_API}${endpoint}`, {
     method,
@@ -160,11 +161,16 @@ async function discordApi<T>(
 
   // Rate limit handling
   if (res.status === 429) {
-    const data = (await res.json()) as { retry_after: number };
-    const retryMs = Math.ceil(data.retry_after * 1000);
-    debugLog(`Rate limited on ${method} ${endpoint}, retrying in ${retryMs}ms`);
+    if (attempt >= 3) {
+      throw new Error(`Discord rate limit exceeded after 3 retries on ${method} ${endpoint}`);
+    }
+    const data = (await res.json().catch(() => ({}))) as { retry_after?: number };
+    const retryMs = typeof data.retry_after === "number" && isFinite(data.retry_after)
+      ? Math.ceil(data.retry_after * 1000)
+      : 5_000;
+    debugLog(`Rate limited on ${method} ${endpoint}, retrying in ${retryMs}ms (attempt ${attempt + 1}/3)`);
     await Bun.sleep(retryMs);
-    return discordApi(token, method, endpoint, body);
+    return discordApi(token, method, endpoint, body, attempt + 1);
   }
 
   if (!res.ok) {
@@ -294,6 +300,7 @@ async function sendMessageWithImages(
   channelId: string,
   text: string,
   imagePaths: string[],
+  attempt = 0,
 ): Promise<void> {
   const form = new FormData();
   form.append("payload_json", JSON.stringify({ content: text || "​" }));
@@ -307,9 +314,15 @@ async function sendMessageWithImages(
     body: form,
   });
   if (res.status === 429) {
-    const data = (await res.json()) as { retry_after: number };
-    await Bun.sleep(Math.ceil(data.retry_after * 1000));
-    return sendMessageWithImages(token, channelId, text, imagePaths);
+    if (attempt >= 3) {
+      throw new Error(`Discord rate limit exceeded after 3 retries on ${channelId}`);
+    }
+    const data = (await res.json().catch(() => ({}))) as { retry_after?: number };
+    const delay = typeof data.retry_after === "number" && isFinite(data.retry_after)
+      ? Math.ceil(data.retry_after * 1000)
+      : 5_000;
+    await Bun.sleep(delay);
+    return sendMessageWithImages(token, channelId, text, imagePaths, attempt + 1);
   }
   if (!res.ok) {
     const errText = await res.text().catch(() => "");

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -8,7 +8,7 @@ import { homedir } from "node:os";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { extname, join, basename } from "node:path";
 
 // --- Discord API constants ---
 
@@ -233,6 +233,53 @@ function extractReactionDirective(text: string): { cleanedText: string; reaction
     .replace(/\n{3,}/g, "\n\n")
     .trim();
   return { cleanedText, reactionEmoji };
+}
+
+// Matches absolute image file paths embedded in reply text so they can be
+// sent as Discord file attachments instead of appearing as raw paths.
+const IMAGE_PATH_RE = /(?<![^\s])(\/[^\s]+\.(?:png|jpe?g|gif|webp))(?=\s|$)/gi;
+
+function extractImagePaths(text: string): { paths: string[]; cleanedText: string } {
+  const paths: string[] = [];
+  const cleanedText = text
+    .replace(IMAGE_PATH_RE, (match, p1) => {
+      if (existsSync(p1)) {
+        paths.push(p1);
+        return "";
+      }
+      return match;
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { paths, cleanedText };
+}
+
+async function sendMessageWithImages(
+  token: string,
+  channelId: string,
+  text: string,
+  imagePaths: string[],
+): Promise<void> {
+  const form = new FormData();
+  form.append("payload_json", JSON.stringify({ content: text || "​" }));
+  for (let i = 0; i < imagePaths.length; i++) {
+    const file = Bun.file(imagePaths[i]);
+    form.append(`files[${i}]`, file, basename(imagePaths[i]));
+  }
+  const res = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+    method: "POST",
+    headers: { Authorization: `Bot ${token}` },
+    body: form,
+  });
+  if (res.status === 429) {
+    const data = (await res.json()) as { retry_after: number };
+    await Bun.sleep(Math.ceil(data.retry_after * 1000));
+    return sendMessageWithImages(token, channelId, text, imagePaths);
+  }
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(`Discord image upload ${channelId}: ${res.status} ${errText}`);
+  }
 }
 
 // --- Thread rejoin helper ---
@@ -649,7 +696,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
           console.error(`[Discord] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
         });
       }
-      await sendMessage(config.token, channelId, cleanedText || "(empty response)");
+      const { paths: imagePaths, cleanedText: finalText } = extractImagePaths(cleanedText || "");
+      if (imagePaths.length > 0) {
+        await sendMessageWithImages(config.token, channelId, finalText || "(empty response)", imagePaths);
+      } else {
+        await sendMessage(config.token, channelId, finalText || "(empty response)");
+      }
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -340,6 +340,12 @@ function isVoiceAttachment(a: DiscordAttachment): boolean {
   return Boolean(a.content_type?.startsWith("audio/"));
 }
 
+function isTextAttachment(a: DiscordAttachment): boolean {
+  if (a.content_type?.startsWith("text/")) return true;
+  const ext = extname(a.filename).toLowerCase();
+  return ext === ".txt" || ext === ".md";
+}
+
 async function downloadDiscordAttachment(
   attachment: DiscordAttachment,
   type: "image" | "voice",
@@ -475,10 +481,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   // Detect attachments
   const imageAttachments = message.attachments.filter(isImageAttachment);
   const voiceAttachments = message.attachments.filter(isVoiceAttachment);
+  const textAttachments = message.attachments.filter(isTextAttachment);
   const hasImage = imageAttachments.length > 0;
   const hasVoice = voiceAttachments.length > 0;
+  const hasText = textAttachments.length > 0;
 
-  if (!content.trim() && !hasImage && !hasVoice) return;
+  if (!content.trim() && !hasImage && !hasVoice && !hasText) return;
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;
@@ -487,7 +495,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   }
 
   const label = message.author.username;
-  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : ""].filter(Boolean);
+  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : "", hasText ? "text" : ""].filter(Boolean);
   const mediaSuffix = mediaParts.length > 0 ? ` [${mediaParts.join("+")}]` : "";
   console.log(
     `[${new Date().toLocaleTimeString()}] Discord ${label}${mediaSuffix}: "${cleanContent.slice(0, 60)}${cleanContent.length > 60 ? "..." : ""}"`,
@@ -502,6 +510,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     let imagePath: string | null = null;
     let voicePath: string | null = null;
     let voiceTranscript: string | null = null;
+    let textContent: string | null = null;
 
     if (hasImage) {
       try {
@@ -528,6 +537,18 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
         } catch (err) {
           console.error(`[Discord] Failed to transcribe voice for ${label}: ${err instanceof Error ? err.message : err}`);
         }
+      }
+    }
+
+    if (hasText) {
+      try {
+        const resp = await fetch(textAttachments[0].url);
+        if (resp.ok) {
+          const raw = await resp.text();
+          textContent = raw.length > 51200 ? raw.slice(0, 51200) + "\n...[truncated]" : raw;
+        }
+      } catch (err) {
+        console.error(`[Discord] Failed to fetch text attachment for ${label}: ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -633,6 +654,11 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       promptParts.push(
         "The user attached voice audio, but it could not be transcribed. Respond and ask them to resend a clearer clip.",
       );
+    }
+    if (textContent) {
+      promptParts.push(`Attached text file (${textAttachments[0].filename}):\n${textContent}`);
+    } else if (hasText) {
+      promptParts.push("The user attached a text file, but downloading it failed. Ask them to resend.");
     }
 
     const prefixedPrompt = promptParts.join("\n");

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,15 +1,15 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { extractErrorDetail } from "../messaging";
-import { getSettings, loadSettings } from "../config";
+import { getSettings, loadSettings, DEFAULT_IMAGE_OUTPUT_ROOT } from "../config";
 import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
 import { readFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
-import { extname, join, basename } from "node:path";
+import { extname, join, basename, sep } from "node:path";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 
 // --- Discord API constants ---
@@ -253,16 +253,36 @@ function extractReactionDirective(text: string): { cleanedText: string; reaction
 // Matches absolute image file paths embedded in reply text so they can be
 // sent as Discord file attachments instead of appearing as raw paths.
 const IMAGE_PATH_RE = /(?<![^\s])(\/[^\s]+\.(?:png|jpe?g|gif|webp))(?=\s|$)/gi;
+const PATH_SKEW_MS = 30_000;
 
-function extractImagePaths(text: string): { paths: string[]; cleanedText: string } {
+function extractImagePaths(
+  text: string,
+  allowedRoots: string[],
+  requestStartedAt: number,
+): { paths: string[]; cleanedText: string } {
+  const roots = allowedRoots.length > 0 ? allowedRoots : [DEFAULT_IMAGE_OUTPUT_ROOT];
+  const canonRoots = roots.map((r) => {
+    try { return realpathSync(r); } catch { return r; }
+  });
   const paths: string[] = [];
   const cleanedText = text
     .replace(IMAGE_PATH_RE, (match, p1) => {
-      if (existsSync(p1)) {
-        paths.push(p1);
-        return "";
+      let resolved: string;
+      try {
+        resolved = realpathSync(p1);
+      } catch {
+        return match;
       }
-      return match;
+      const confined = canonRoots.some((root) => resolved === root || resolved.startsWith(root + sep));
+      if (!confined) return match;
+      try {
+        const { mtimeMs } = statSync(resolved);
+        if (mtimeMs < requestStartedAt - PATH_SKEW_MS) return match;
+      } catch {
+        return match;
+      }
+      paths.push(resolved);
+      return "";
     })
     .replace(/\n{3,}/g, "\n\n")
     .trim();
@@ -744,6 +764,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const prefixedPrompt = promptParts.join("\n");
     // Use thread-specific session if message is in a known thread
     const threadId = knownThreads.has(channelId) ? channelId : undefined;
+    const requestStartedAt = Date.now();
     const result = await runUserMessage("discord", prefixedPrompt, threadId, threadInfo?.agentName);
 
     if (result.exitCode !== 0) {
@@ -755,7 +776,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
           console.error(`[Discord] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
         });
       }
-      const { paths: imagePaths, cleanedText: finalText } = extractImagePaths(cleanedText || "");
+      const { paths: imagePaths, cleanedText: finalText } = extractImagePaths(cleanedText || "", config.imageOutputRoots, requestStartedAt);
       if (imagePaths.length > 0) {
         await sendMessageWithImages(config.token, channelId, finalText || "(empty response)", imagePaths);
       } else {

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -9,7 +9,7 @@ import { homedir } from "node:os";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { extname, join, basename } from "node:path";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 
 // --- Discord API constants ---
@@ -248,6 +248,53 @@ function extractReactionDirective(text: string): { cleanedText: string; reaction
     .replace(/\n{3,}/g, "\n\n")
     .trim();
   return { cleanedText, reactionEmoji };
+}
+
+// Matches absolute image file paths embedded in reply text so they can be
+// sent as Discord file attachments instead of appearing as raw paths.
+const IMAGE_PATH_RE = /(?<![^\s])(\/[^\s]+\.(?:png|jpe?g|gif|webp))(?=\s|$)/gi;
+
+function extractImagePaths(text: string): { paths: string[]; cleanedText: string } {
+  const paths: string[] = [];
+  const cleanedText = text
+    .replace(IMAGE_PATH_RE, (match, p1) => {
+      if (existsSync(p1)) {
+        paths.push(p1);
+        return "";
+      }
+      return match;
+    })
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { paths, cleanedText };
+}
+
+async function sendMessageWithImages(
+  token: string,
+  channelId: string,
+  text: string,
+  imagePaths: string[],
+): Promise<void> {
+  const form = new FormData();
+  form.append("payload_json", JSON.stringify({ content: text || "​" }));
+  for (let i = 0; i < imagePaths.length; i++) {
+    const file = Bun.file(imagePaths[i]);
+    form.append(`files[${i}]`, file, basename(imagePaths[i]));
+  }
+  const res = await fetch(`${DISCORD_API}/channels/${channelId}/messages`, {
+    method: "POST",
+    headers: { Authorization: `Bot ${token}` },
+    body: form,
+  });
+  if (res.status === 429) {
+    const data = (await res.json()) as { retry_after: number };
+    await Bun.sleep(Math.ceil(data.retry_after * 1000));
+    return sendMessageWithImages(token, channelId, text, imagePaths);
+  }
+  if (!res.ok) {
+    const errText = await res.text().catch(() => "");
+    throw new Error(`Discord image upload ${channelId}: ${res.status} ${errText}`);
+  }
 }
 
 // --- Thread rejoin helper ---
@@ -708,7 +755,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
           console.error(`[Discord] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
         });
       }
-      await sendMessage(config.token, channelId, cleanedText || "(empty response)");
+      const { paths: imagePaths, cleanedText: finalText } = extractImagePaths(cleanedText || "");
+      if (imagePaths.length > 0) {
+        await sendMessageWithImages(config.token, channelId, finalText || "(empty response)", imagePaths);
+      } else {
+        await sendMessage(config.token, channelId, finalText || "(empty response)");
+      }
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,8 @@ const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
 /** Default Claude session timeout (30 minutes). Exported so runner.ts can reference the same value. */
 export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
+export const DEFAULT_IMAGE_OUTPUT_ROOT = join(HEARTBEAT_DIR, "outbox", "discord");
+
 export function getJobsDir(): string {
   if (cached?.jobsDir) {
     return isAbsolute(cached.jobsDir) ? cached.jobsDir : join(process.cwd(), cached.jobsDir);
@@ -77,7 +79,7 @@ const DEFAULT_SETTINGS: Settings = {
     forwardToTelegram: true,
   },
   telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true },
-  discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [] },
+  discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [] },
   slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
@@ -116,6 +118,7 @@ export interface DiscordConfig {
   allowedUserIds: string[]; // Discord snowflake IDs exceed Number.MAX_SAFE_INTEGER
   listenChannels: string[]; // Channel IDs where bot responds to all messages (no mention needed)
   listenGuilds: string[]; // Guild IDs where bot responds to all messages in any channel/thread
+  imageOutputRoots: string[]; // Absolute path prefixes from which image uploads are permitted
 }
 
 export interface SlackConfig {
@@ -336,6 +339,9 @@ function parseSettings(
         : [],
       listenGuilds: Array.isArray(raw.discord?.listenGuilds)
         ? raw.discord.listenGuilds.map(String)
+        : [],
+      imageOutputRoots: Array.isArray(raw.discord?.imageOutputRoots)
+        ? raw.discord.imageOutputRoots.filter((r: unknown) => typeof r === "string" && isAbsolute(r))
         : [],
     },
     slack: {


### PR DESCRIPTION
## Summary
Detects absolute image file paths (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`) in Claude's Discord replies and uploads them as native Discord attachments instead of leaking the raw filesystem path into chat.

## Why
When Claude generates or references a local image (e.g. via the ComfyUI skill writing to `/tmp/output.png`), the path was being posted as plain text — useless to the human on the other end. Now the file is uploaded inline.

## Changes
- New `extractImagePaths()` strips matching paths from the message body and verifies each exists on disk
- New `sendMessageWithImages()` posts via `multipart/form-data` (`payload_json` + `files[i]` parts), with 429 retry-after handling
- Reply dispatch picks the multipart path when images are found, otherwise falls through to the existing `sendMessage()`
- Uses negative-lookbehind regex so paths embedded in URLs/code aren't mis-matched

## Test plan
- [x] agent generated image (`/tmp/agent_image.png`) — posted as attachment, path stripped from text
- [x] Reply with no image path — unchanged behavior
- [x] Reply with both text and image — both arrive
- [x] Text-attachment feature (merged from `feature/discord-text-attachments`) still works