### PR TITLE
batch: merge runner, Discord, Telegram, config, and jobs follow-up fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -240,6 +240,7 @@ async function rejoinThreads(token: string): Promise<void> {
   const threadSessions = await listThreadSessions();
   for (const ts of threadSessions) {
     try {
+      await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
       if (!knownThreads.has(ts.threadId)) {
         const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
@@ -433,7 +434,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   const channelId = message.channel_id;
   const isDM = !message.guild_id;
   const isGuild = !!message.guild_id;
-  const content = message.content;
+  const content = message.content.replace(/\0/g, "");
 
   // Recover lost thread from sessions.json (fallback for knownThreads volatility)
   if (isGuild && !knownThreads.has(channelId)) {
@@ -1008,6 +1009,11 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       if (data.id && data.parent_id) {
         knownThreads.set(data.id, { parentId: data.parent_id });
         debugLog(`Thread tracked: ${data.id} (parent: ${data.parent_id})`);
+        if (getSettings().discord.listenChannels.includes(data.parent_id)) {
+          discordApi(token, "PUT", `/channels/${data.id}/thread-members/@me`).catch((err) =>
+            console.error(`[Discord] Failed to join thread ${data.id}: ${err}`),
+          );
+        }
       }
       break;
 

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -341,6 +341,12 @@ function isVoiceAttachment(a: DiscordAttachment): boolean {
   return Boolean(a.content_type?.startsWith("audio/"));
 }
 
+function isTextAttachment(a: DiscordAttachment): boolean {
+  if (a.content_type?.startsWith("text/")) return true;
+  const ext = extname(a.filename).toLowerCase();
+  return ext === ".txt" || ext === ".md";
+}
+
 async function downloadDiscordAttachment(
   attachment: DiscordAttachment,
   type: "image" | "voice",
@@ -476,10 +482,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   // Detect attachments
   const imageAttachments = message.attachments.filter(isImageAttachment);
   const voiceAttachments = message.attachments.filter(isVoiceAttachment);
+  const textAttachments = message.attachments.filter(isTextAttachment);
   const hasImage = imageAttachments.length > 0;
   const hasVoice = voiceAttachments.length > 0;
+  const hasText = textAttachments.length > 0;
 
-  if (!content.trim() && !hasImage && !hasVoice) return;
+  if (!content.trim() && !hasImage && !hasVoice && !hasText) return;
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;
@@ -488,7 +496,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   }
 
   const label = message.author.username;
-  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : ""].filter(Boolean);
+  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : "", hasText ? "text" : ""].filter(Boolean);
   const mediaSuffix = mediaParts.length > 0 ? ` [${mediaParts.join("+")}]` : "";
   console.log(
     `[${new Date().toLocaleTimeString()}] Discord ${label}${mediaSuffix}: "${cleanContent.slice(0, 60)}${cleanContent.length > 60 ? "..." : ""}"`,
@@ -503,6 +511,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     let imagePath: string | null = null;
     let voicePath: string | null = null;
     let voiceTranscript: string | null = null;
+    let textContent: string | null = null;
 
     if (hasImage) {
       try {
@@ -529,6 +538,18 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
         } catch (err) {
           console.error(`[Discord] Failed to transcribe voice for ${label}: ${err instanceof Error ? err.message : err}`);
         }
+      }
+    }
+
+    if (hasText) {
+      try {
+        const resp = await fetch(textAttachments[0].url);
+        if (resp.ok) {
+          const raw = await resp.text();
+          textContent = raw.length > 51200 ? raw.slice(0, 51200) + "\n...[truncated]" : raw;
+        }
+      } catch (err) {
+        console.error(`[Discord] Failed to fetch text attachment for ${label}: ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -634,6 +655,11 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       promptParts.push(
         "The user attached voice audio, but it could not be transcribed. Respond and ask them to resend a clearer clip.",
       );
+    }
+    if (textContent) {
+      promptParts.push(`Attached text file (${textAttachments[0].filename}):\n${textContent}`);
+    } else if (hasText) {
+      promptParts.push("The user attached a text file, but downloading it failed. Ask them to resend.");
     }
 
     const prefixedPrompt = promptParts.join("\n");

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -711,7 +711,7 @@ export async function start(args: string[] = []) {
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt))
+          .then((prompt) => run(job.name, prompt, undefined, job.model))
           .then((r) => {
             if (job.notify === false) return;
             if (job.notify === "error" && r.exitCode === 0) return;

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -419,6 +419,9 @@ function groupTriggerReason(message: TelegramMessage): string | null {
     }
   }
 
+  const { telegram } = getSettings();
+  if (telegram.listenChats?.includes(message.chat.id)) return "listen_chat";
+
   return null;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [] },
+  telegram: { token: "", allowedUserIds: [], listenChats: [] },
   discord: { token: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
@@ -87,6 +87,7 @@ export interface HeartbeatConfig {
 export interface TelegramConfig {
   token: string;
   allowedUserIds: number[];
+  listenChats: number[];
 }
 
 export interface DiscordConfig {
@@ -257,6 +258,7 @@ function parseSettings(
     telegram: {
       token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
+      listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,7 +260,7 @@ function parseSettings(
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
-      allowedUserIds: Array.isArray(discordUserIds)
+      allowedUserIds: Array.isArray(discordUserIds) && discordUserIds.length > 0
         ? discordUserIds
         : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -8,6 +8,8 @@ export interface Job {
   prompt: string;
   recurring: boolean;
   notify: true | false | "error";
+  /** When set, overrides the global model for this job. Useful for routing cheap tasks to haiku. */
+  model?: string;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -50,7 +52,10 @@ function parseJobFile(name: string, content: string): Job | null {
     : notifyRaw === "error" ? "error"
     : true;
 
-  return { name, schedule, prompt, recurring, notify };
+  const modelLine = lines.find((l) => l.startsWith("model:"));
+  const model = modelLine ? parseFrontmatterValue(modelLine.replace("model:", "")) || undefined : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model };
 }
 
 export async function loadJobs(): Promise<Job[]> {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -378,7 +378,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string): Promise<RunResult> {
+async function execClaude(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
   const existing = threadId
@@ -396,7 +396,10 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   let taskType = "unknown";
   let routingReasoning = "";
 
-  if (agentic.enabled) {
+  if (modelOverride) {
+    primaryConfig = { model: modelOverride, api };
+    console.log(`[${new Date().toLocaleTimeString()}] Job model override: ${modelOverride}`);
+  } else if (agentic.enabled) {
     const routing = selectModel(prompt, agentic.modes, agentic.defaultMode);
     primaryConfig = { model: routing.model, api };
     taskType = routing.taskType;
@@ -574,8 +577,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId), threadId);
+export async function run(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt, threadId, modelOverride), threadId);
 }
 
 async function streamClaude(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -54,13 +54,17 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * resolves credentials using its own per-platform code path.
  */
 function cleanSpawnEnv(): Record<string, string> {
-  const {
-    CLAUDECODE: _cc,
-    CLAUDE_CODE_OAUTH_TOKEN: _tok,
-    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: _mgr,
-    ...rest
-  } = process.env;
-  return rest as Record<string, string>;
+  const stripped = new Set([
+    "CLAUDECODE",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+  ]);
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (stripped.has(key)) continue;
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
 }
 
 export type CompactEvent =

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -31,6 +31,38 @@ const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
 const COMPACT_WARN_THRESHOLD = 25;
 const COMPACT_TIMEOUT_ENABLED = true;
 
+/**
+ * Build a sanitized env for spawning the `claude` CLI as a long-running daemon
+ * subprocess. Drops env vars injected by a parent Claude Code / Claude Desktop
+ * session that break detached child auth:
+ *
+ * - `CLAUDECODE`: marks "we're nested inside Claude Code" — confuses the CLI's
+ *   reentry detection and triggers transcript-aware behaviour we don't want.
+ * - `CLAUDE_CODE_OAUTH_TOKEN`: the parent's frozen OAuth access token. Without
+ *   the matching refresh token (which lives in the platform-native credential
+ *   store, not the env), it expires after ~8h and the daemon's spawned `claude`
+ *   processes start returning HTTP 401 silently. Stripping it lets the CLI
+ *   fall back to the credential store on each platform — Keychain on macOS,
+ *   `~/.claude/.credentials.json` on Linux/WSL2, Credential Manager on Windows
+ *   — which handles refresh automatically.
+ * - `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`: tells the CLI "the host process
+ *   manages provider auth — don't read local credentials." In a detached
+ *   daemon there is no host to consult; the CLI errors with `Not logged in`.
+ *
+ * Cross-platform note: the helper just deletes keys from the inherited env
+ * object — no shell, no OS-specific calls. The `claude` CLI it spawns then
+ * resolves credentials using its own per-platform code path.
+ */
+function cleanSpawnEnv(): Record<string, string> {
+  const {
+    CLAUDECODE: _cc,
+    CLAUDE_CODE_OAUTH_TOKEN: _tok,
+    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: _mgr,
+    ...rest
+  } = process.env;
+  return rest as Record<string, string>;
+}
+
 export type CompactEvent =
   | { type: "warn"; turnCount: number }
   | { type: "auto-compact-start" }
@@ -325,8 +357,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
 
   const settings = getSettings();
   const securityArgs = buildSecurityArgs(settings.security);
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const baseEnv = cleanSpawnEnv();
   const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
@@ -417,9 +448,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     args.push("--append-system-prompt", appendParts.join("\n\n"));
   }
 
-  // Strip CLAUDECODE env var so child claude processes don't think they're nested
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const baseEnv = cleanSpawnEnv();
 
   let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
@@ -583,8 +612,7 @@ async function streamClaude(
   const normalizedModel = model.trim().toLowerCase();
   if (model.trim() && normalizedModel !== "glm") args.push("--model", model.trim());
 
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const childEnv = buildChildEnv(cleanEnv as Record<string, string>, model, api);
+  const childEnv = buildChildEnv(cleanSpawnEnv(), model, api);
 
   console.log(`[${new Date().toLocaleTimeString()}] Running: ${name} (stream-json, session: ${existing?.sessionId?.slice(0, 8) ?? "new"})`);
 


### PR DESCRIPTION
Batches the clean current functional changes from:
- #102 — strip parent OAuth / host-managed auth env from spawned `claude`
- #112 — Discord thread delivery restore + null-byte stripping + `THREAD_CREATE` join
- #118 — per-job model override via frontmatter
- #123 — Discord text attachment inlining
- #124 — Telegram `listenChats`

Also folds in:
- #122 — config guard hotfix prerequisite (`discordUserIds.length > 0` before overriding parsed IDs)

Why this batch exists:
- these PRs are all small and compatible
- several contributor branches had gone stale or carried old metadata bumps
- this branch cherry-picks only the functional changes onto current `master`
- plugin/marketplace metadata was regenerated once at the end on the integrated branch

Validation:
- `bun install`
- `bunx tsc --noEmit`
