### PR TITLE
feat(jobs): per-job retry with configurable attempts and delay

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -706,27 +706,62 @@ export async function start(args: string[] = []) {
 
   updateState();
 
+  // Track per-job retry state (in-memory, resets on daemon restart)
+  const jobRetryState = new Map<string, { failCount: number; retryAt: number }>();
+
+  function runJob(job: (typeof currentJobs)[0]) {
+    const timeoutMs = job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined;
+    resolvePrompt(job.prompt)
+      .then((prompt) => run(job.name, prompt, job.name, job.model, timeoutMs))
+      .then((r) => {
+        // Reset retry state on success
+        if (r.exitCode === 0) {
+          jobRetryState.delete(job.name);
+        } else if (job.retry && job.retry > 0) {
+          // Schedule a retry if under the limit
+          const state = jobRetryState.get(job.name) ?? { failCount: 0, retryAt: 0 };
+          state.failCount += 1;
+          if (state.failCount <= job.retry) {
+            const delayMs = (job.retryDelay ?? 300) * 1000;
+            state.retryAt = Date.now() + delayMs;
+            jobRetryState.set(job.name, state);
+            console.log(`[${ts()}] Job ${job.name} failed (attempt ${state.failCount}/${job.retry}), retrying in ${job.retryDelay ?? 300}s`);
+          } else {
+            jobRetryState.delete(job.name);
+            console.log(`[${ts()}] Job ${job.name} exhausted ${job.retry} retries`);
+          }
+        }
+        if (job.notify === false) return;
+        if (job.notify === "error" && r.exitCode === 0) return;
+        forwardToTelegram(job.name, r);
+        forwardToDiscord(job.name, r);
+      })
+      .finally(async () => {
+        if (job.recurring) return;
+        // Only clear schedule for one-shot jobs when no retry is pending
+        if (jobRetryState.has(job.name)) return;
+        try {
+          await clearJobSchedule(job.name);
+          console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
+        } catch (err) {
+          console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
+        }
+      });
+  }
+
   setInterval(() => {
     const now = new Date();
     for (const job of currentJobs) {
+      // Check if a retry is due before the next scheduled run
+      const retryState = jobRetryState.get(job.name);
+      if (retryState && retryState.retryAt <= Date.now()) {
+        jobRetryState.delete(job.name); // clear so it doesn't re-trigger next tick
+        console.log(`[${ts()}] Retrying job: ${job.name} (attempt ${retryState.failCount + 1})`);
+        runJob(job);
+        continue;
+      }
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
-        resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt, job.name, job.model, job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined))
-          .then((r) => {
-            if (job.notify === false) return;
-            if (job.notify === "error" && r.exitCode === 0) return;
-            forwardToTelegram(job.name, r);
-            forwardToDiscord(job.name, r);
-          })
-          .finally(async () => {
-            if (job.recurring) return;
-            try {
-              await clearJobSchedule(job.name);
-              console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
-            } catch (err) {
-              console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
-            }
-          });
+        runJob(job);
       }
     }
     updateState();

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -12,6 +12,10 @@ export interface Job {
   model?: string;
   /** When set, overrides the global session timeout for this job (in seconds). */
   timeoutSeconds?: number;
+  /** Max number of retry attempts on failure before giving up until next scheduled run. */
+  retry?: number;
+  /** Seconds to wait between retry attempts. Defaults to 300 (5 min). */
+  retryDelay?: number;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -62,7 +66,13 @@ function parseJobFile(name: string, content: string): Job | null {
   const timeoutParsed = timeoutRaw ? parseInt(timeoutRaw, 10) : NaN;
   const timeoutSeconds = Number.isFinite(timeoutParsed) && timeoutParsed > 0 ? timeoutParsed : undefined;
 
-  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds };
+  const retryLine = lines.find((l) => l.startsWith("retry:"));
+  const retry = retryLine ? parseInt(parseFrontmatterValue(retryLine.replace("retry:", "")), 10) || undefined : undefined;
+
+  const retryDelayLine = lines.find((l) => l.startsWith("retry_delay:"));
+  const retryDelay = retryDelayLine ? parseInt(parseFrontmatterValue(retryDelayLine.replace("retry_delay:", "")), 10) || undefined : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds, retry, retryDelay };
 }
 
 export async function loadJobs(): Promise<Job[]> {


### PR DESCRIPTION
## Summary

Adds `retry` and `retry_delay` frontmatter fields to job files. When a job exits with a non-zero code, it is automatically retried up to `retry` times before giving up until the next scheduled run.

## Usage

```markdown
---
schedule: "*/10 * * * *"
retry: 3
retry_delay: 120
---
Your job prompt here
```

- `retry`: max number of retry attempts (default: none — existing behaviour unchanged)
- `retry_delay`: seconds between retries (default: 300s / 5 min)

## How it works

- Retry state is tracked in-memory (Map) per daemon session — no external storage, no state.json changes
- On success: retry state is cleared
- On failure with retries remaining: `retryAt` is scheduled; next 60s tick checks and fires if due
- On retry exhaustion: logs a message, stops until next cron match

## Test plan

- [ ] Job with `retry: 3` that fails retries up to 3 times with logged attempts
- [ ] Job without `retry` behaves exactly as before (no regression)
- [ ] `retry_delay: 60` waits ~60s between attempts
- [ ] Successful run after 1 failure resets the counter (next failure starts fresh)
- [ ] Exhausted retries logs the exhaustion message and stops

## Notes

Retry state is intentionally in-memory only. A daemon restart clears all retry counters — this avoids stale retry debt accumulating across restarts and keeps the implementation minimal (no new files, no state.json schema changes).