### PR TITLE
fix(statusline): reject 0/NaN/non-positive PIDs in alive()

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -57,7 +57,11 @@ function fmt(ms) {
 function alive() {
   try {
     var pid = readFileSync(PID_FILE, "utf-8").trim();
-    process.kill(Number(pid), 0);
+    var parsedPid = Number(pid);
+    if (!Number.isFinite(parsedPid) || !Number.isInteger(parsedPid) || parsedPid <= 0) {
+      return false;
+    }
+    process.kill(parsedPid, 0);
     return true;
   } catch { return false; }
 }


### PR DESCRIPTION
## Problem

The statusline script bundled in [`src/commands/start.ts`](src/commands/start.ts) checks daemon liveness with:

```js
function alive() {
  try {
    var pid = readFileSync(PID_FILE, "utf-8").trim();
    process.kill(Number(pid), 0);
    return true;
  } catch { return false; }
}
```

For non-numeric pidfile contents `Number(pid)` returns `NaN` and `process.kill(NaN, 0)` throws → correctly returns `false`. So far so good.

The edge case this targets is **`pid === 0`** (or empty pidfile, since `Number("")` is also `0`). [`process.kill(0, signal)` in Node](https://nodejs.org/api/process.html#processkillpid-signal) is special — it operates on the **calling process group** rather than a specific PID, and always reports the caller is alive. So if the pidfile is empty (claudeclaw crashed mid-write, or some other lifecycle race truncated it):

- `alive()` returns `true`
- The statusline shows `● live`
- The next `claudeclaw start` invocation that gates on `alive()` to clean up a stale pidfile refuses to restart, since it thinks the daemon is already running

It's a recoverable-but-annoying state — usually requires a manual `rm .claude/claudeclaw/daemon.pid` to escape.

## Fix

Validate the parsed PID is a finite, positive integer before passing it to `process.kill`. Anything else (NaN, 0, negative, non-integer) returns `false` so the statusline correctly reports offline and start/stop logic can recover automatically.

```js
function alive() {
  try {
    var pid = readFileSync(PID_FILE, "utf-8").trim();
    var parsedPid = Number(pid);
    if (!Number.isFinite(parsedPid) || !Number.isInteger(parsedPid) || parsedPid <= 0) {
      return false;
    }
    process.kill(parsedPid, 0);
    return true;
  } catch { return false; }
}
```

No behaviour change for valid PIDs.

## Test plan

- [x] Empty pidfile → `alive()` returns `false` (was `true` before).
- [x] Pidfile contains `"0"` → `false` (was `true`).
- [x] Pidfile contains `"-1"` → `false` (was `true` if PID -1 happens to map to a process group the caller can signal).
- [x] Pidfile contains `"banana"` → `false` (unchanged — `process.kill(NaN, 0)` already throws).
- [x] Pidfile contains a valid running PID → `true` (unchanged).
- [x] Pidfile contains a stale numeric PID → `false` (unchanged — `process.kill` throws ESRCH, caught).

## Context

Hit this while integrating claudeclaw into a project's Makefile flow (`make claudeclaw-up` / `claudeclaw-down`). After a daemon crash left the pidfile empty, the statusline reported live forever and `make claudeclaw-up` skipped the restart. Tracking this fix locally for now (`prashantsolanki3/yolo` renames `statusline.cjs` to a non-clobbered path); happy to drop the local rename once this lands.