### PR TITLE
feat(telegram): inline button support via [buttons: ...] directive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,13 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.0",
-      "keywords": ["cron", "heartbeat", "scheduler", "daemon"],
+      "version": "1.0.1",
+      "keywords": [
+        "cron",
+        "heartbeat",
+        "scheduler",
+        "daemon"
+      ],
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Validation
+
+- [ ] I ran the relevant checks locally
+- [ ] I updated any docs or setup guidance affected by this change
+
+## Plugin Versioning
+
+If this PR changes shipped plugin files under `src/`, `commands/`, `prompts/`, or `.claude-plugin/`, version metadata may also need to be bumped.
+
+Run as needed:
+
+```bash
+bun run bump:plugin-version
+bun run bump:marketplace-version
+```
+
+Typical rule:
+- bump `.claude-plugin/plugin.json` when shipped plugin content changes
+- bump `.claude-plugin/marketplace.json` when marketplace metadata should reflect the new shipped version
+
+Docs-only and other non-shipped changes do not require these bumps.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -21,24 +21,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_non_write_users: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/marketplace-version-guard.yml
+++ b/.github/workflows/marketplace-version-guard.yml
@@ -43,6 +43,8 @@ jobs:
           if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/marketplace.json"; then
             echo "Shipped plugin files changed but .claude-plugin/marketplace.json was not updated."
             echo "Run: bun run bump:marketplace-version"
+            echo "If your PR also changes the plugin manifest, you may also need:"
+            echo "  bun run bump:plugin-version"
             exit 1
           fi
 
@@ -57,6 +59,8 @@ jobs:
           if [ "$base_version" = "$head_version" ]; then
             echo "Shipped plugin files changed but marketplace version did not change ($head_version)."
             echo "Run: bun run bump:marketplace-version"
+            echo "If your PR also changes the plugin manifest, you may also need:"
+            echo "  bun run bump:plugin-version"
             exit 1
           fi
 

--- a/.github/workflows/marketplace-version-guard.yml
+++ b/.github/workflows/marketplace-version-guard.yml
@@ -1,0 +1,63 @@
+name: Marketplace Version Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  marketplace-version-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require marketplace version bump for shipped plugin changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changed files detected."
+            exit 0
+          fi
+
+          shipped_pattern='^(src/|commands/|prompts/|\.claude-plugin/)'
+
+          if ! printf '%s\n' "$changed_files" | grep -Eq "$shipped_pattern"; then
+            echo "Docs-only or non-shipped changes detected; marketplace version bump not required."
+            exit 0
+          fi
+
+          if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/marketplace.json"; then
+            echo "Shipped plugin files changed but .claude-plugin/marketplace.json was not updated."
+            echo "Run: bun run bump:marketplace-version"
+            exit 1
+          fi
+
+          base_version="$(
+            git show "$BASE_SHA:.claude-plugin/marketplace.json" | \
+            python3 -c 'import json,sys; data=json.load(sys.stdin); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
+          )"
+          head_version="$(
+            python3 -c 'import json; data=json.load(open(".claude-plugin/marketplace.json")); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
+          )"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "Shipped plugin files changed but marketplace version did not change ($head_version)."
+            echo "Run: bun run bump:marketplace-version"
+            exit 1
+          fi
+
+          echo "Marketplace version changed: $base_version -> $head_version"

--- a/.github/workflows/plugin-version-guard.yml
+++ b/.github/workflows/plugin-version-guard.yml
@@ -43,6 +43,8 @@ jobs:
           if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/plugin.json"; then
             echo "Shipped plugin files changed but .claude-plugin/plugin.json was not updated."
             echo "Run: bun run bump:plugin-version"
+            echo "If your PR also touches marketplace metadata expectations, you may also need:"
+            echo "  bun run bump:marketplace-version"
             exit 1
           fi
 
@@ -52,6 +54,8 @@ jobs:
           if [ "$base_version" = "$head_version" ]; then
             echo "Shipped plugin files changed but plugin version did not change ($head_version)."
             echo "Run: bun run bump:plugin-version"
+            echo "If your PR also touches marketplace metadata expectations, you may also need:"
+            echo "  bun run bump:marketplace-version"
             exit 1
           fi
 

