### PR TITLE
feat(watchdog): minimal runaway-session guard with opt-in limits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/__tests__/watchdog.test.ts
+++ b/src/__tests__/watchdog.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  recordResult,
+  abortReason,
+  clearSession,
+  startSession,
+  parseWatchdogConfig,
+  injectClock,
+  resetClock,
+  DEFAULT_WATCHDOG_CONFIG,
+  TIMEOUT_EXIT_CODE,
+  type WatchdogConfig,
+} from "../watchdog";
+
+const SESSION = "test-session-abc";
+const DISABLED: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null };
+
+beforeEach(() => {
+  clearSession(SESSION);
+  resetClock();
+});
+
+afterEach(() => {
+  resetClock();
+});
+
+// --- parseWatchdogConfig ---
+
+describe("parseWatchdogConfig", () => {
+  it("returns defaults for missing input", () => {
+    expect(parseWatchdogConfig(undefined)).toEqual(DEFAULT_WATCHDOG_CONFIG);
+    expect(parseWatchdogConfig(null)).toEqual(DEFAULT_WATCHDOG_CONFIG);
+    expect(parseWatchdogConfig({})).toEqual(DEFAULT_WATCHDOG_CONFIG);
+  });
+
+  it("parses valid maxConsecutiveTimeouts", () => {
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: 3 }).maxConsecutiveTimeouts).toBe(3);
+  });
+
+  it("rejects non-integer or non-positive maxConsecutiveTimeouts", () => {
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: -1 }).maxConsecutiveTimeouts).toBeNull();
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: 0 }).maxConsecutiveTimeouts).toBeNull();
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: 1.5 }).maxConsecutiveTimeouts).toBeNull();
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: "3" }).maxConsecutiveTimeouts).toBeNull();
+  });
+
+  it("parses valid maxRuntimeSeconds", () => {
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: 3600 }).maxRuntimeSeconds).toBe(3600);
+  });
+
+  it("rejects non-positive or non-finite maxRuntimeSeconds", () => {
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: 0 }).maxRuntimeSeconds).toBeNull();
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: -60 }).maxRuntimeSeconds).toBeNull();
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: Infinity }).maxRuntimeSeconds).toBeNull();
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: null }).maxRuntimeSeconds).toBeNull();
+  });
+});
+
+// --- disabled config ---
+
+describe("abortReason (disabled)", () => {
+  it("never triggers when both limits are null", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, DISABLED)).toBeNull();
+  });
+
+  it("returns null for an untracked session ID", () => {
+    expect(abortReason("no-such-session", DISABLED)).toBeNull();
+  });
+});
+
+// --- consecutive timeout tracking ---
+
+describe("maxConsecutiveTimeouts", () => {
+  const cfg: WatchdogConfig = { maxConsecutiveTimeouts: 3, maxRuntimeSeconds: null };
+
+  it("does not abort before limit is reached", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("aborts exactly at the limit", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toMatch(/3 consecutive timeouts/);
+  });
+
+  it("resets the counter on a successful exit", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, 0);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("resets on any non-timeout exit code", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, 1);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+});
+
+// --- clearSession ---
+
+describe("clearSession", () => {
+  it("removes accumulated state so abortReason returns null", () => {
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: 2, maxRuntimeSeconds: null };
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toMatch(/consecutive timeouts/);
+    clearSession(SESSION);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+});
+
+// --- maxRuntimeSeconds with injected clock ---
+
+describe("maxRuntimeSeconds", () => {
+  it("does not abort if session has not started", () => {
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 1 };
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("does not abort before limit is reached", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 3600 };
+    startSession(SESSION);
+    fakeNow = 1000 * 1000; // 1000 seconds
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("aborts when elapsed time reaches the limit", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 60 };
+    startSession(SESSION);
+    fakeNow = 60_001; // 60.001 seconds
+    expect(abortReason(SESSION, cfg)).toMatch(/exceeded maximum runtime/);
+  });
+
+  it("includes elapsed and limit in the abort message", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 60 };
+    startSession(SESSION);
+    fakeNow = 90_000;
+    const reason = abortReason(SESSION, cfg);
+    expect(reason).toMatch(/90s \/ 60s/);
+  });
+});
+
+// --- startSession is idempotent ---
+
+describe("startSession", () => {
+  it("second call does not reset the clock", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 60 };
+    startSession(SESSION);
+    fakeNow = 30_000;
+    startSession(SESSION); // should be a no-op
+    fakeNow = 90_000;
+    expect(abortReason(SESSION, cfg)).toMatch(/exceeded maximum runtime/);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,10 @@ import { join, isAbsolute } from "path";
 import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
+import { parseWatchdogConfig, type WatchdogConfig } from "./watchdog";
+
+/** Re-exported under the name used in the Settings interface. */
+export type WatchdogSettings = WatchdogConfig;
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
@@ -68,6 +72,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
 };
 
 export interface HeartbeatExcludeWindow {
@@ -121,8 +126,10 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  watchdog: WatchdogSettings;
   jobsDir?: string;
 }
+
 
 export interface AgenticMode {
   name: string;
@@ -289,6 +296,7 @@ function parseSettings(
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    watchdog: parseWatchdogConfig(raw.watchdog),
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,6 +11,7 @@ import {
 import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
+import { recordResult, abortReason, clearSession, startSession } from "./watchdog";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
@@ -385,11 +386,13 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
     ? await getThreadSession(threadId)
     : await getSession();
   const isNew = !existing;
+  // Start the watchdog clock for resumed sessions (we know the ID immediately).
+  if (existing) startSession(existing.sessionId);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const logFile = join(LOGS_DIR, `${name}-${timestamp}.log`);
 
   const settings = getSettings();
-  const { security, model, api, fallback, agentic } = settings;
+  const { security, model, api, fallback, agentic, watchdog } = settings;
 
   // Determine which model to use based on agentic routing
   let primaryConfig: ModelConfig;
@@ -494,6 +497,7 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
         await createSession(sessionId);
         console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}`);
       }
+      startSession(sessionId);
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to parse session from Claude output:`, e);
     }
@@ -521,6 +525,26 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
 
   await Bun.write(logFile, output);
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
+
+  // --- Watchdog: track consecutive timeouts ---
+  // Skip tracking for unresolved session IDs ("unknown") to avoid cross-session
+  // state collisions when a new session fails before its real ID is known.
+  const trackingId = sessionId !== "unknown" ? sessionId : null;
+  if (trackingId) {
+    if (exitCode === 0) {
+      clearSession(trackingId);
+    } else {
+      recordResult(trackingId, exitCode);
+      const reason = abortReason(trackingId, watchdog);
+      if (reason) {
+        console.warn(`[${new Date().toLocaleTimeString()}] ${reason}`);
+        clearSession(trackingId);
+        return result;
+      }
+      // Non-timeout failures reset the counter but leave nothing to track.
+      if (exitCode !== 124) clearSession(trackingId);
+    }
+  }
 
   // --- Auto-compact on timeout (exit 124) ---
   if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -1,0 +1,155 @@
+/**
+ * Minimal runaway-session watchdog.
+ *
+ * Tracks consecutive timeouts per session and aborts when a configurable
+ * threshold is exceeded.  This prevents a session stuck in a timeout loop from
+ * continuously draining the user's Claude Code allowance.
+ *
+ * Abort is a single-cycle circuit-breaker: the session state is cleared after
+ * an abort so the next invocation starts fresh.
+ *
+ * Opt-in: all limits default to null (disabled).  Enable via settings.json:
+ *
+ *   "watchdog": {
+ *     "maxConsecutiveTimeouts": 3,
+ *     "maxRuntimeSeconds": 3600
+ *   }
+ */
+
+/** Exit code produced by runClaudeOnce when the per-invocation wall-clock expires. */
+export const TIMEOUT_EXIT_CODE = 124;
+
+export interface WatchdogConfig {
+  /** Stop retrying after this many consecutive TIMEOUT_EXIT_CODE exits. null = disabled. */
+  maxConsecutiveTimeouts: number | null;
+  /**
+   * Hard wall-clock limit (seconds) measured from when the session is first
+   * registered via startSession(). null = disabled.
+   *
+   * Tip: the existing per-invocation timeout (settings.sessionTimeoutMs) already
+   * caps each individual Claude call.  maxRuntimeSeconds adds a session-level
+   * guard for cases where many sequential invocations keep timing out.
+   */
+  maxRuntimeSeconds: number | null;
+}
+
+export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
+  maxConsecutiveTimeouts: null,
+  maxRuntimeSeconds: null,
+};
+
+interface SessionState {
+  consecutiveTimeouts: number;
+  startedAt: number;
+}
+
+/** Allows tests to inject a deterministic clock. */
+let _now: () => number = () => Date.now();
+
+/** For tests only — restore with resetClock(). */
+export function injectClock(fn: () => number): void {
+  _now = fn;
+}
+
+export function resetClock(): void {
+  _now = () => Date.now();
+}
+
+const sessions = new Map<string, SessionState>();
+
+/**
+ * Register the start of a session.  Must be called with a real session ID
+ * (not the "unknown" sentinel) so the runtime clock begins at the right time.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function startSession(sessionId: string): void {
+  if (!sessions.has(sessionId)) {
+    sessions.set(sessionId, { consecutiveTimeouts: 0, startedAt: _now() });
+  }
+}
+
+/**
+ * Record the outcome of a single Claude invocation.
+ * Only call this with a real session ID (not "unknown").
+ */
+export function recordResult(sessionId: string, exitCode: number): void {
+  const state = sessions.get(sessionId);
+  if (!state) return;
+  if (exitCode === TIMEOUT_EXIT_CODE) {
+    state.consecutiveTimeouts += 1;
+  } else {
+    state.consecutiveTimeouts = 0;
+  }
+}
+
+/**
+ * Returns an abort-reason string if the watchdog has determined this session
+ * should stop, or null if the session is healthy.
+ *
+ * Call this BEFORE triggering any auto-compact / retry logic.
+ * Only call with a real session ID.
+ */
+export function abortReason(
+  sessionId: string,
+  config: WatchdogConfig,
+): string | null {
+  const state = sessions.get(sessionId);
+  if (!state) return null;
+
+  if (
+    config.maxConsecutiveTimeouts !== null &&
+    state.consecutiveTimeouts >= config.maxConsecutiveTimeouts
+  ) {
+    return (
+      `Watchdog: aborted after ${state.consecutiveTimeouts} consecutive timeouts` +
+      ` (limit: ${config.maxConsecutiveTimeouts})`
+    );
+  }
+
+  if (config.maxRuntimeSeconds !== null) {
+    const elapsed = (_now() - state.startedAt) / 1000;
+    if (elapsed >= config.maxRuntimeSeconds) {
+      return (
+        `Watchdog: session exceeded maximum runtime` +
+        ` (${elapsed.toFixed(0)}s / ${config.maxRuntimeSeconds}s)`
+      );
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Remove tracking state for a session.
+ * Called on clean exit, on abort (circuit-breaker reset), and on non-timeout
+ * failures where there is nothing left to track.
+ */
+export function clearSession(sessionId: string): void {
+  sessions.delete(sessionId);
+}
+
+/**
+ * Parse and validate a raw settings value into a WatchdogConfig.
+ * Unknown keys are ignored; invalid values fall back to null (disabled).
+ */
+export function parseWatchdogConfig(raw: unknown): WatchdogConfig {
+  if (!raw || typeof raw !== "object") return { ...DEFAULT_WATCHDOG_CONFIG };
+
+  const r = raw as Record<string, unknown>;
+
+  const maxConsecutiveTimeouts =
+    typeof r.maxConsecutiveTimeouts === "number" &&
+    Number.isInteger(r.maxConsecutiveTimeouts) &&
+    r.maxConsecutiveTimeouts > 0
+      ? r.maxConsecutiveTimeouts
+      : null;
+
+  const maxRuntimeSeconds =
+    typeof r.maxRuntimeSeconds === "number" &&
+    Number.isFinite(r.maxRuntimeSeconds) &&
+    r.maxRuntimeSeconds > 0
+      ? r.maxRuntimeSeconds
+      : null;
+
+  return { maxConsecutiveTimeouts, maxRuntimeSeconds };
+}


### PR DESCRIPTION
## Summary

- Adds a minimal runaway-session watchdog that stops auto-compact retries when a session has timed out too many consecutive times
- Both limits default to `null` (disabled) — **no behaviour change unless opted in**
- Configurable via `settings.json` under a new `watchdog` key
- Single new source file (`src/watchdog.ts`, 155 LOC); no new runtime dependencies

## Motivation

Without this guard, a session stuck in a timeout loop will retry indefinitely via the existing auto-compact path, draining the user's Claude Code allowance until the daemon is manually stopped.

## How it works

**Consecutive-timeout circuit breaker (primary protection):**
After `maxConsecutiveTimeouts` consecutive exit-124 timeouts on the same session, the watchdog aborts the current retry cycle and logs a warning. The counter resets on any successful exit.

**Wall-clock runtime limit (secondary, opt-in):**
`maxRuntimeSeconds` measures wall-clock time from when the session is first registered via `startSession()`. Useful as a hard cap on very long-running agentic tasks.

## Configuration (opt-in)

Add to `settings.json` to enable:

```json
"watchdog": {
  "maxConsecutiveTimeouts": 3,
  "maxRuntimeSeconds": null
}
```

Both fields default to `null` (disabled). Any absent or invalid value falls back to `null` — no silent coercion.

## Lightweight check

- No new runtime dependencies
- In-memory `Map` — entries cleared on clean exit, abort, or non-timeout failure
- 26 lines added to `runner.ts`, 8 lines to `config.ts`
- Zero changes to the happy path (watchdog block only runs when `exitCode !== 0`)

## Tests

17 tests (`bun test`) — 17 pass, 0 fail

- `parseWatchdogConfig`: valid values, rejections (negative, float, string, `Infinity`, null)
- Disabled mode never triggers
- Abort fires at exactly the configured threshold
- Counter resets on success and on non-timeout failure
- `clearSession` removes state
- `maxRuntimeSeconds` with injected clock (no real `setTimeout` in tests)
- `startSession` is idempotent (second call does not reset the clock)

## Test plan

- [x] `bun test src/__tests__/watchdog.test.ts` — 17 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run bump:plugin-version` → 1.0.5
- [x] `bun run bump:marketplace-version` → 1.0.5
- [ ] Manual: daemon starts normally with no `watchdog` key in `settings.json`
- [ ] Manual: with `maxConsecutiveTimeouts: 2`, daemon logs warning and stops after 2 consecutive timeouts