### PR TITLE
feat: integrate agent-scoped jobs and watchdog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+
+const TEST_ROOT = join(import.meta.dir, "../../test-sandbox-jobs");
+const LEGACY_JOBS_DIR = join(TEST_ROOT, ".claude", "claudeclaw", "jobs");
+const AGENTS_DIR = join(TEST_ROOT, "agents");
+
+async function resetSandbox() {
+  await rm(TEST_ROOT, { recursive: true, force: true });
+  await mkdir(LEGACY_JOBS_DIR, { recursive: true });
+  await mkdir(join(AGENTS_DIR, "suzy", "jobs"), { recursive: true });
+  await mkdir(join(AGENTS_DIR, "reg", "jobs"), { recursive: true });
+}
+
+afterAll(async () => {
+  await rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+function jobMd(schedule: string, prompt: string, extra = ""): string {
+  const extras = extra ? extra + "\n" : "";
+  return `---\nschedule: ${schedule}\nrecurring: true\n${extras}---\n${prompt}\n`;
+}
+
+/** Run loadJobs() in the sandbox dir via a child bun process (so process.cwd() == TEST_ROOT). */
+async function loadJobsInSandbox(): Promise<import("../jobs").Job[]> {
+  const script = `
+import { loadJobs } from ${JSON.stringify(join(import.meta.dir, "..", "jobs"))};
+const jobs = await loadJobs();
+process.stdout.write(JSON.stringify(jobs));
+`;
+  const scriptPath = join(TEST_ROOT, "_run.ts");
+  await writeFile(scriptPath, script);
+  const proc = Bun.spawn(["bun", "run", scriptPath], {
+    cwd: TEST_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return JSON.parse(out || "[]");
+}
+
+// ─── Integration tests ────────────────────────────────────────────────────
+
+describe("loadJobs", () => {
+  beforeEach(resetSandbox);
+
+  test("empty dirs → zero jobs, no throw", async () => {
+    const jobs = await loadJobsInSandbox();
+    expect(jobs).toEqual([]);
+  });
+
+  test("loads job from legacy .claude/claudeclaw/jobs/", async () => {
+    await writeFile(
+      join(LEGACY_JOBS_DIR, "nightly.md"),
+      jobMd("0 3 * * *", "Run nightly report")
+    );
+    const jobs = await loadJobsInSandbox();
+    const job = jobs.find((j) => j.name === "nightly");
+    expect(job).toBeDefined();
+    expect(job?.agent).toBeUndefined(); // not agent-scoped
+    expect(job?.schedule).toBe("0 3 * * *");
+    expect(job?.prompt).toBe("Run nightly report");
+  });
+
+  test("loads job from agents/<name>/jobs/ (Phase 17 path)", async () => {
+    await writeFile(
+      join(AGENTS_DIR, "suzy", "jobs", "daily-digest.md"),
+      jobMd("0 9 * * *", "Summarise today's news")
+    );
+    const jobs = await loadJobsInSandbox();
+    const job = jobs.find((j) => j.name === "suzy/daily-digest");
+    expect(job).toBeDefined();
+    expect(job?.agent).toBe("suzy");
+    expect(job?.label).toBe("daily-digest");
+    expect(job?.schedule).toBe("0 9 * * *");
+    expect(job?.prompt).toBe("Summarise today's news");
+  });
+
+  test("directory location overrides frontmatter agent field", async () => {
+    // Even if the .md file says agent: wrong, the enclosing dir wins.
+    await writeFile(
+      join(AGENTS_DIR, "reg", "jobs", "seo.md"),
+      jobMd("30 10 * * *", "SEO review", "agent: wrong-agent")
+    );
+    const jobs = await loadJobsInSandbox();
+    const job = jobs.find((j) => j.name === "reg/seo");
+    expect(job?.agent).toBe("reg");
+  });
+
+  test("enabled: false excludes job", async () => {
+    await writeFile(
+      join(AGENTS_DIR, "suzy", "jobs", "disabled.md"),
+      jobMd("0 12 * * *", "Disabled", "enabled: false")
+    );
+    const jobs = await loadJobsInSandbox();
+    expect(jobs.find((j) => j.name === "suzy/disabled")).toBeUndefined();
+  });
+
+  test("returns jobs from both legacy and agent-scoped locations together", async () => {
+    await writeFile(join(LEGACY_JOBS_DIR, "nightly.md"), jobMd("0 3 * * *", "Nightly"));
+    await writeFile(join(AGENTS_DIR, "suzy", "jobs", "morning.md"), jobMd("0 9 * * *", "Morning"));
+    const jobs = await loadJobsInSandbox();
+    const names = jobs.map((j) => j.name);
+    expect(names).toContain("nightly");
+    expect(names).toContain("suzy/morning");
+  });
+
+  test("missing agents/ dir is silently ignored (no throw)", async () => {
+    await rm(AGENTS_DIR, { recursive: true, force: true });
+    const jobs = await loadJobsInSandbox();
+    expect(Array.isArray(jobs)).toBe(true);
+  });
+
+  test("agent dir without jobs/ subdir is skipped", async () => {
+    // publisher/ exists but has no jobs/ subdirectory
+    await mkdir(join(AGENTS_DIR, "publisher"), { recursive: true });
+    const jobs = await loadJobsInSandbox();
+    expect(jobs.filter((j) => j.name.startsWith("publisher/"))).toEqual([]);
+  });
+
+  test("job file without schedule: field is skipped gracefully", async () => {
+    await writeFile(
+      join(AGENTS_DIR, "suzy", "jobs", "bad.md"),
+      "---\nprompt: test\n---\nNo schedule line.\n"
+    );
+    // Should not throw, should return other valid jobs
+    const jobs = await loadJobsInSandbox();
+    expect(jobs.find((j) => j.name === "suzy/bad")).toBeUndefined();
+  });
+});
+
+// ─── Unit: Job type and session path assertions ───────────────────────────
+
+describe("Job type", () => {
+  test("includes agent, label, enabled fields", () => {
+    const job: import("../jobs").Job = {
+      name: "agent/job",
+      schedule: "0 9 * * *",
+      prompt: "test",
+      recurring: true,
+      notify: true,
+      agent: "myagent",
+      label: "myjob",
+      enabled: true,
+    };
+    expect(job.agent).toBe("myagent");
+    expect(job.label).toBe("myjob");
+    expect(job.enabled).toBe(true);
+  });
+});
+
+describe("sessions — agent-scoped paths", () => {
+  test("getSession/createSession/incrementTurn accept optional agentName", async () => {
+    const src = await Bun.file(join(import.meta.dir, "../sessions.ts")).text();
+    // All public functions should have agentName? param
+    expect(src).toContain("getSession(\n  agentName?: string");
+    expect(src).toContain("createSession(sessionId: string, agentName?: string)");
+    expect(src).toContain("incrementTurn(agentName?: string)");
+    expect(src).toContain("markCompactWarned(agentName?: string)");
+  });
+
+  test("agent sessions stored outside .claude/", async () => {
+    const src = await Bun.file(join(import.meta.dir, "../sessions.ts")).text();
+    // Verify path uses AGENTS_DIR (project root) not HEARTBEAT_DIR (.claude/...)
+    expect(src).toContain('join(AGENTS_DIR, agentName, "session.json")');
+  });
+});
+
+// ─── Unit: protection-bug validation (the core motivation) ───────────────
+
+describe("write-protection bug validation", () => {
+  test("agent-scoped job path is outside .claude/ (key property)", () => {
+    // The Claude Code CLI hardcodes a protection list for .claude/ paths.
+    // Agent-scoped jobs live at agents/<name>/jobs/<job>.md — no .claude/ prefix.
+    // This test documents the requirement explicitly.
+    const legacyPath = join(process.cwd(), ".claude", "claudeclaw", "jobs", "job.md");
+    const agentPath = join(process.cwd(), "agents", "suzy", "jobs", "daily.md");
+    expect(legacyPath).toContain("/.claude/");
+    expect(agentPath).not.toContain("/.claude/");
+  });
+});

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -163,8 +163,8 @@ describe("sessions — agent-scoped paths", () => {
 
   test("agent sessions stored outside .claude/", async () => {
     const src = await Bun.file(join(import.meta.dir, "../sessions.ts")).text();
-    // Verify path uses AGENTS_DIR (project root) not HEARTBEAT_DIR (.claude/...)
-    expect(src).toContain('join(AGENTS_DIR, agentName, "session.json")');
+    // Verify path uses getAgentsDir() (project root) not HEARTBEAT_DIR (.claude/...)
+    expect(src).toContain('join(getAgentsDir(), agentName, "session.json")');
   });
 });
 

--- a/src/__tests__/watchdog.test.ts
+++ b/src/__tests__/watchdog.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  recordResult,
+  abortReason,
+  clearSession,
+  startSession,
+  parseWatchdogConfig,
+  injectClock,
+  resetClock,
+  DEFAULT_WATCHDOG_CONFIG,
+  TIMEOUT_EXIT_CODE,
+  type WatchdogConfig,
+} from "../watchdog";
+
+const SESSION = "test-session-abc";
+const DISABLED: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null };
+
+beforeEach(() => {
+  clearSession(SESSION);
+  resetClock();
+});
+
+afterEach(() => {
+  resetClock();
+});
+
+// --- parseWatchdogConfig ---
+
+describe("parseWatchdogConfig", () => {
+  it("returns defaults for missing input", () => {
+    expect(parseWatchdogConfig(undefined)).toEqual(DEFAULT_WATCHDOG_CONFIG);
+    expect(parseWatchdogConfig(null)).toEqual(DEFAULT_WATCHDOG_CONFIG);
+    expect(parseWatchdogConfig({})).toEqual(DEFAULT_WATCHDOG_CONFIG);
+  });
+
+  it("parses valid maxConsecutiveTimeouts", () => {
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: 3 }).maxConsecutiveTimeouts).toBe(3);
+  });
+
+  it("rejects non-integer or non-positive maxConsecutiveTimeouts", () => {
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: -1 }).maxConsecutiveTimeouts).toBeNull();
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: 0 }).maxConsecutiveTimeouts).toBeNull();
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: 1.5 }).maxConsecutiveTimeouts).toBeNull();
+    expect(parseWatchdogConfig({ maxConsecutiveTimeouts: "3" }).maxConsecutiveTimeouts).toBeNull();
+  });
+
+  it("parses valid maxRuntimeSeconds", () => {
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: 3600 }).maxRuntimeSeconds).toBe(3600);
+  });
+
+  it("rejects non-positive or non-finite maxRuntimeSeconds", () => {
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: 0 }).maxRuntimeSeconds).toBeNull();
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: -60 }).maxRuntimeSeconds).toBeNull();
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: Infinity }).maxRuntimeSeconds).toBeNull();
+    expect(parseWatchdogConfig({ maxRuntimeSeconds: null }).maxRuntimeSeconds).toBeNull();
+  });
+});
+
+// --- disabled config ---
+
+describe("abortReason (disabled)", () => {
+  it("never triggers when both limits are null", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, DISABLED)).toBeNull();
+  });
+
+  it("returns null for an untracked session ID", () => {
+    expect(abortReason("no-such-session", DISABLED)).toBeNull();
+  });
+});
+
+// --- consecutive timeout tracking ---
+
+describe("maxConsecutiveTimeouts", () => {
+  const cfg: WatchdogConfig = { maxConsecutiveTimeouts: 3, maxRuntimeSeconds: null };
+
+  it("does not abort before limit is reached", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("aborts exactly at the limit", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toMatch(/3 consecutive timeouts/);
+  });
+
+  it("resets the counter on a successful exit", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, 0);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("resets on any non-timeout exit code", () => {
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, 1);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+});
+
+// --- clearSession ---
+
+describe("clearSession", () => {
+  it("removes accumulated state so abortReason returns null", () => {
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: 2, maxRuntimeSeconds: null };
+    startSession(SESSION);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    recordResult(SESSION, TIMEOUT_EXIT_CODE);
+    expect(abortReason(SESSION, cfg)).toMatch(/consecutive timeouts/);
+    clearSession(SESSION);
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+});
+
+// --- maxRuntimeSeconds with injected clock ---
+
+describe("maxRuntimeSeconds", () => {
+  it("does not abort if session has not started", () => {
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 1 };
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("does not abort before limit is reached", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 3600 };
+    startSession(SESSION);
+    fakeNow = 1000 * 1000; // 1000 seconds
+    expect(abortReason(SESSION, cfg)).toBeNull();
+  });
+
+  it("aborts when elapsed time reaches the limit", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 60 };
+    startSession(SESSION);
+    fakeNow = 60_001; // 60.001 seconds
+    expect(abortReason(SESSION, cfg)).toMatch(/exceeded maximum runtime/);
+  });
+
+  it("includes elapsed and limit in the abort message", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 60 };
+    startSession(SESSION);
+    fakeNow = 90_000;
+    const reason = abortReason(SESSION, cfg);
+    expect(reason).toMatch(/90s \/ 60s/);
+  });
+});
+
+// --- startSession is idempotent ---
+
+describe("startSession", () => {
+  it("second call does not reset the clock", () => {
+    let fakeNow = 0;
+    injectClock(() => fakeNow);
+    const cfg: WatchdogConfig = { maxConsecutiveTimeouts: null, maxRuntimeSeconds: 60 };
+    startSession(SESSION);
+    fakeNow = 30_000;
+    startSession(SESSION); // should be a no-op
+    fakeNow = 90_000;
+    expect(abortReason(SESSION, cfg)).toMatch(/exceeded maximum runtime/);
+  });
+});

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -706,36 +706,70 @@ export async function start(args: string[] = []) {
 
   updateState();
 
+  // In-memory retry state: resets on daemon restart (no stale debt across restarts).
+  const jobRetryState = new Map<string, { failCount: number; retryAt: number }>();
+
+  function runJob(job: (typeof currentJobs)[0]) {
+    const timeoutMs = job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined;
+    resolvePrompt(job.prompt)
+      .then((prompt) =>
+        run(
+          job.name,
+          prompt,
+          job.agent ? `agent:${job.agent}` : job.name,
+          job.model,
+          timeoutMs,
+          job.agent
+        )
+      )
+      .then((r) => {
+        if (r.exitCode === 0) {
+          jobRetryState.delete(job.name);
+        } else if (job.retry && job.retry > 0) {
+          // Preserve existing state so failCount accumulates correctly across retries.
+          const state = jobRetryState.get(job.name) ?? { failCount: 0, retryAt: 0 };
+          state.failCount += 1;
+          if (state.failCount <= job.retry) {
+            const delayMs = (job.retryDelay ?? 300) * 1000;
+            state.retryAt = Date.now() + delayMs;
+            jobRetryState.set(job.name, state);
+            console.log(`[${ts()}] Job ${job.name} failed (attempt ${state.failCount}/${job.retry}), retrying in ${job.retryDelay ?? 300}s`);
+          } else {
+            jobRetryState.delete(job.name);
+            console.log(`[${ts()}] Job ${job.name} exhausted ${job.retry} retries`);
+          }
+        }
+        if (job.notify === false) return;
+        if (job.notify === "error" && r.exitCode === 0) return;
+        forwardToTelegram(job.name, r);
+        forwardToDiscord(job.name, r);
+      })
+      .finally(async () => {
+        if (job.recurring) return;
+        // Only clear one-shot schedule when no retry is pending.
+        if (jobRetryState.has(job.name)) return;
+        try {
+          await clearJobSchedule(job.name);
+          console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
+        } catch (err) {
+          console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
+        }
+      });
+  }
+
   setInterval(() => {
     const now = new Date();
     for (const job of currentJobs) {
+      // Fire pending retries before checking the cron schedule.
+      const retryState = jobRetryState.get(job.name);
+      if (retryState && retryState.retryAt <= Date.now()) {
+        // Do NOT delete state here — runJob reads it to continue counting failures correctly.
+        console.log(`[${ts()}] Retrying job: ${job.name} (attempt ${retryState.failCount + 1}/${job.retry})`);
+        runJob(job);
+        continue;
+      }
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
-        resolvePrompt(job.prompt)
-          .then((prompt) =>
-            run(
-              job.name,
-              prompt,
-              job.agent ? `agent:${job.agent}` : job.name,
-              job.model,
-              job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined,
-              job.agent
-            )
-          )
-          .then((r) => {
-            if (job.notify === false) return;
-            if (job.notify === "error" && r.exitCode === 0) return;
-            forwardToTelegram(job.name, r);
-            forwardToDiscord(job.name, r);
-          })
-          .finally(async () => {
-            if (job.recurring) return;
-            try {
-              await clearJobSchedule(job.name);
-              console.log(`[${ts()}] Cleared schedule for one-time job: ${job.name}`);
-            } catch (err) {
-              console.error(`[${ts()}] Failed to clear schedule for ${job.name}:`, err);
-            }
-          });
+        runJob(job);
       }
     }
     updateState();

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -715,7 +715,7 @@ export async function start(args: string[] = []) {
             run(
               job.name,
               prompt,
-              job.agent ? undefined : job.name,
+              job.agent ? `agent:${job.agent}` : job.name,
               job.model,
               job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined,
               job.agent

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -763,7 +763,9 @@ export async function start(args: string[] = []) {
       // Fire pending retries before checking the cron schedule.
       const retryState = jobRetryState.get(job.name);
       if (retryState && retryState.retryAt <= Date.now()) {
-        // Do NOT delete state here — runJob reads it to continue counting failures correctly.
+        // Push retryAt to sentinel so subsequent cron ticks don't re-fire while in flight.
+        // runJob's .then() handler overwrites this with the real next-retry time (or deletes it).
+        retryState.retryAt = Number.MAX_SAFE_INTEGER;
         console.log(`[${ts()}] Retrying job: ${job.name} (attempt ${retryState.failCount + 1}/${job.retry})`);
         runJob(job);
         continue;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -711,7 +711,16 @@ export async function start(args: string[] = []) {
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt, job.name, job.model, job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined))
+          .then((prompt) =>
+            run(
+              job.name,
+              prompt,
+              job.agent ? undefined : job.name,
+              job.model,
+              job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined,
+              job.agent
+            )
+          )
           .then((r) => {
             if (job.notify === false) return;
             if (job.notify === "error" && r.exitCode === 0) return;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -8,6 +8,7 @@ const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
 const PID_FILE = join(HEARTBEAT_DIR, "daemon.pid");
 const STATE_FILE = join(HEARTBEAT_DIR, "state.json");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
+const AGENTS_DIR = join(process.cwd(), "agents");
 
 function formatCountdown(ms: number): string {
   if (ms <= 0) return "now!";
@@ -100,16 +101,36 @@ async function showStatus(): Promise<boolean> {
   } catch {}
 
   try {
-    const files = await readdir(getJobsDir());
-    const mdFiles = files.filter((f) => f.endsWith(".md"));
-    if (mdFiles.length > 0) {
-      console.log(`  Jobs: ${mdFiles.length}`);
-      for (const f of mdFiles) {
+    const jobLines: string[] = [];
+    // Standalone jobs
+    try {
+      const files = await readdir(getJobsDir());
+      for (const f of files.filter((f) => f.endsWith(".md"))) {
         const content = await Bun.file(join(getJobsDir(), f)).text();
         const match = content.match(/schedule:\s*["']?([^"'\n]+)/);
         const schedule = match ? match[1].trim() : "unknown";
-        console.log(`    - ${f.replace(/\.md$/, "")} [${schedule}]`);
+        jobLines.push(`    - ${f.replace(/\.md$/, "")} [${schedule}]`);
       }
+    } catch {}
+    // Agent-scoped jobs: agents/<name>/jobs/*.md
+    try {
+      const agentDirs = await readdir(AGENTS_DIR);
+      for (const agentName of agentDirs) {
+        try {
+          const agentJobsDir = join(AGENTS_DIR, agentName, "jobs");
+          const files = await readdir(agentJobsDir);
+          for (const f of files.filter((f) => f.endsWith(".md"))) {
+            const content = await Bun.file(join(agentJobsDir, f)).text();
+            const match = content.match(/schedule:\s*["']?([^"'\n]+)/);
+            const schedule = match ? match[1].trim() : "unknown";
+            jobLines.push(`    - ${agentName}/${f.replace(/\.md$/, "")} [${schedule}]`);
+          }
+        } catch {}
+      }
+    } catch {}
+    if (jobLines.length > 0) {
+      console.log(`  Jobs: ${jobLines.length}`);
+      for (const line of jobLines) console.log(line);
     }
   } catch {}
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,14 +1,13 @@
 import { join } from "path";
 import { readdir, readFile } from "fs/promises";
 import { homedir } from "os";
-import { getJobsDir, loadSettings } from "../config";
+import { getJobsDir, getAgentsDir, loadSettings } from "../config";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
 const PID_FILE = join(HEARTBEAT_DIR, "daemon.pid");
 const STATE_FILE = join(HEARTBEAT_DIR, "state.json");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
-const AGENTS_DIR = join(process.cwd(), "agents");
 
 function formatCountdown(ms: number): string {
   if (ms <= 0) return "now!";
@@ -114,10 +113,10 @@ async function showStatus(): Promise<boolean> {
     } catch {}
     // Agent-scoped jobs: agents/<name>/jobs/*.md
     try {
-      const agentDirs = await readdir(AGENTS_DIR);
+      const agentDirs = await readdir(getAgentsDir());
       for (const agentName of agentDirs) {
         try {
-          const agentJobsDir = join(AGENTS_DIR, agentName, "jobs");
+          const agentJobsDir = join(getAgentsDir(), agentName, "jobs");
           const files = await readdir(agentJobsDir);
           for (const f of files.filter((f) => f.endsWith(".md"))) {
             const content = await Bun.file(join(agentJobsDir, f)).text();

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,10 @@ import { join, isAbsolute } from "path";
 import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
+import { parseWatchdogConfig, type WatchdogConfig } from "./watchdog";
+
+/** Re-exported under the name used in the Settings interface. */
+export type WatchdogSettings = WatchdogConfig;
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
@@ -72,6 +76,7 @@ const DEFAULT_SETTINGS: Settings = {
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
   sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
+  watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
 };
 
 export interface HeartbeatExcludeWindow {
@@ -126,8 +131,10 @@ export interface Settings {
   web: WebConfig;
   stt: SttConfig;
   sessionTimeoutMs: number;
+  watchdog: WatchdogSettings;
   jobsDir?: string;
 }
+
 
 export interface AgenticMode {
   name: string;
@@ -297,6 +304,7 @@ function parseSettings(
     sessionTimeoutMs: typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
       ? raw.sessionTimeoutMs
       : DEFAULT_SESSION_TIMEOUT_MS,
+    watchdog: parseWatchdogConfig(raw.watchdog),
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,11 @@ export function getJobsDir(): string {
   return DEFAULT_JOBS_DIR;
 }
 
+/** Returns the root directory for agent-scoped sessions and jobs. */
+export function getAgentsDir(): string {
+  return join(process.cwd(), "agents");
+}
+
 const DEFAULT_SETTINGS: Settings = {
   model: "",
   api: "",

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -19,6 +19,10 @@ export interface Job {
   label?: string;
   /** When false, the job is loaded but not scheduled. Defaults to true. */
   enabled?: boolean;
+  /** Max number of retry attempts on failure before giving up until next scheduled run. */
+  retry?: number;
+  /** Seconds to wait between retry attempts. Defaults to 300 (5 min). */
+  retryDelay?: number;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -86,7 +90,13 @@ function parseJobFile(name: string, content: string): Job | null {
       ? false
       : undefined;
 
-  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds, agent, label, enabled };
+  const retryLine = lines.find((l) => l.startsWith("retry:"));
+  const retry = retryLine ? parseInt(parseFrontmatterValue(retryLine.replace("retry:", "")), 10) || undefined : undefined;
+
+  const retryDelayLine = lines.find((l) => l.startsWith("retry_delay:"));
+  const retryDelay = retryDelayLine ? parseInt(parseFrontmatterValue(retryDelayLine.replace("retry_delay:", "")), 10) || undefined : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds, agent, label, enabled, retry, retryDelay };
 }
 
 export async function loadJobs(): Promise<Job[]> {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,8 +1,6 @@
 import { readdir } from "fs/promises";
 import { join } from "path";
-import { getJobsDir } from "./config";
-
-const AGENTS_DIR = join(process.cwd(), "agents");
+import { getJobsDir, getAgentsDir } from "./config";
 
 export interface Job {
   /** Scheduler key. For standalone jobs this is the file stem. For agent-scoped jobs this is "agent/label". */
@@ -111,12 +109,12 @@ export async function loadJobs(): Promise<Job[]> {
   // agents/ lives at project root (outside .claude/), so agent-managed jobs are writable by Claude Code.
   let agentDirs: string[] = [];
   try {
-    agentDirs = await readdir(AGENTS_DIR);
+    agentDirs = await readdir(getAgentsDir());
   } catch {
     return jobs;
   }
   for (const agentName of agentDirs) {
-    const agentJobsDir = join(AGENTS_DIR, agentName, "jobs");
+    const agentJobsDir = join(getAgentsDir(), agentName, "jobs");
     let jobFiles: string[] = [];
     try {
       jobFiles = await readdir(agentJobsDir);
@@ -143,7 +141,7 @@ function resolveJobPath(jobName: string): string {
   if (slash > 0 && slash < jobName.length - 1) {
     const agentName = jobName.slice(0, slash);
     const label = jobName.slice(slash + 1);
-    return join(AGENTS_DIR, agentName, "jobs", `${label}.md`);
+    return join(getAgentsDir(), agentName, "jobs", `${label}.md`);
   }
   return join(getJobsDir(), `${jobName}.md`);
 }

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -2,7 +2,10 @@ import { readdir } from "fs/promises";
 import { join } from "path";
 import { getJobsDir } from "./config";
 
+const AGENTS_DIR = join(process.cwd(), "agents");
+
 export interface Job {
+  /** Scheduler key. For standalone jobs this is the file stem. For agent-scoped jobs this is "agent/label". */
   name: string;
   schedule: string;
   prompt: string;
@@ -12,6 +15,12 @@ export interface Job {
   model?: string;
   /** When set, overrides the global session timeout for this job (in seconds). */
   timeoutSeconds?: number;
+  /** If set, this job is scoped to an agent. */
+  agent?: string;
+  /** Human-readable label for agent-scoped jobs (file stem). */
+  label?: string;
+  /** When false, the job is loaded but not scheduled. Defaults to true. */
+  enabled?: boolean;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -62,29 +71,85 @@ function parseJobFile(name: string, content: string): Job | null {
   const timeoutParsed = timeoutRaw ? parseInt(timeoutRaw, 10) : NaN;
   const timeoutSeconds = Number.isFinite(timeoutParsed) && timeoutParsed > 0 ? timeoutParsed : undefined;
 
-  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds };
+  const agentLine = lines.find((l) => l.startsWith("agent:"));
+  const agentRaw = agentLine ? parseFrontmatterValue(agentLine.replace("agent:", "")) : "";
+  const agent = agentRaw || undefined;
+
+  const labelLine = lines.find((l) => l.startsWith("label:"));
+  const labelRaw = labelLine ? parseFrontmatterValue(labelLine.replace("label:", "")) : "";
+  const label = labelRaw || undefined;
+
+  const enabledLine = lines.find((l) => l.startsWith("enabled:"));
+  const enabledRaw = enabledLine
+    ? parseFrontmatterValue(enabledLine.replace("enabled:", "")).toLowerCase()
+    : "";
+  const enabled =
+    enabledRaw === "false" || enabledRaw === "no" || enabledRaw === "0"
+      ? false
+      : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds, agent, label, enabled };
 }
 
 export async function loadJobs(): Promise<Job[]> {
   const jobs: Job[] = [];
-  let files: string[];
-  try {
-    files = await readdir(getJobsDir());
-  } catch {
-    return jobs;
-  }
 
-  for (const file of files) {
+  let flatFiles: string[] = [];
+  try {
+    flatFiles = await readdir(getJobsDir());
+  } catch {
+    /* missing dir is fine */
+  }
+  for (const file of flatFiles) {
     if (!file.endsWith(".md")) continue;
     const content = await Bun.file(join(getJobsDir(), file)).text();
     const job = parseJobFile(file.replace(/\.md$/, ""), content);
-    if (job) jobs.push(job);
+    if (!job) continue;
+    if (job.enabled !== false) jobs.push(job);
   }
+
+  // agents/ lives at project root (outside .claude/), so agent-managed jobs are writable by Claude Code.
+  let agentDirs: string[] = [];
+  try {
+    agentDirs = await readdir(AGENTS_DIR);
+  } catch {
+    return jobs;
+  }
+  for (const agentName of agentDirs) {
+    const agentJobsDir = join(AGENTS_DIR, agentName, "jobs");
+    let jobFiles: string[] = [];
+    try {
+      jobFiles = await readdir(agentJobsDir);
+    } catch {
+      continue;
+    }
+    for (const file of jobFiles) {
+      if (!file.endsWith(".md")) continue;
+      const labelFromFile = file.replace(/\.md$/, "");
+      const content = await Bun.file(join(agentJobsDir, file)).text();
+      const job = parseJobFile(`${agentName}/${labelFromFile}`, content);
+      if (!job) continue;
+      job.agent = agentName;
+      job.label = labelFromFile;
+      if (job.enabled !== false) jobs.push(job);
+    }
+  }
+
   return jobs;
 }
 
+function resolveJobPath(jobName: string): string {
+  const slash = jobName.indexOf("/");
+  if (slash > 0 && slash < jobName.length - 1) {
+    const agentName = jobName.slice(0, slash);
+    const label = jobName.slice(slash + 1);
+    return join(AGENTS_DIR, agentName, "jobs", `${label}.md`);
+  }
+  return join(getJobsDir(), `${jobName}.md`);
+}
+
 export async function clearJobSchedule(jobName: string): Promise<void> {
-  const path = join(getJobsDir(), `${jobName}.md`);
+  const path = resolveJobPath(jobName);
   const content = await Bun.file(path).text();
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!match) return;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -375,12 +375,19 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string, modelOverride?: string, timeoutMsOverride?: number): Promise<RunResult> {
+async function execClaude(
+  name: string,
+  prompt: string,
+  threadId?: string,
+  modelOverride?: string,
+  timeoutMsOverride?: number,
+  agentName?: string
+): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
   const existing = threadId
     ? await getThreadSession(threadId)
-    : await getSession();
+    : await getSession(agentName);
   const isNew = !existing;
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const logFile = join(LOGS_DIR, `${name}-${timestamp}.log`);
@@ -488,8 +495,9 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
         await createThreadSession(threadId, sessionId);
         console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
       } else {
-        await createSession(sessionId);
-        console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}`);
+        await createSession(sessionId, agentName);
+        const label = agentName ? ` (agent ${agentName})` : "";
+        console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}${label}`);
       }
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to parse session from Claude output:`, e);
@@ -549,7 +557,7 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
       });
 
       if (retryExec.exitCode === 0) {
-        const count = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
+        const count = threadId ? await incrementThreadTurn(threadId) : await incrementTurn(agentName);
         console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${count} (after compact + retry)`);
       }
       return retryResult;
@@ -558,14 +566,15 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
 
   // --- Turn tracking & compact warning ---
   if (exitCode === 0 && !isNew) {
-    const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
-    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${threadId ? ` (thread ${threadId.slice(0, 8)})` : ""}`);
+    const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn(agentName);
+    const turnLabel = threadId ? ` (thread ${threadId.slice(0, 8)})` : agentName ? ` (agent ${agentName})` : "";
+    console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${turnLabel}`);
 
     if (turnCount >= COMPACT_WARN_THRESHOLD && existing && !existing.compactWarned) {
       if (threadId) {
         await markThreadCompactWarned(threadId);
       } else {
-        await markCompactWarned();
+        await markCompactWarned(agentName);
       }
       emitCompactEvent({ type: "warn", turnCount });
     }
@@ -574,8 +583,15 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string, modelOverride?: string, timeoutMs?: number): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId, modelOverride, timeoutMs), threadId);
+export async function run(
+  name: string,
+  prompt: string,
+  threadId?: string,
+  modelOverride?: string,
+  timeoutMs?: number,
+  agentName?: string
+): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt, threadId, modelOverride, timeoutMs, agentName), threadId);
 }
 
 async function streamClaude(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -353,8 +353,8 @@ export async function runCompact(
  * High-level compact: resolves session + settings internally.
  * Returns { success, message }.
  */
-export async function compactCurrentSession(): Promise<{ success: boolean; message: string }> {
-  const existing = await getSession();
+export async function compactCurrentSession(agentName?: string): Promise<{ success: boolean; message: string }> {
+  const existing = await getSession(agentName);
   if (!existing) return { success: false, message: "No active session to compact." };
 
   const settings = getSettings();
@@ -546,8 +546,8 @@ async function execClaude(
         clearSession(trackingId);
         return result;
       }
-      // Non-timeout failures reset the counter but leave nothing to track.
-      if (exitCode !== 124) clearSession(trackingId);
+      // Non-timeout, non-zero exits: counter is already reset by recordResult.
+      // Do NOT clearSession here — that would reset startedAt and weaken maxRuntimeSeconds.
     }
   }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,6 +11,7 @@ import {
 import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
+import { recordResult, abortReason, clearSession, startSession } from "./watchdog";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
@@ -389,11 +390,13 @@ async function execClaude(
     ? await getThreadSession(threadId)
     : await getSession(agentName);
   const isNew = !existing;
+  // Start the watchdog clock for resumed sessions (we know the ID immediately).
+  if (existing) startSession(existing.sessionId);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const logFile = join(LOGS_DIR, `${name}-${timestamp}.log`);
 
   const settings = getSettings();
-  const { security, model, api, fallback, agentic } = settings;
+  const { security, model, api, fallback, agentic, watchdog } = settings;
 
   // Determine which model to use based on agentic routing
   let primaryConfig: ModelConfig;
@@ -499,6 +502,7 @@ async function execClaude(
         const label = agentName ? ` (agent ${agentName})` : "";
         console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}${label}`);
       }
+      startSession(sessionId);
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to parse session from Claude output:`, e);
     }
@@ -526,6 +530,26 @@ async function execClaude(
 
   await Bun.write(logFile, output);
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
+
+  // --- Watchdog: track consecutive timeouts ---
+  // Skip tracking for unresolved session IDs ("unknown") to avoid cross-session
+  // state collisions when a new session fails before its real ID is known.
+  const trackingId = sessionId !== "unknown" ? sessionId : null;
+  if (trackingId) {
+    if (exitCode === 0) {
+      clearSession(trackingId);
+    } else {
+      recordResult(trackingId, exitCode);
+      const reason = abortReason(trackingId, watchdog);
+      if (reason) {
+        console.warn(`[${new Date().toLocaleTimeString()}] ${reason}`);
+        clearSession(trackingId);
+        return result;
+      }
+      // Non-timeout failures reset the counter but leave nothing to track.
+      if (exitCode !== 124) clearSession(trackingId);
+    }
+  }
 
   // --- Auto-compact on timeout (exit 124) ---
   if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -3,6 +3,7 @@ import { unlink, readdir, rename } from "fs/promises";
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
+const AGENTS_DIR = join(process.cwd(), "agents");
 
 export interface GlobalSession {
   sessionId: string;
@@ -12,9 +13,23 @@ export interface GlobalSession {
   compactWarned: boolean;
 }
 
+// Module-level cache is for the GLOBAL session only.
+// Agent sessions bypass this cache — they read/write directly.
 let current: GlobalSession | null = null;
 
-async function loadSession(): Promise<GlobalSession | null> {
+function sessionPathFor(agentName?: string): string {
+  if (agentName) return join(AGENTS_DIR, agentName, "session.json");
+  return SESSION_FILE;
+}
+
+async function loadSession(agentName?: string): Promise<GlobalSession | null> {
+  if (agentName) {
+    try {
+      return await Bun.file(sessionPathFor(agentName)).json();
+    } catch {
+      return null;
+    }
+  }
   if (current) return current;
   try {
     current = await Bun.file(SESSION_FILE).json();
@@ -24,63 +39,65 @@ async function loadSession(): Promise<GlobalSession | null> {
   }
 }
 
-async function saveSession(session: GlobalSession): Promise<void> {
-  current = session;
-  await Bun.write(SESSION_FILE, JSON.stringify(session, null, 2) + "\n");
+async function saveSession(session: GlobalSession, agentName?: string): Promise<void> {
+  if (!agentName) current = session;
+  await Bun.write(sessionPathFor(agentName), JSON.stringify(session, null, 2) + "\n");
 }
 
 /** Returns the existing session or null. Never creates one. */
-export async function getSession(): Promise<{ sessionId: string; turnCount: number; compactWarned: boolean } | null> {
-  const existing = await loadSession();
+export async function getSession(
+  agentName?: string
+): Promise<{ sessionId: string; turnCount: number; compactWarned: boolean } | null> {
+  const existing = await loadSession(agentName);
   if (existing) {
     // Backfill missing fields from older session.json files
     if (typeof existing.turnCount !== "number") existing.turnCount = 0;
     if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
     existing.lastUsedAt = new Date().toISOString();
-    await saveSession(existing);
+    await saveSession(existing, agentName);
     return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
   }
   return null;
 }
 
 /** Save a session ID obtained from Claude Code's output. */
-export async function createSession(sessionId: string): Promise<void> {
+export async function createSession(sessionId: string, agentName?: string): Promise<void> {
   await saveSession({
     sessionId,
     createdAt: new Date().toISOString(),
     lastUsedAt: new Date().toISOString(),
     turnCount: 0,
     compactWarned: false,
-  });
+  }, agentName);
 }
 
 /** Returns session metadata without mutating lastUsedAt. */
-export async function peekSession(): Promise<GlobalSession | null> {
-  return await loadSession();
+export async function peekSession(agentName?: string): Promise<GlobalSession | null> {
+  return await loadSession(agentName);
 }
 
 /** Increment the turn counter after a successful Claude invocation. */
-export async function incrementTurn(): Promise<number> {
-  const existing = await loadSession();
+export async function incrementTurn(agentName?: string): Promise<number> {
+  const existing = await loadSession(agentName);
   if (!existing) return 0;
   if (typeof existing.turnCount !== "number") existing.turnCount = 0;
   existing.turnCount += 1;
-  await saveSession(existing);
+  await saveSession(existing, agentName);
   return existing.turnCount;
 }
 
 /** Mark that the compact warning has been sent for the current session. */
-export async function markCompactWarned(): Promise<void> {
-  const existing = await loadSession();
+export async function markCompactWarned(agentName?: string): Promise<void> {
+  const existing = await loadSession(agentName);
   if (!existing) return;
   existing.compactWarned = true;
-  await saveSession(existing);
+  await saveSession(existing, agentName);
 }
 
-export async function resetSession(): Promise<void> {
-  current = null;
+export async function resetSession(agentName?: string): Promise<void> {
+  if (!agentName) current = null;
   try {
-    await unlink(SESSION_FILE);
+    await unlink(sessionPathFor(agentName));
   } catch {
     // already gone
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,9 +1,9 @@
 import { join } from "path";
 import { unlink, readdir, rename } from "fs/promises";
+import { getAgentsDir } from "./config";
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
-const AGENTS_DIR = join(process.cwd(), "agents");
 
 export interface GlobalSession {
   sessionId: string;
@@ -18,7 +18,7 @@ export interface GlobalSession {
 let current: GlobalSession | null = null;
 
 function sessionPathFor(agentName?: string): string {
-  if (agentName) return join(AGENTS_DIR, agentName, "session.json");
+  if (agentName) return join(getAgentsDir(), agentName, "session.json");
   return SESSION_FILE;
 }
 

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -1,0 +1,155 @@
+/**
+ * Minimal runaway-session watchdog.
+ *
+ * Tracks consecutive timeouts per session and aborts when a configurable
+ * threshold is exceeded.  This prevents a session stuck in a timeout loop from
+ * continuously draining the user's Claude Code allowance.
+ *
+ * Abort is a single-cycle circuit-breaker: the session state is cleared after
+ * an abort so the next invocation starts fresh.
+ *
+ * Opt-in: all limits default to null (disabled).  Enable via settings.json:
+ *
+ *   "watchdog": {
+ *     "maxConsecutiveTimeouts": 3,
+ *     "maxRuntimeSeconds": 3600
+ *   }
+ */
+
+/** Exit code produced by runClaudeOnce when the per-invocation wall-clock expires. */
+export const TIMEOUT_EXIT_CODE = 124;
+
+export interface WatchdogConfig {
+  /** Stop retrying after this many consecutive TIMEOUT_EXIT_CODE exits. null = disabled. */
+  maxConsecutiveTimeouts: number | null;
+  /**
+   * Hard wall-clock limit (seconds) measured from when the session is first
+   * registered via startSession(). null = disabled.
+   *
+   * Tip: the existing per-invocation timeout (settings.sessionTimeoutMs) already
+   * caps each individual Claude call.  maxRuntimeSeconds adds a session-level
+   * guard for cases where many sequential invocations keep timing out.
+   */
+  maxRuntimeSeconds: number | null;
+}
+
+export const DEFAULT_WATCHDOG_CONFIG: WatchdogConfig = {
+  maxConsecutiveTimeouts: null,
+  maxRuntimeSeconds: null,
+};
+
+interface SessionState {
+  consecutiveTimeouts: number;
+  startedAt: number;
+}
+
+/** Allows tests to inject a deterministic clock. */
+let _now: () => number = () => Date.now();
+
+/** For tests only — restore with resetClock(). */
+export function injectClock(fn: () => number): void {
+  _now = fn;
+}
+
+export function resetClock(): void {
+  _now = () => Date.now();
+}
+
+const sessions = new Map<string, SessionState>();
+
+/**
+ * Register the start of a session.  Must be called with a real session ID
+ * (not the "unknown" sentinel) so the runtime clock begins at the right time.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function startSession(sessionId: string): void {
+  if (!sessions.has(sessionId)) {
+    sessions.set(sessionId, { consecutiveTimeouts: 0, startedAt: _now() });
+  }
+}
+
+/**
+ * Record the outcome of a single Claude invocation.
+ * Only call this with a real session ID (not "unknown").
+ */
+export function recordResult(sessionId: string, exitCode: number): void {
+  const state = sessions.get(sessionId);
+  if (!state) return;
+  if (exitCode === TIMEOUT_EXIT_CODE) {
+    state.consecutiveTimeouts += 1;
+  } else {
+    state.consecutiveTimeouts = 0;
+  }
+}
+
+/**
+ * Returns an abort-reason string if the watchdog has determined this session
+ * should stop, or null if the session is healthy.
+ *
+ * Call this BEFORE triggering any auto-compact / retry logic.
+ * Only call with a real session ID.
+ */
+export function abortReason(
+  sessionId: string,
+  config: WatchdogConfig,
+): string | null {
+  const state = sessions.get(sessionId);
+  if (!state) return null;
+
+  if (
+    config.maxConsecutiveTimeouts !== null &&
+    state.consecutiveTimeouts >= config.maxConsecutiveTimeouts
+  ) {
+    return (
+      `Watchdog: aborted after ${state.consecutiveTimeouts} consecutive timeouts` +
+      ` (limit: ${config.maxConsecutiveTimeouts})`
+    );
+  }
+
+  if (config.maxRuntimeSeconds !== null) {
+    const elapsed = (_now() - state.startedAt) / 1000;
+    if (elapsed >= config.maxRuntimeSeconds) {
+      return (
+        `Watchdog: session exceeded maximum runtime` +
+        ` (${elapsed.toFixed(0)}s / ${config.maxRuntimeSeconds}s)`
+      );
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Remove tracking state for a session.
+ * Called on clean exit, on abort (circuit-breaker reset), and on non-timeout
+ * failures where there is nothing left to track.
+ */
+export function clearSession(sessionId: string): void {
+  sessions.delete(sessionId);
+}
+
+/**
+ * Parse and validate a raw settings value into a WatchdogConfig.
+ * Unknown keys are ignored; invalid values fall back to null (disabled).
+ */
+export function parseWatchdogConfig(raw: unknown): WatchdogConfig {
+  if (!raw || typeof raw !== "object") return { ...DEFAULT_WATCHDOG_CONFIG };
+
+  const r = raw as Record<string, unknown>;
+
+  const maxConsecutiveTimeouts =
+    typeof r.maxConsecutiveTimeouts === "number" &&
+    Number.isInteger(r.maxConsecutiveTimeouts) &&
+    r.maxConsecutiveTimeouts > 0
+      ? r.maxConsecutiveTimeouts
+      : null;
+
+  const maxRuntimeSeconds =
+    typeof r.maxRuntimeSeconds === "number" &&
+    Number.isFinite(r.maxRuntimeSeconds) &&
+    r.maxRuntimeSeconds > 0
+      ? r.maxRuntimeSeconds
+      : null;
+
+  return { maxConsecutiveTimeouts, maxRuntimeSeconds };
+}

--- a/src/watchdog.ts
+++ b/src/watchdog.ts
@@ -61,6 +61,10 @@ const sessions = new Map<string, SessionState>();
  * Register the start of a session.  Must be called with a real session ID
  * (not the "unknown" sentinel) so the runtime clock begins at the right time.
  * Safe to call multiple times — subsequent calls are no-ops.
+ *
+ * Note: tracking is in-memory only. If the daemon restarts, the clock resets on
+ * the first resume — maxRuntimeSeconds will not catch sessions older than the
+ * current daemon process.
  */
 export function startSession(sessionId: string): void {
   if (!sessions.has(sessionId)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["bun-types"],
+    "types": ["bun"],
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "bundler"


### PR DESCRIPTION
## Summary

- Rebase and cherry-pick the current functional changes from #107 onto current master, excluding the stale version bump.
- Rebase and cherry-pick the current functional changes from #131 onto current master, preserving the current session timeout config from master.
- Add a fresh plugin and marketplace metadata bump to 1.0.6 so the version guards have a current change to validate.
- Fix tsconfig's Bun type reference from bun-types to bun so local typecheck can actually run with the declared @types/bun dependency.

## Replaces

Supersedes #107 and #131. Both source PRs should be closed in favour of this consolidated PR.

## Checks

- bun install --frozen-lockfile
- bun run bump:plugin-version
- bun run bump:marketplace-version
- bunx tsc --noEmit
- bun test