--- a/.github/workflows/plugin-version-guard.yml
+++ b/.github/workflows/plugin-version-guard.yml
@@ -1,0 +1,58 @@
+name: Plugin Version Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  plugin-version-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require plugin version bump for shipped plugin changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+
+          echo "Changed files:"
+          printf '%s\n' "$changed_files"
+
+          if [ -z "$changed_files" ]; then
+            echo "No changed files detected."
+            exit 0
+          fi
+
+          shipped_pattern='^(src/|commands/|prompts/|\.claude-plugin/)'
+
+          if ! printf '%s\n' "$changed_files" | grep -Eq "$shipped_pattern"; then
+            echo "Docs-only or non-shipped changes detected; plugin version bump not required."
+            exit 0
+          fi
+
+          if ! printf '%s\n' "$changed_files" | grep -Fxq ".claude-plugin/plugin.json"; then
+            echo "Shipped plugin files changed but .claude-plugin/plugin.json was not updated."
+            echo "Run: bun run bump:plugin-version"
+            exit 1
+          fi
+
+          base_version="$(git show "$BASE_SHA:.claude-plugin/plugin.json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+          head_version="$(python3 -c 'import json; print(json.load(open(".claude-plugin/plugin.json"))["version"])')"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "Shipped plugin files changed but plugin version did not change ($head_version)."
+            echo "Run: bun run bump:plugin-version"
+            exit 1
+          fi
+
+          echo "Plugin version changed: $base_version -> $head_version"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Then open a Claude Code session and run:
 ```
 The setup wizard walks you through model, heartbeat, Telegram, Discord, and security, then your daemon is live with a web dashboard.
 
+### Contributor Note: Plugin Version Metadata
+
+If you change shipped plugin files under `src/`, `commands/`, `prompts/`, or `.claude-plugin/`, the plugin metadata version may also need to be bumped so Claude Code and marketplace consumers detect the update correctly.
+
+Helpers:
+
+```bash
+bun run bump:plugin-version
+bun run bump:marketplace-version
+```
+
+Docs-only and other non-shipped changes do not require these bumps.
+
 ## What Would Be Built Next?
 
 > **Mega Post:** Help shape the next ClaudeClaw features.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "telegram": "bun run src/index.ts telegram",
     "discord": "bun run src/index.ts discord",
     "status": "bun run src/index.ts status",
-    "bump:plugin-version": "bun run scripts/bump-plugin-version.ts"
+    "bump:plugin-version": "bun run scripts/bump-plugin-version.ts",
+    "bump:marketplace-version": "bun run scripts/bump-marketplace-version.ts"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:web": "bun --watch src/index.ts start --web --replace-existing",
     "telegram": "bun run src/index.ts telegram",
     "discord": "bun run src/index.ts discord",
-    "status": "bun run src/index.ts status"
+    "status": "bun run src/index.ts status",
+    "bump:plugin-version": "bun run scripts/bump-plugin-version.ts"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9"

--- a/scripts/bump-marketplace-version.ts
+++ b/scripts/bump-marketplace-version.ts
@@ -1,0 +1,66 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const MARKETPLACE_JSON = ".claude-plugin/marketplace.json";
+const VALID_BUMP_TYPES = new Set(["patch", "minor", "major"]);
+
+type BumpType = "patch" | "minor" | "major";
+
+function bumpVersion(version: string, bumpType: BumpType): string {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Unsupported marketplace version format: ${version}`);
+  }
+
+  let [, major, minor, patch] = match;
+  let nextMajor = Number(major);
+  let nextMinor = Number(minor);
+  let nextPatch = Number(patch);
+
+  switch (bumpType) {
+    case "major":
+      nextMajor += 1;
+      nextMinor = 0;
+      nextPatch = 0;
+      break;
+    case "minor":
+      nextMinor += 1;
+      nextPatch = 0;
+      break;
+    case "patch":
+      nextPatch += 1;
+      break;
+  }
+
+  return `${nextMajor}.${nextMinor}.${nextPatch}`;
+}
+
+async function main(): Promise<void> {
+  const rawBumpType = process.argv[2] ?? "patch";
+  if (!VALID_BUMP_TYPES.has(rawBumpType)) {
+    throw new Error(`Unsupported bump type: ${rawBumpType}. Use patch, minor, or major.`);
+  }
+
+  const bumpType = rawBumpType as BumpType;
+  const raw = await readFile(MARKETPLACE_JSON, "utf8");
+  const marketplace = JSON.parse(raw) as { plugins?: Array<{ name?: string; version?: string }> };
+
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+    throw new Error(`${MARKETPLACE_JSON} does not contain any plugins.`);
+  }
+
+  const plugin = marketplace.plugins.find((entry) => entry.name === "claudeclaw") ?? marketplace.plugins[0];
+  if (!plugin || typeof plugin.version !== "string" || plugin.version.trim() === "") {
+    throw new Error(`${MARKETPLACE_JSON} is missing a valid plugin version string.`);
+  }
+
+  const nextVersion = bumpVersion(plugin.version, bumpType);
+  plugin.version = nextVersion;
+
+  await writeFile(MARKETPLACE_JSON, `${JSON.stringify(marketplace, null, 2)}\n`, "utf8");
+  console.log(`${MARKETPLACE_JSON}: ${nextVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/bump-plugin-version.ts
+++ b/scripts/bump-plugin-version.ts
@@ -1,0 +1,61 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const PLUGIN_JSON = ".claude-plugin/plugin.json";
+const VALID_BUMP_TYPES = new Set(["patch", "minor", "major"]);
+
+type BumpType = "patch" | "minor" | "major";
+
+function bumpVersion(version: string, bumpType: BumpType): string {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Unsupported plugin version format: ${version}`);
+  }
+
+  let [, major, minor, patch] = match;
+  let nextMajor = Number(major);
+  let nextMinor = Number(minor);
+  let nextPatch = Number(patch);
+
+  switch (bumpType) {
+    case "major":
+      nextMajor += 1;
+      nextMinor = 0;
+      nextPatch = 0;
+      break;
+    case "minor":
+      nextMinor += 1;
+      nextPatch = 0;
+      break;
+    case "patch":
+      nextPatch += 1;
+      break;
+  }
+
+  return `${nextMajor}.${nextMinor}.${nextPatch}`;
+}
+
+async function main(): Promise<void> {
+  const rawBumpType = process.argv[2] ?? "patch";
+  if (!VALID_BUMP_TYPES.has(rawBumpType)) {
+    throw new Error(`Unsupported bump type: ${rawBumpType}. Use patch, minor, or major.`);
+  }
+
+  const bumpType = rawBumpType as BumpType;
+  const raw = await readFile(PLUGIN_JSON, "utf8");
+  const plugin = JSON.parse(raw) as { version?: string };
+
+  if (typeof plugin.version !== "string" || plugin.version.trim() === "") {
+    throw new Error(`${PLUGIN_JSON} is missing a valid version string.`);
+  }
+
+  const nextVersion = bumpVersion(plugin.version, bumpType);
+  plugin.version = nextVersion;
+
+  await writeFile(PLUGIN_JSON, `${JSON.stringify(plugin, null, 2)}\n`, "utf8");
+  console.log(`${PLUGIN_JSON}: ${nextVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -240,6 +240,7 @@ async function rejoinThreads(token: string): Promise<void> {
   const threadSessions = await listThreadSessions();
   for (const ts of threadSessions) {
     try {
+      await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
       if (!knownThreads.has(ts.threadId)) {
         const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
@@ -433,7 +434,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   const channelId = message.channel_id;
   const isDM = !message.guild_id;
   const isGuild = !!message.guild_id;
-  const content = message.content;
+  const content = message.content.replace(/\0/g, "");
 
   // Recover lost thread from sessions.json (fallback for knownThreads volatility)
   if (isGuild && !knownThreads.has(channelId)) {
@@ -1008,6 +1009,11 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       if (data.id && data.parent_id) {
         knownThreads.set(data.id, { parentId: data.parent_id });
         debugLog(`Thread tracked: ${data.id} (parent: ${data.parent_id})`);
+        if (getSettings().discord.listenChannels.includes(data.parent_id)) {
+          discordApi(token, "PUT", `/channels/${data.id}/thread-members/@me`).catch((err) =>
+            console.error(`[Discord] Failed to join thread ${data.id}: ${err}`),
+          );
+        }
       }
       break;
 

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -341,6 +341,12 @@ function isVoiceAttachment(a: DiscordAttachment): boolean {
   return Boolean(a.content_type?.startsWith("audio/"));
 }
 
+function isTextAttachment(a: DiscordAttachment): boolean {
+  if (a.content_type?.startsWith("text/")) return true;
+  const ext = extname(a.filename).toLowerCase();
+  return ext === ".txt" || ext === ".md";
+}
+
 async function downloadDiscordAttachment(
   attachment: DiscordAttachment,
   type: "image" | "voice",
@@ -476,10 +482,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   // Detect attachments
   const imageAttachments = message.attachments.filter(isImageAttachment);
   const voiceAttachments = message.attachments.filter(isVoiceAttachment);
+  const textAttachments = message.attachments.filter(isTextAttachment);
   const hasImage = imageAttachments.length > 0;
   const hasVoice = voiceAttachments.length > 0;
+  const hasText = textAttachments.length > 0;
 
-  if (!content.trim() && !hasImage && !hasVoice) return;
+  if (!content.trim() && !hasImage && !hasVoice && !hasText) return;
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;
@@ -488,7 +496,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   }
 
   const label = message.author.username;
-  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : ""].filter(Boolean);
+  const mediaParts = [hasImage ? "image" : "", hasVoice ? "voice" : "", hasText ? "text" : ""].filter(Boolean);
   const mediaSuffix = mediaParts.length > 0 ? ` [${mediaParts.join("+")}]` : "";
   console.log(
     `[${new Date().toLocaleTimeString()}] Discord ${label}${mediaSuffix}: "${cleanContent.slice(0, 60)}${cleanContent.length > 60 ? "..." : ""}"`,
@@ -503,6 +511,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     let imagePath: string | null = null;
     let voicePath: string | null = null;
     let voiceTranscript: string | null = null;
+    let textContent: string | null = null;
 
     if (hasImage) {
       try {
@@ -529,6 +538,18 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
         } catch (err) {
           console.error(`[Discord] Failed to transcribe voice for ${label}: ${err instanceof Error ? err.message : err}`);
         }
+      }
+    }
+
+    if (hasText) {
+      try {
+        const resp = await fetch(textAttachments[0].url);
+        if (resp.ok) {
+          const raw = await resp.text();
+          textContent = raw.length > 51200 ? raw.slice(0, 51200) + "\n...[truncated]" : raw;
+        }
+      } catch (err) {
+        console.error(`[Discord] Failed to fetch text attachment for ${label}: ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -634,6 +655,11 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       promptParts.push(
         "The user attached voice audio, but it could not be transcribed. Respond and ask them to resend a clearer clip.",
       );
+    }
+    if (textContent) {
+      promptParts.push(`Attached text file (${textAttachments[0].filename}):\n${textContent}`);
+    } else if (hasText) {
+      promptParts.push("The user attached a text file, but downloading it failed. Ask them to resend.");
     }
 
     const prefixedPrompt = promptParts.join("\n");

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -239,6 +239,8 @@ function extractReactionDirective(text: string): { cleanedText: string; reaction
 async function rejoinThreads(token: string): Promise<void> {
   const threadSessions = await listThreadSessions();
   for (const ts of threadSessions) {
+    // Skip non-snowflake keys (e.g. job names) — they are not Discord thread IDs
+    if (!/^\d{17,19}$/.test(ts.threadId)) continue;
     try {
       await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -670,7 +670,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt, threadId);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stderr || result.stdout || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stdout || result.stderr || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -711,7 +711,7 @@ export async function start(args: string[] = []) {
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt))
+          .then((prompt) => run(job.name, prompt, undefined, job.model))
           .then((r) => {
             if (job.notify === false) return;
             if (job.notify === "error" && r.exitCode === 0) return;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -32,6 +32,18 @@ const DIM = "\\x1b[2m";
 const RED = "\\x1b[31m";
 const GREEN = "\\x1b[32m";
 
+function stripAnsi(s) { return s.replace(/\\x1b\\[[0-9;]*m/g, ""); }
+function visibleLen(s) {
+  var clean = stripAnsi(s);
+  var len = 0;
+  for (var i = 0; i < clean.length; i++) {
+    var code = clean.codePointAt(i);
+    if (code > 0xffff) { i++; len += 2; }
+    else { len++; }
+  }
+  return len;
+}
+
 function fmt(ms) {
   if (ms <= 0) return GREEN + "now!" + R;
   var s = Math.floor(ms / 1000);
@@ -51,20 +63,26 @@ function alive() {
 }
 
 var B = DIM + "\\u2502" + R;
-var TL = DIM + "\\u256d" + R;
-var TR = DIM + "\\u256e" + R;
-var BL = DIM + "\\u2570" + R;
-var BR = DIM + "\\u256f" + R;
-var H = DIM + "\\u2500" + R;
-var HEADER = TL + H.repeat(6) + " \\ud83e\\udd9e ClaudeClaw \\ud83e\\udd9e " + H.repeat(6) + TR;
-var FOOTER = BL + H.repeat(30) + BR;
+var TITLE = " \\ud83e\\udd9e ClaudeClaw \\ud83e\\udd9e ";
+var PAD = 6;
+var INNER_W = PAD + visibleLen(TITLE) + PAD;
+
+function render(content) {
+  var contentW = visibleLen(content);
+  var w = Math.max(contentW, INNER_W);
+  var titlePad = w - visibleLen(TITLE);
+  var leftPad = Math.floor(titlePad / 2);
+  var rightPad = titlePad - leftPad;
+  var H = DIM + "\\u2500" + R;
+  var header = DIM + "\\u256d" + R + H.repeat(leftPad) + TITLE + H.repeat(rightPad) + DIM + "\\u256e" + R;
+  var footer = DIM + "\\u2570" + R + H.repeat(w) + DIM + "\\u256f" + R;
+  var gap = w - contentW;
+  var padded = gap > 0 ? content + " ".repeat(gap) : content;
+  process.stdout.write(header + "\\n" + B + padded + B + "\\n" + footer);
+}
 
 if (!alive()) {
-  process.stdout.write(
-    HEADER + "\\n" +
-    B + "        " + RED + "\\u25cb offline" + R + "              " + B + "\\n" +
-    FOOTER
-  );
+  render("        " + RED + "\\u25cb offline" + R);
   process.exit(0);
 }
 
@@ -89,15 +107,9 @@ try {
     info.push(GREEN + "\\ud83c\\udfae" + R);
   }
 
-  var mid = " " + info.join(" " + B + " ") + " ";
-
-  process.stdout.write(HEADER + "\\n" + B + mid + B + "\\n" + FOOTER);
+  render(" " + info.join(" " + B + " ") + " ");
 } catch {
-  process.stdout.write(
-    HEADER + "\\n" +
-    B + DIM + "         waiting...         " + R + B + "\\n" +
-    FOOTER
-  );
+  render(DIM + "         waiting...         " + R);
 }
 `;
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -711,7 +711,7 @@ export async function start(args: string[] = []) {
     for (const job of currentJobs) {
       if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
         resolvePrompt(job.prompt)
-          .then((prompt) => run(job.name, prompt, undefined, job.model))
+          .then((prompt) => run(job.name, prompt, job.name, job.model, job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined))
           .then((r) => {
             if (job.notify === false) return;
             if (job.notify === "error" && r.exitCode === 0) return;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -567,7 +567,9 @@ export async function start(args: string[] = []) {
         })
         .then((r) => {
           if (!r) return;
-          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.includes("HEARTBEAT_OK");
+          const normalized = r.stdout.trim();
+          const shouldSuppress = normalized.startsWith("HEARTBEAT_OK") || normalized.endsWith("HEARTBEAT_OK");
+          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !shouldSuppress;
           if (shouldForward) {
             forwardToTelegram("", r);
             forwardToDiscord("", r);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -567,7 +567,7 @@ export async function start(args: string[] = []) {
         })
         .then((r) => {
           if (!r) return;
-          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.trim().startsWith("HEARTBEAT_OK");
+          const shouldForward = currentSettings.heartbeat.forwardToTelegram || !r.stdout.includes("HEARTBEAT_OK");
           if (shouldForward) {
             forwardToTelegram("", r);
             forwardToDiscord("", r);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { readdir, readFile } from "fs/promises";
 import { homedir } from "os";
-import { getJobsDir } from "../config";
+import { getJobsDir, loadSettings } from "../config";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -133,6 +133,10 @@ async function showStatus(): Promise<boolean> {
 }
 
 export async function status(args: string[]) {
+  // Populate the settings cache so runtime-resolved helpers (e.g. getJobsDir())
+  // return configured values rather than compile-time defaults.
+  try { await loadSettings(); } catch {}
+
   if (args.includes("--all")) {
     await showAll();
   } else {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,13 +1,13 @@
 import { join } from "path";
 import { readdir, readFile } from "fs/promises";
 import { homedir } from "os";
+import { getJobsDir } from "../config";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
 const PID_FILE = join(HEARTBEAT_DIR, "daemon.pid");
 const STATE_FILE = join(HEARTBEAT_DIR, "state.json");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
-const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 
 function formatCountdown(ms: number): string {
   if (ms <= 0) return "now!";
@@ -100,12 +100,12 @@ async function showStatus(): Promise<boolean> {
   } catch {}
 
   try {
-    const files = await readdir(JOBS_DIR);
+    const files = await readdir(getJobsDir());
     const mdFiles = files.filter((f) => f.endsWith(".md"));
     if (mdFiles.length > 0) {
       console.log(`  Jobs: ${mdFiles.length}`);
       for (const f of mdFiles) {
-        const content = await Bun.file(join(JOBS_DIR, f)).text();
+        const content = await Bun.file(join(getJobsDir(), f)).text();
         const match = content.match(/schedule:\s*["']?([^"'\n]+)/);
         const schedule = match ? match[1].trim() : "unknown";
         console.log(`    - ${f.replace(/\.md$/, "")} [${schedule}]`);

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -419,6 +419,9 @@ function groupTriggerReason(message: TelegramMessage): string | null {
     }
   }
 
+  const { telegram } = getSettings();
+  if (telegram.listenChats?.includes(message.chat.id)) return "listen_chat";
+
   return null;
 }
 

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -952,6 +952,7 @@ async function registerBotCommands(token: string): Promise<void> {
 // --- Polling loop ---
 
 let running = true;
+let isPolling = false;
 
 async function poll(): Promise<void> {
   const config = getSettings().telegram;
@@ -1030,12 +1031,15 @@ process.on("SIGINT", () => { running = false; });
 
 /** Start polling in-process (called by start.ts when token is configured) */
 export function startPolling(debug = false): void {
+  if (isPolling) return;
+  isPolling = true;
   telegramDebug = debug;
   (async () => {
     await ensureProjectClaudeMd();
     await poll();
   })().catch((err) => {
     console.error(`[Telegram] Fatal: ${err}`);
+    isPolling = false;
   });
 }
 

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -423,10 +423,12 @@ function extractButtonsDirective(text: string): { cleanedText: string; buttonRow
 
 // Map short button IDs to labels for callback routing (in-memory, per-process)
 const buttonLabelMap = new Map<string, string>();
+let _buttonCounter = 0;
 
 function makeButtonId(label: string): string {
-  // Generate a short stable ID (max 32 bytes) to stay well under Telegram's 64-byte limit
-  const id = Buffer.from(label).toString("base64url").slice(0, 24);
+  // Use a per-button counter to guarantee uniqueness — avoids collisions when
+  // two labels share the same first ~18 bytes (base64 truncation bug).
+  const id = `b${_buttonCounter++}`;
   buttonLabelMap.set(id, label);
   return `btn:${id}`;
 }
@@ -443,22 +445,28 @@ async function sendMessageWithButtons(
   const inline_keyboard = buttonRows.map((row) =>
     row.map((label) => ({ text: label, callback_data: makeButtonId(label) }))
   );
-  try {
-    await callApi(token, "sendMessage", {
-      chat_id: chatId,
-      text: html,
-      parse_mode: "HTML",
-      reply_markup: { inline_keyboard },
-      ...(threadId ? { message_thread_id: threadId } : {}),
-    });
-  } catch {
-    // Fallback to plain text with buttons
-    await callApi(token, "sendMessage", {
-      chat_id: chatId,
-      text: normalized,
-      reply_markup: { inline_keyboard },
-      ...(threadId ? { message_thread_id: threadId } : {}),
-    });
+  const MAX_LEN = 4096;
+  // Send all chunks except the last without buttons, then attach buttons to the final chunk.
+  for (let i = 0; i < html.length; i += MAX_LEN) {
+    const isLast = i + MAX_LEN >= html.length;
+    const replyMarkup = isLast ? { inline_keyboard } : undefined;
+    try {
+      await callApi(token, "sendMessage", {
+        chat_id: chatId,
+        text: html.slice(i, i + MAX_LEN),
+        parse_mode: "HTML",
+        ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
+        ...(threadId ? { message_thread_id: threadId } : {}),
+      });
+    } catch {
+      // Fallback to plain text
+      await callApi(token, "sendMessage", {
+        chat_id: chatId,
+        text: normalized.slice(i, i + MAX_LEN),
+        ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
+        ...(threadId ? { message_thread_id: threadId } : {}),
+      });
+    }
   }
 }
 

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -421,6 +421,16 @@ function extractButtonsDirective(text: string): { cleanedText: string; buttonRow
   return { cleanedText, buttonRows };
 }
 
+// Map short button IDs to labels for callback routing (in-memory, per-process)
+const buttonLabelMap = new Map<string, string>();
+
+function makeButtonId(label: string): string {
+  // Generate a short stable ID (max 32 bytes) to stay well under Telegram's 64-byte limit
+  const id = Buffer.from(label).toString("base64url").slice(0, 24);
+  buttonLabelMap.set(id, label);
+  return `btn:${id}`;
+}
+
 async function sendMessageWithButtons(
   token: string,
   chatId: number,
@@ -431,7 +441,7 @@ async function sendMessageWithButtons(
   const normalized = normalizeTelegramText(text).replace(/\[react:[^\]\r\n]+\]/gi, "");
   const html = markdownToTelegramHtml(normalized);
   const inline_keyboard = buttonRows.map((row) =>
-    row.map((label) => ({ text: label, callback_data: `btn:${label}` }))
+    row.map((label) => ({ text: label, callback_data: makeButtonId(label) }))
   );
   try {
     await callApi(token, "sendMessage", {
@@ -936,6 +946,16 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
   const config = getSettings().telegram;
   const data = query.data ?? "";
 
+  // Enforce allowlist on callback queries (same policy as regular messages)
+  const callbackUserId = query.from.id;
+  if (config.allowedUserIds.length > 0 && !config.allowedUserIds.includes(callbackUserId)) {
+    await callApi(config.token, "answerCallbackQuery", {
+      callback_query_id: query.id,
+      text: "Unauthorized.",
+    }).catch(() => {});
+    return;
+  }
+
   // Secretary pattern: "sec_yes_<8hex>" or "sec_no_<8hex>"
   const secMatch = data.match(/^sec_(yes|no)_([0-9a-f]{8})$/);
   if (secMatch) {
@@ -965,9 +985,10 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
     return;
   }
 
-  // Generic inline button press (btn:<label> pattern from [buttons: ...] directive)
+  // Generic inline button press (btn:<id> pattern from [buttons: ...] directive)
   if (data.startsWith("btn:")) {
-    const label = data.slice(4);
+    const btnId = data.slice(4);
+    const label = buttonLabelMap.get(btnId) ?? btnId;
     // Ack immediately so Telegram stops showing the loading spinner
     await callApi(config.token, "answerCallbackQuery", {
       callback_query_id: query.id,

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -287,10 +287,14 @@ function extractTelegramCommand(text: string): string | null {
 }
 
 async function callApi<T>(token: string, method: string, body?: Record<string, unknown>): Promise<T> {
+  // Add 15s buffer on top of Telegram's own long-poll timeout (default 30s)
+  const telegramTimeout = (body?.timeout as number | undefined) ?? 0;
+  const httpTimeout = Math.max(30_000, (telegramTimeout + 15) * 1000);
   const res = await fetch(`${API_BASE}${token}/${method}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(httpTimeout),
   });
   if (!res.ok) {
     throw new Error(`Telegram API ${method}: ${res.status} ${res.statusText}`);

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -396,6 +396,62 @@ async function sendReaction(token: string, chatId: number, messageId: number, em
   });
 }
 
+// --- Inline buttons support ---
+
+/**
+ * Parse [buttons: Label A | Label B \n Label C | Label D] directives from Claude output.
+ * Each line of the directive becomes a row; pipes split buttons within a row.
+ * Returns button rows and the cleaned text with the directive removed.
+ */
+function extractButtonsDirective(text: string): { cleanedText: string; buttonRows: string[][] | null } {
+  let buttonRows: string[][] | null = null;
+  const cleanedText = text
+    .replace(/\[buttons:([^\]]+)\]/gi, (_match, raw) => {
+      const rows = String(raw)
+        .trim()
+        .split(/\r?\n/)
+        .map((row) => row.split("|").map((label) => label.trim()).filter(Boolean))
+        .filter((row) => row.length > 0);
+      if (rows.length > 0) buttonRows = rows;
+      return "";
+    })
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { cleanedText, buttonRows };
+}
+
+async function sendMessageWithButtons(
+  token: string,
+  chatId: number,
+  text: string,
+  buttonRows: string[][],
+  threadId?: number
+): Promise<void> {
+  const normalized = normalizeTelegramText(text).replace(/\[react:[^\]\r\n]+\]/gi, "");
+  const html = markdownToTelegramHtml(normalized);
+  const inline_keyboard = buttonRows.map((row) =>
+    row.map((label) => ({ text: label, callback_data: `btn:${label}` }))
+  );
+  try {
+    await callApi(token, "sendMessage", {
+      chat_id: chatId,
+      text: html,
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard },
+      ...(threadId ? { message_thread_id: threadId } : {}),
+    });
+  } catch {
+    // Fallback to plain text with buttons
+    await callApi(token, "sendMessage", {
+      chat_id: chatId,
+      text: normalized,
+      reply_markup: { inline_keyboard },
+      ...(threadId ? { message_thread_id: threadId } : {}),
+    });
+  }
+}
+
 let botUsername: string | null = null;
 let botId: number | null = null;
 
@@ -841,13 +897,16 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
-      const { cleanedText, filePaths } = extractSendFileDirectives(afterReact);
+      const { cleanedText: afterFile, filePaths } = extractSendFileDirectives(afterReact);
+      const { cleanedText, buttonRows } = extractButtonsDirective(afterFile);
       if (reactionEmoji) {
         await sendReaction(config.token, chatId, message.message_id, reactionEmoji).catch((err) => {
           console.error(`[Telegram] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
         });
       }
-      if (cleanedText) {
+      if (cleanedText && buttonRows) {
+        await sendMessageWithButtons(config.token, chatId, cleanedText, buttonRows, threadId);
+      } else if (cleanedText) {
         await sendMessage(config.token, chatId, cleanedText, threadId);
       }
       for (const fp of filePaths) {
@@ -903,6 +962,55 @@ async function handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> 
       callback_query_id: query.id,
       text: answerText,
     }).catch(() => {});
+    return;
+  }
+
+  // Generic inline button press (btn:<label> pattern from [buttons: ...] directive)
+  if (data.startsWith("btn:")) {
+    const label = data.slice(4);
+    // Ack immediately so Telegram stops showing the loading spinner
+    await callApi(config.token, "answerCallbackQuery", {
+      callback_query_id: query.id,
+      text: label,
+    }).catch(() => {});
+
+    // Edit original message to mark the selected button visually
+    if (query.message) {
+      const originalText = query.message.text ?? "";
+      await callApi(config.token, "editMessageText", {
+        chat_id: query.message.chat.id,
+        message_id: query.message.message_id,
+        text: `${originalText}\n\n› ${label}`,
+      }).catch(() => {});
+    }
+
+    // Inject button press as a new user message to the running Claude session
+    const chatId = query.message?.chat.id ?? query.from.id;
+    const threadId = query.message?.message_thread_id;
+    try {
+      const result = await runUserMessage("telegram", `[Button pressed: ${label}]`);
+      if (result.exitCode === 0 && result.stdout) {
+        const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout);
+        const { cleanedText: afterFile, filePaths } = extractSendFileDirectives(afterReact);
+        const { cleanedText, buttonRows } = extractButtonsDirective(afterFile);
+        if (reactionEmoji && query.message) {
+          await sendReaction(config.token, chatId, query.message.message_id, reactionEmoji).catch(() => {});
+        }
+        if (cleanedText && buttonRows) {
+          await sendMessageWithButtons(config.token, chatId, cleanedText, buttonRows, threadId);
+        } else if (cleanedText) {
+          await sendMessage(config.token, chatId, cleanedText, threadId);
+        }
+        for (const fp of filePaths) {
+          await sendDocumentToChat(config.token, chatId, fp, threadId).catch(() => {});
+        }
+      } else if (result.exitCode !== 0) {
+        await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(`[Telegram] Button callback error: ${errMsg}`);
+    }
     return;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [] },
+  telegram: { token: "", allowedUserIds: [], listenChats: [] },
   discord: { token: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
@@ -87,6 +87,7 @@ export interface HeartbeatConfig {
 export interface TelegramConfig {
   token: string;
   allowedUserIds: number[];
+  listenChats: number[];
 }
 
 export interface DiscordConfig {
@@ -257,6 +258,7 @@ function parseSettings(
     telegram: {
       token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
+      listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,9 @@ const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 const DEFAULT_JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
 
+/** Default Claude session timeout (30 minutes). Exported so runner.ts can reference the same value. */
+export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
 export function getJobsDir(): string {
   if (cached?.jobsDir) {
     return isAbsolute(cached.jobsDir) ? cached.jobsDir : join(process.cwd(), cached.jobsDir);
@@ -68,7 +71,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
-  sessionTimeoutMs: 30 * 60 * 1000,
+  sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
 };
 
 export interface HeartbeatExcludeWindow {
@@ -293,7 +296,7 @@ function parseSettings(
     },
     sessionTimeoutMs: typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
       ? raw.sessionTimeoutMs
-      : 30 * 60 * 1000,
+      : DEFAULT_SESSION_TIMEOUT_MS,
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,15 @@ import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone"
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
-const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
+const DEFAULT_JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
+
+export function getJobsDir(): string {
+  if (cached?.jobsDir) {
+    return isAbsolute(cached.jobsDir) ? cached.jobsDir : join(process.cwd(), cached.jobsDir);
+  }
+  return DEFAULT_JOBS_DIR;
+}
 
 const DEFAULT_SETTINGS: Settings = {
   model: "",
@@ -113,6 +120,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  jobsDir?: string;
 }
 
 export interface AgenticMode {
@@ -152,7 +160,7 @@ let cached: Settings | null = null;
 
 export async function initConfig(): Promise<void> {
   await mkdir(HEARTBEAT_DIR, { recursive: true });
-  await mkdir(JOBS_DIR, { recursive: true });
+  await mkdir(getJobsDir(), { recursive: true });
   await mkdir(LOGS_DIR, { recursive: true });
 
   if (!existsSync(SETTINGS_FILE)) {
@@ -217,7 +225,10 @@ function parseAgenticConfig(raw: any): AgenticConfig {
   };
 }
 
-function parseSettings(raw: Record<string, any>): Settings {
+function parseSettings(
+  raw: Record<string, any>,
+  discordUserIds?: string[],
+): Settings {
   const rawLevel = raw.security?.level;
   const level: SecurityLevel =
     typeof rawLevel === "string" && VALID_LEVELS.has(rawLevel as SecurityLevel)
@@ -244,12 +255,14 @@ function parseSettings(raw: Record<string, any>): Settings {
       forwardToTelegram: raw.heartbeat?.forwardToTelegram ?? false,
     },
     telegram: {
-      token: raw.telegram?.token ?? "",
+      token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
     },
     discord: {
-      token: typeof raw.discord?.token === "string" ? raw.discord.token.trim() : "",
-      allowedUserIds: Array.isArray(raw.discord?.allowedUserIds)
+      token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
+      allowedUserIds: Array.isArray(discordUserIds)
+        ? discordUserIds
+        : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)
@@ -274,6 +287,7 @@ function parseSettings(raw: Record<string, any>): Settings {
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,7 +260,7 @@ function parseSettings(
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
-      allowedUserIds: Array.isArray(discordUserIds)
+      allowedUserIds: Array.isArray(discordUserIds) && discordUserIds.length > 0
         ? discordUserIds
         : Array.isArray(raw.discord?.allowedUserIds)
           ? raw.discord.allowedUserIds.map(String)

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ const DEFAULT_SETTINGS: Settings = {
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
+  sessionTimeoutMs: 30 * 60 * 1000,
 };
 
 export interface HeartbeatExcludeWindow {
@@ -121,6 +122,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  sessionTimeoutMs: number;
   jobsDir?: string;
 }
 
@@ -289,6 +291,9 @@ function parseSettings(
       baseUrl: typeof raw.stt?.baseUrl === "string" ? raw.stt.baseUrl.trim() : "",
       model: typeof raw.stt?.model === "string" ? raw.stt.model.trim() : "",
     },
+    sessionTimeoutMs: typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
+      ? raw.sessionTimeoutMs
+      : 30 * 60 * 1000,
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -8,6 +8,8 @@ export interface Job {
   prompt: string;
   recurring: boolean;
   notify: true | false | "error";
+  /** When set, overrides the global model for this job. Useful for routing cheap tasks to haiku. */
+  model?: string;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -50,7 +52,10 @@ function parseJobFile(name: string, content: string): Job | null {
     : notifyRaw === "error" ? "error"
     : true;
 
-  return { name, schedule, prompt, recurring, notify };
+  const modelLine = lines.find((l) => l.startsWith("model:"));
+  const model = modelLine ? parseFrontmatterValue(modelLine.replace("model:", "")) || undefined : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model };
 }
 
 export async function loadJobs(): Promise<Job[]> {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -10,6 +10,8 @@ export interface Job {
   notify: true | false | "error";
   /** When set, overrides the global model for this job. Useful for routing cheap tasks to haiku. */
   model?: string;
+  /** When set, overrides the global session timeout for this job (in seconds). */
+  timeoutSeconds?: number;
 }
 
 function parseFrontmatterValue(raw: string): string {
@@ -55,7 +57,11 @@ function parseJobFile(name: string, content: string): Job | null {
   const modelLine = lines.find((l) => l.startsWith("model:"));
   const model = modelLine ? parseFrontmatterValue(modelLine.replace("model:", "")) || undefined : undefined;
 
-  return { name, schedule, prompt, recurring, notify, model };
+  const timeoutLine = lines.find((l) => l.startsWith("timeout:"));
+  const timeoutRaw = timeoutLine ? parseFrontmatterValue(timeoutLine.replace("timeout:", "")) : "";
+  const timeoutSeconds = timeoutRaw ? parseInt(timeoutRaw, 10) || undefined : undefined;
+
+  return { name, schedule, prompt, recurring, notify, model, timeoutSeconds };
 }
 
 export async function loadJobs(): Promise<Job[]> {

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,7 +1,6 @@
 import { readdir } from "fs/promises";
 import { join } from "path";
-
-const JOBS_DIR = join(process.cwd(), ".claude", "claudeclaw", "jobs");
+import { getJobsDir } from "./config";
 
 export interface Job {
   name: string;
@@ -58,14 +57,14 @@ export async function loadJobs(): Promise<Job[]> {
   const jobs: Job[] = [];
   let files: string[];
   try {
-    files = await readdir(JOBS_DIR);
+    files = await readdir(getJobsDir());
   } catch {
     return jobs;
   }
 
   for (const file of files) {
     if (!file.endsWith(".md")) continue;
-    const content = await Bun.file(join(JOBS_DIR, file)).text();
+    const content = await Bun.file(join(getJobsDir(), file)).text();
     const job = parseJobFile(file.replace(/\.md$/, ""), content);
     if (job) jobs.push(job);
   }
@@ -73,7 +72,7 @@ export async function loadJobs(): Promise<Job[]> {
 }
 
 export async function clearJobSchedule(jobName: string): Promise<void> {
-  const path = join(JOBS_DIR, `${jobName}.md`);
+  const path = join(getJobsDir(), `${jobName}.md`);
   const content = await Bun.file(path).text();
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
   if (!match) return;

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -59,7 +59,8 @@ function parseJobFile(name: string, content: string): Job | null {
 
   const timeoutLine = lines.find((l) => l.startsWith("timeout:"));
   const timeoutRaw = timeoutLine ? parseFrontmatterValue(timeoutLine.replace("timeout:", "")) : "";
-  const timeoutSeconds = timeoutRaw ? parseInt(timeoutRaw, 10) || undefined : undefined;
+  const timeoutParsed = timeoutRaw ? parseInt(timeoutRaw, 10) : NaN;
+  const timeoutSeconds = Number.isFinite(timeoutParsed) && timeoutParsed > 0 ? timeoutParsed : undefined;
 
   return { name, schedule, prompt, recurring, notify, model, timeoutSeconds };
 }

--- a/src/pid.ts
+++ b/src/pid.ts
@@ -21,7 +21,7 @@ export async function checkExistingDaemon(): Promise<number | null> {
   }
 
   const pid = Number(raw);
-  if (!pid || isNaN(pid)) {
+  if (!pid || isNaN(pid) || pid <= 0) {
     await cleanupPidFile();
     return null;
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -378,7 +378,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string): Promise<RunResult> {
+async function execClaude(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
   const existing = threadId
@@ -396,7 +396,10 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   let taskType = "unknown";
   let routingReasoning = "";
 
-  if (agentic.enabled) {
+  if (modelOverride) {
+    primaryConfig = { model: modelOverride, api };
+    console.log(`[${new Date().toLocaleTimeString()}] Job model override: ${modelOverride}`);
+  } else if (agentic.enabled) {
     const routing = selectModel(prompt, agentic.modes, agentic.defaultMode);
     primaryConfig = { model: routing.model, api };
     taskType = routing.taskType;
@@ -574,8 +577,8 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId), threadId);
+export async function run(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt, threadId, modelOverride), threadId);
 }
 
 async function streamClaude(

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -54,13 +54,17 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * resolves credentials using its own per-platform code path.
  */
 function cleanSpawnEnv(): Record<string, string> {
-  const {
-    CLAUDECODE: _cc,
-    CLAUDE_CODE_OAUTH_TOKEN: _tok,
-    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: _mgr,
-    ...rest
-  } = process.env;
-  return rest as Record<string, string>;
+  const stripped = new Set([
+    "CLAUDECODE",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+  ]);
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (stripped.has(key)) continue;
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
 }
 
 export type CompactEvent =

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,12 +1,13 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
+import { getSession, createSession, incrementTurn, markCompactWarned, backupSession } from "./sessions";
 import {
   getThreadSession,
   createThreadSession,
   incrementThreadTurn,
   markThreadCompactWarned,
+  removeThreadSession,
 } from "./sessionManager";
 import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
@@ -94,6 +95,37 @@ export interface RunResult {
 }
 
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
+
+// Claude Code prints this when --resume references a session it no longer
+// has on disk (cleared, expired, compacted away, or moved to another machine).
+// When we see it, the cached session ID is dead and the only recovery is to
+// drop --resume and start fresh.
+const STALE_SESSION_PATTERN = /No conversation found with session ID/i;
+
+function isStaleSessionError(stdout: string, stderr: string): boolean {
+  return STALE_SESSION_PATTERN.test(stderr) || STALE_SESSION_PATTERN.test(stdout);
+}
+
+/** Strip --resume <id> from a claude argv list so it runs as a brand-new session. */
+function stripResume(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--resume") {
+      i += 1; // skip the session id that follows
+      continue;
+    }
+    out.push(args[i]!);
+  }
+  return out;
+}
+
+/** Replace the value following --output-format (mutates a copy and returns it). */
+function withOutputFormat(args: string[], format: string): string[] {
+  const out = [...args];
+  const idx = out.indexOf("--output-format");
+  if (idx >= 0 && idx + 1 < out.length) out[idx + 1] = format;
+  return out;
+}
 
 // Serial queue — prevents concurrent --resume on the same session
 // Global queue for non-thread messages (backward compatible)
@@ -505,19 +537,62 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
     usedFallback = true;
   }
 
-  const rawStdout = exec.rawStdout;
-  const stderr = exec.stderr;
-  const exitCode = exec.exitCode;
+  let rawStdout = exec.rawStdout;
+  let stderr = exec.stderr;
+  let exitCode = exec.exitCode;
   let stdout = rawStdout;
   let sessionId = existing?.sessionId ?? "unknown";
+  let recoveredFromStale = false;
   const rateLimitMessage = extractRateLimitMessage(rawStdout, stderr);
 
   if (rateLimitMessage) {
     stdout = rateLimitMessage;
   }
 
-  // For new sessions, parse the JSON to extract session_id and result text
-  if (!rateLimitMessage && isNew && exitCode === 0) {
+  // --- Stale session recovery ---
+  // Claude Code returns "No conversation found with session ID: <id>" when
+  // --resume points at a session it no longer has (cleared, expired, etc.).
+  // The cached ID is dead; back it up, drop --resume, and retry as a new
+  // session so the user isn't permanently stuck.
+  if (
+    !rateLimitMessage &&
+    !isNew &&
+    exitCode !== 0 &&
+    existing &&
+    isStaleSessionError(rawStdout, stderr)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name}; recovering with a new session...`
+    );
+
+    if (threadId) {
+      await removeThreadSession(threadId);
+    } else {
+      await backupSession();
+    }
+
+    const retryArgs = withOutputFormat(stripResume(args), "json");
+    const retryConfig = usedFallback ? fallbackConfig : primaryConfig;
+    const retryExec = await runClaudeOnce(
+      retryArgs,
+      retryConfig.model,
+      retryConfig.api,
+      baseEnv,
+      timeoutMs
+    );
+
+    rawStdout = retryExec.rawStdout;
+    stderr = retryExec.stderr;
+    exitCode = retryExec.exitCode;
+    stdout = rawStdout;
+    recoveredFromStale = true;
+  }
+
+  // For new sessions, parse the JSON to extract session_id and result text.
+  // After a stale-session recovery, the retry was forced to JSON output too,
+  // so reuse the same parsing branch by treating it as a "new" session.
+  const parseAsNew = (isNew || recoveredFromStale);
+  if (!rateLimitMessage && parseAsNew && exitCode === 0) {
     try {
       const json = JSON.parse(rawStdout);
       sessionId = json.session_id;
@@ -559,7 +634,9 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
 
   // --- Auto-compact on timeout (exit 124) ---
-  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {
+  // Skip after a stale-session recovery: `existing` references the dead
+  // session ID, so /compact would fail the same way --resume just did.
+  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing && !recoveredFromStale) {
     emitCompactEvent({ type: "auto-compact-start" });
     const compactOk = await runCompact(
       existing.sessionId,
@@ -596,7 +673,9 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
   }
 
   // --- Turn tracking & compact warning ---
-  if (exitCode === 0 && !isNew) {
+  // Recovered sessions were just created (turnCount = 0); the next call will
+  // resume normally and start counting from there.
+  if (exitCode === 0 && !isNew && !recoveredFromStale) {
     const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn();
     console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${threadId ? ` (thread ${threadId.slice(0, 8)})` : ""}`);
 
@@ -670,6 +749,9 @@ async function streamClaude(
   let buf = "";
   let unblocked = false;
   let textEmitted = false;
+  // Drain stderr concurrently so we can detect stale-session errors and
+  // avoid backpressure if Claude prints a lot to stderr (verbose/--debug).
+  const stderrPromise = new Response(proc.stderr).text();
 
   const maybeUnblock = () => {
     if (!unblocked) {
@@ -732,6 +814,28 @@ async function streamClaude(
   }
 
   await proc.exited;
+  const stderrText = await stderrPromise;
+
+  // --- Stale session recovery (stream path) ---
+  // Same situation as execClaude: --resume hit a session Claude no longer
+  // has. Back up the dead ID and re-stream as a brand-new session so the
+  // user gets a real reply instead of a silent error.
+  if (
+    existing &&
+    !textEmitted &&
+    (proc.exitCode ?? 0) !== 0 &&
+    isStaleSessionError("", stderrText)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name} (stream); recovering with a new session...`
+    );
+    await backupSession();
+    // Recurse without pre-firing onUnblock: the recursive call manages its
+    // own unblock so the UI keeps showing "typing" until the real reply lands.
+    await streamClaude(name, prompt, onChunk, onUnblock);
+    return;
+  }
+
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -362,7 +362,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
   const settings = getSettings();
   const securityArgs = buildSecurityArgs(settings.security);
   const baseEnv = cleanSpawnEnv();
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = settings.sessionTimeoutMs;
 
   const ok = await runCompact(
     existing.sessionId,
@@ -416,7 +416,7 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = timeoutMsOverride ?? (settings as any).sessionTimeoutMs ?? CLAUDE_TIMEOUT_MS;
+  const timeoutMs = timeoutMsOverride ?? settings.sessionTimeoutMs;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -97,6 +97,8 @@ const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
 // Global queue for non-thread messages (backward compatible)
+// Reset to a fresh resolved promise after each task to avoid holding
+// references to every previous result (memory leak).
 let globalQueue: Promise<unknown> = Promise.resolve();
 // Per-thread queues — each thread runs independently in parallel
 const threadQueues = new Map<string, Promise<unknown>>();
@@ -105,11 +107,11 @@ function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
   if (threadId) {
     const current = threadQueues.get(threadId) ?? Promise.resolve();
     const task = current.then(fn, fn);
-    threadQueues.set(threadId, task.catch(() => {}));
+    threadQueues.set(threadId, task.then(() => {}, () => {}));
     return task;
   }
   const task = globalQueue.then(fn, fn);
-  globalQueue = task.catch(() => {});
+  globalQueue = task.then(() => {}, () => {});
   return task;
 }
 
@@ -152,6 +154,39 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
   return childEnv;
 }
 
+// Cap stdout/stderr to prevent unbounded memory growth.
+// 10 MB is far beyond any real Claude response; protects against runaway streams only.
+const MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+async function collectStream(stream: ReadableStream<Uint8Array>, maxBytes: number): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (totalBytes + value.byteLength > maxBytes) {
+        const remaining = maxBytes - totalBytes;
+        if (remaining > 0) chunks.push(value.subarray(0, remaining));
+        totalBytes = maxBytes;
+        break;
+      }
+      chunks.push(value);
+      totalBytes += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
 async function runClaudeOnce(
   baseArgs: string[],
   model: string,
@@ -169,18 +204,21 @@ async function runClaudeOnce(
     env: buildChildEnv(baseEnv, model, api),
   });
 
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+    timeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
   });
 
   try {
     const [rawStdout, stderr] = await Promise.race([
       Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+        collectStream(proc.stdout as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
+        collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
       ]),
       timeoutPromise,
     ]) as [string, string];
+
+    if (timeoutId) clearTimeout(timeoutId);
     await proc.exited;
 
     return {
@@ -189,6 +227,7 @@ async function runClaudeOnce(
       exitCode: proc.exitCode ?? 1,
     };
   } catch (err) {
+    if (timeoutId) clearTimeout(timeoutId);
     // Kill the hung process
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,7 +8,7 @@ import {
   incrementThreadTurn,
   markThreadCompactWarned,
 } from "./sessionManager";
-import { getSettings, type ModelConfig, type SecurityConfig } from "./config";
+import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
 
@@ -152,15 +152,12 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
   return childEnv;
 }
 
-/** Default timeout for a single Claude Code invocation (5 minutes). */
-const CLAUDE_TIMEOUT_MS = 5 * 60 * 1000;
-
 async function runClaudeOnce(
   baseArgs: string[],
   model: string,
   api: string,
   baseEnv: Record<string, string>,
-  timeoutMs: number = CLAUDE_TIMEOUT_MS
+  timeoutMs: number = DEFAULT_SESSION_TIMEOUT_MS
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -31,6 +31,38 @@ const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
 const COMPACT_WARN_THRESHOLD = 25;
 const COMPACT_TIMEOUT_ENABLED = true;
 
+/**
+ * Build a sanitized env for spawning the `claude` CLI as a long-running daemon
+ * subprocess. Drops env vars injected by a parent Claude Code / Claude Desktop
+ * session that break detached child auth:
+ *
+ * - `CLAUDECODE`: marks "we're nested inside Claude Code" — confuses the CLI's
+ *   reentry detection and triggers transcript-aware behaviour we don't want.
+ * - `CLAUDE_CODE_OAUTH_TOKEN`: the parent's frozen OAuth access token. Without
+ *   the matching refresh token (which lives in the platform-native credential
+ *   store, not the env), it expires after ~8h and the daemon's spawned `claude`
+ *   processes start returning HTTP 401 silently. Stripping it lets the CLI
+ *   fall back to the credential store on each platform — Keychain on macOS,
+ *   `~/.claude/.credentials.json` on Linux/WSL2, Credential Manager on Windows
+ *   — which handles refresh automatically.
+ * - `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`: tells the CLI "the host process
+ *   manages provider auth — don't read local credentials." In a detached
+ *   daemon there is no host to consult; the CLI errors with `Not logged in`.
+ *
+ * Cross-platform note: the helper just deletes keys from the inherited env
+ * object — no shell, no OS-specific calls. The `claude` CLI it spawns then
+ * resolves credentials using its own per-platform code path.
+ */
+function cleanSpawnEnv(): Record<string, string> {
+  const {
+    CLAUDECODE: _cc,
+    CLAUDE_CODE_OAUTH_TOKEN: _tok,
+    CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: _mgr,
+    ...rest
+  } = process.env;
+  return rest as Record<string, string>;
+}
+
 export type CompactEvent =
   | { type: "warn"; turnCount: number }
   | { type: "auto-compact-start" }
@@ -325,8 +357,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
 
   const settings = getSettings();
   const securityArgs = buildSecurityArgs(settings.security);
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const baseEnv = cleanSpawnEnv();
   const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
 
   const ok = await runCompact(
@@ -417,9 +448,7 @@ async function execClaude(name: string, prompt: string, threadId?: string): Prom
     args.push("--append-system-prompt", appendParts.join("\n\n"));
   }
 
-  // Strip CLAUDECODE env var so child claude processes don't think they're nested
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const baseEnv = { ...cleanEnv } as Record<string, string>;
+  const baseEnv = cleanSpawnEnv();
 
   let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
@@ -583,8 +612,7 @@ async function streamClaude(
   const normalizedModel = model.trim().toLowerCase();
   if (model.trim() && normalizedModel !== "glm") args.push("--model", model.trim());
 
-  const { CLAUDECODE: _, ...cleanEnv } = process.env;
-  const childEnv = buildChildEnv(cleanEnv as Record<string, string>, model, api);
+  const childEnv = buildChildEnv(cleanSpawnEnv(), model, api);
 
   console.log(`[${new Date().toLocaleTimeString()}] Running: ${name} (stream-json, session: ${existing?.sessionId?.slice(0, 8) ?? "new"})`);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -378,7 +378,7 @@ export async function compactCurrentSession(): Promise<{ success: boolean; messa
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
-async function execClaude(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
+async function execClaude(name: string, prompt: string, threadId?: string, modelOverride?: string, timeoutMsOverride?: number): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
   const existing = threadId
@@ -416,7 +416,7 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
     api: fallback?.api ?? "",
   };
   const securityArgs = buildSecurityArgs(security);
-  const timeoutMs = (settings as any).sessionTimeoutMs || CLAUDE_TIMEOUT_MS;
+  const timeoutMs = timeoutMsOverride ?? (settings as any).sessionTimeoutMs ?? CLAUDE_TIMEOUT_MS;
 
   console.log(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
@@ -577,8 +577,8 @@ async function execClaude(name: string, prompt: string, threadId?: string, model
   return result;
 }
 
-export async function run(name: string, prompt: string, threadId?: string, modelOverride?: string): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId, modelOverride), threadId);
+export async function run(name: string, prompt: string, threadId?: string, modelOverride?: string, timeoutMs?: number): Promise<RunResult> {
+  return enqueue(() => execClaude(name, prompt, threadId, modelOverride, timeoutMs), threadId);
 }
 
 async function streamClaude(

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -55,13 +55,8 @@ export async function getThreadSession(
   };
 }
 
-function isSnowflake(id: string): boolean {
-  return /^\d{17,19}$/.test(id);
-}
-
 /** Create a new thread session after Claude outputs a session_id. */
 export async function createThreadSession(threadId: string, sessionId: string): Promise<void> {
-  if (!isSnowflake(threadId)) return; // skip job-named sessions (e.g. "podcast-curator")
   const data = await loadSessions();
   data.threads[threadId] = {
     sessionId,

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -55,8 +55,13 @@ export async function getThreadSession(
   };
 }
 
+function isSnowflake(id: string): boolean {
+  return /^\d{17,19}$/.test(id);
+}
+
 /** Create a new thread session after Claude outputs a session_id. */
 export async function createThreadSession(threadId: string, sessionId: string): Promise<void> {
+  if (!isSnowflake(threadId)) return; // skip job-named sessions (e.g. "podcast-curator")
   const data = await loadSessions();
   data.threads[threadId] = {
     sessionId,

--- a/src/ui/constants.ts
+++ b/src/ui/constants.ts
@@ -2,7 +2,6 @@ import { join } from "path";
 
 export const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 export const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
-export const JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 export const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 export const SESSION_FILE = join(HEARTBEAT_DIR, "session.json");
 export const STATE_FILE = join(HEARTBEAT_DIR, "state.json");

--- a/src/ui/services/jobs.ts
+++ b/src/ui/services/jobs.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "fs/promises";
 import { join } from "path";
-import { JOBS_DIR } from "../constants";
+import { getJobsDir } from "../../config";
 
 export interface QuickJobInput {
   time?: unknown;
@@ -35,10 +35,10 @@ export async function createQuickJob(input: QuickJobInput): Promise<{ name: stri
   const schedule = `${minute} ${hour} * * *`;
   const stamp = new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
   const name = `quick-${stamp}-${hour.toString().padStart(2, "0")}${minute.toString().padStart(2, "0")}`;
-  const path = join(JOBS_DIR, `${name}.md`);
+  const path = join(getJobsDir(), `${name}.md`);
   const content = `---\nschedule: "${schedule}"\nrecurring: ${recurring ? "true" : "false"}\n---\n${prompt}\n`;
 
-  await mkdir(JOBS_DIR, { recursive: true });
+  await mkdir(getJobsDir(), { recursive: true });
   await writeFile(path, content, "utf-8");
   return { name, schedule, recurring };
 }
@@ -48,6 +48,6 @@ export async function deleteJob(name: string): Promise<void> {
   if (!/^[a-zA-Z0-9._-]+$/.test(jobName)) {
     throw new Error("Invalid job name.");
   }
-  const path = join(JOBS_DIR, `${jobName}.md`);
+  const path = join(getJobsDir(), `${jobName}.md`);
   await Bun.file(path).delete();
 }


### PR DESCRIPTION
## Summary

Adds inline keyboard button support for Telegram. Claude can embed a `[buttons: ...]` directive in its output to send actionable messages with inline buttons.

```
[buttons: ✅ Approve | ❌ Reject | ⏸ Later]
```

Multi-row buttons use newlines within the directive:

```
[buttons: ✅ Yes | ❌ No
⏸ Snooze | 🔄 Retry]
```

When a user taps a button:
- Telegram's spinner is acknowledged immediately
- The original message is edited to show `› <selected label>`
- A `[Button pressed: <label>]` message is injected into the Claude session

## Changes from v1 (#133)

Addresses all feedback from @TerrysPOV:

1. **Allowlist enforcement on callbacks** — `handleCallbackQuery` now applies the same `allowedUserIds` check as regular message handling. Unauthorized users get a silent rejection.
2. **Stable button IDs** — `callback_data` now uses a base64url-encoded short ID (≤28 bytes including prefix) instead of the raw label, staying well under Telegram's 64-byte limit. A process-local map resolves IDs back to display labels.
3. **Rebased onto current master** — clean on top of `b1a62d4`, resolves the `config.ts` conflict from #129.
4. **Watchdog removed** — watchdog feature is not included here; it belongs in Terry's #134.

## Excluded from this PR

- Watchdog / runaway session guard → covered by #134

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>