### PR TITLE
feat(plugin): expose Claude Code plugin marketplace via /plugin wizard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/__tests__/plugin-cli.test.ts
+++ b/src/__tests__/plugin-cli.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { buildArgs, type PluginAction } from "../commands/plugin-cli";
+
+describe("buildArgs", () => {
+  it("marketplace-add", () => {
+    const action: PluginAction = { kind: "marketplace-add", source: "https://github.com/example/plugins" };
+    expect(buildArgs(action)).toEqual(["claude", "plugin", "marketplace", "add", "https://github.com/example/plugins"]);
+  });
+
+  it("marketplace-list", () => {
+    expect(buildArgs({ kind: "marketplace-list" })).toEqual(["claude", "plugin", "marketplace", "list"]);
+  });
+
+  it("marketplace-update with name", () => {
+    expect(buildArgs({ kind: "marketplace-update", name: "my-marketplace" })).toEqual([
+      "claude", "plugin", "marketplace", "update", "my-marketplace",
+    ]);
+  });
+
+  it("marketplace-update without name (update all)", () => {
+    expect(buildArgs({ kind: "marketplace-update" })).toEqual(["claude", "plugin", "marketplace", "update"]);
+  });
+
+  it("marketplace-remove", () => {
+    expect(buildArgs({ kind: "marketplace-remove", name: "old-marketplace" })).toEqual([
+      "claude", "plugin", "marketplace", "remove", "old-marketplace",
+    ]);
+  });
+
+  it("install user scope", () => {
+    expect(buildArgs({ kind: "install", plugin: "my-plugin", scope: "user" })).toEqual([
+      "claude", "plugin", "install", "my-plugin", "-s", "user",
+    ]);
+  });
+
+  it("install project scope", () => {
+    expect(buildArgs({ kind: "install", plugin: "my-plugin@my-marketplace", scope: "project" })).toEqual([
+      "claude", "plugin", "install", "my-plugin@my-marketplace", "-s", "project",
+    ]);
+  });
+
+  it("list", () => {
+    expect(buildArgs({ kind: "list" })).toEqual(["claude", "plugin", "list"]);
+  });
+
+  it("uninstall", () => {
+    expect(buildArgs({ kind: "uninstall", plugin: "my-plugin" })).toEqual(["claude", "plugin", "uninstall", "my-plugin"]);
+  });
+
+  it("enable", () => {
+    expect(buildArgs({ kind: "enable", plugin: "my-plugin" })).toEqual(["claude", "plugin", "enable", "my-plugin"]);
+  });
+
+  it("disable", () => {
+    expect(buildArgs({ kind: "disable", plugin: "my-plugin" })).toEqual(["claude", "plugin", "disable", "my-plugin"]);
+  });
+});

--- a/src/__tests__/plugin-wizard.test.ts
+++ b/src/__tests__/plugin-wizard.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  isWizardTrigger,
+  hasActiveWizard,
+  handleWizardInput,
+  cancelWizard,
+  type WizardContext,
+} from "../commands/plugin-wizard";
+
+// Wizard tests use real state machine but rely on the fact that
+// runPluginCli is never reached in unit tests (all paths that would call
+// it require valid CLI responses). We only test state transitions and
+// input classification here.
+
+const ctx: WizardContext = { iface: "web", scopeId: "test-unit" };
+
+beforeEach(() => {
+  cancelWizard(ctx);
+});
+
+// --- isWizardTrigger ---
+
+describe("isWizardTrigger", () => {
+  it("recognises /plugin", () => { expect(isWizardTrigger("/plugin")).toBe(true); });
+  it("recognises /claudeclaw:plugin", () => { expect(isWizardTrigger("/claudeclaw:plugin")).toBe(true); });
+  it("ignores case differences", () => { expect(isWizardTrigger("/PLUGIN")).toBe(true); });
+  it("rejects non-plugin commands", () => { expect(isWizardTrigger("/reset")).toBe(false); });
+  it("rejects plain text", () => { expect(isWizardTrigger("hello world")).toBe(false); });
+  it("accepts /plugin with trailing args", () => { expect(isWizardTrigger("/plugin some args")).toBe(true); });
+});
+
+// --- hasActiveWizard / lifecycle ---
+
+describe("hasActiveWizard", () => {
+  it("returns false before any interaction", () => {
+    expect(hasActiveWizard(ctx)).toBe(false);
+  });
+
+  it("returns true after opening the wizard", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    expect(hasActiveWizard(ctx)).toBe(true);
+  });
+
+  it("returns false after cancel", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    await handleWizardInput(ctx, "cancel");
+    expect(hasActiveWizard(ctx)).toBe(false);
+  });
+});
+
+// --- cancelWizard ---
+
+describe("cancelWizard", () => {
+  it("clears an active session", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    cancelWizard(ctx);
+    expect(hasActiveWizard(ctx)).toBe(false);
+  });
+
+  it("is safe to call when no session exists", () => {
+    expect(() => cancelWizard(ctx)).not.toThrow();
+  });
+});
+
+// --- wizard flow: menu ---
+
+describe("wizard menu", () => {
+  it("returns the action menu on /plugin", async () => {
+    const reply = await handleWizardInput(ctx, "/plugin");
+    expect(reply).toContain("Add marketplace");
+    expect(reply).toContain("Install plugin");
+  });
+
+  it("shows menu on unrecognised option", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    const reply = await handleWizardInput(ctx, "99");
+    expect(reply).toContain("Add marketplace");
+  });
+});
+
+// --- wizard flow: marketplace source prompt ---
+
+describe("marketplace-source step", () => {
+  it("asks for source URL after choosing option 1", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    const reply = await handleWizardInput(ctx, "1");
+    expect(reply).toMatch(/url|path|repo/i);
+  });
+
+  it("can be cancelled mid-flow", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    await handleWizardInput(ctx, "1");
+    const reply = await handleWizardInput(ctx, "cancel");
+    expect(reply).toContain("cancelled");
+    expect(hasActiveWizard(ctx)).toBe(false);
+  });
+});
+
+// --- wizard flow: install scope prompt ---
+
+describe("install-scope step", () => {
+  it("asks for scope after providing plugin name", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    await handleWizardInput(ctx, "4");
+    const reply = await handleWizardInput(ctx, "my-plugin");
+    expect(reply).toContain("user");
+    expect(reply).toContain("project");
+  });
+
+  it("rejects invalid scope choice and re-prompts", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    await handleWizardInput(ctx, "4");
+    await handleWizardInput(ctx, "my-plugin");
+    const reply = await handleWizardInput(ctx, "3");
+    expect(reply).toMatch(/1.*user|2.*project/i);
+  });
+});
+
+// --- install-confirm: no manifest path (readPluginManifest returns null) ---
+
+describe("install-confirm step", () => {
+  it("shows confirmation prompt with plugin name", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    await handleWizardInput(ctx, "4");
+    await handleWizardInput(ctx, "test-plugin");
+    const reply = await handleWizardInput(ctx, "1"); // scope: user
+    expect(reply).toContain("test-plugin");
+    expect(reply).toMatch(/yes/i);
+  });
+
+  it("rejects non-yes reply and re-prompts", async () => {
+    await handleWizardInput(ctx, "/plugin");
+    await handleWizardInput(ctx, "4");
+    await handleWizardInput(ctx, "test-plugin");
+    await handleWizardInput(ctx, "1");
+    const reply = await handleWizardInput(ctx, "nope");
+    expect(reply).toMatch(/yes.*install|cancel/i);
+  });
+});
+
+// --- independent contexts don't interfere ---
+
+describe("context isolation", () => {
+  it("sessions from different contexts are independent", async () => {
+    const ctx2: WizardContext = { iface: "discord", scopeId: "channel-abc" };
+    cancelWizard(ctx2);
+
+    await handleWizardInput(ctx, "/plugin");
+    expect(hasActiveWizard(ctx)).toBe(true);
+    expect(hasActiveWizard(ctx2)).toBe(false);
+  });
+});

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -9,6 +9,7 @@ import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
+import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 
 // --- Discord API constants ---
 
@@ -622,6 +623,15 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
 
     // Skill routing: detect slash commands and resolve to SKILL.md prompts
     const command = cleanContent.startsWith("/") ? cleanContent.trim().split(/\s+/, 1)[0].toLowerCase() : null;
+
+    // Plugin wizard: intercept /plugin and /claudeclaw:plugin before Claude routing
+    const wizardCtx = { iface: "discord" as const, scopeId: channelId };
+    if ((command && isWizardTrigger(command)) || hasActiveWizard(wizardCtx)) {
+      const reply = await handleWizardInput(wizardCtx, cleanContent.trim());
+      await sendMessage(config.token, channelId, reply);
+      return;
+    }
+
     let skillContext: string | null = null;
     if (command) {
       try {

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -505,6 +505,16 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     `[${new Date().toLocaleTimeString()}] Discord ${label}${mediaSuffix}: "${cleanContent.slice(0, 60)}${cleanContent.length > 60 ? "..." : ""}"`,
   );
 
+  // Plugin wizard: intercept /plugin and /claudeclaw:plugin before thread management and Claude routing.
+  // Must run here — after auth + non-empty checks but before AI thread intent classification,
+  // so an active wizard cannot be bypassed by messages that classify as "hire" / "fire".
+  const wizardCtx = { iface: "discord" as const, scopeId: channelId };
+  if ((cleanContent.trim().startsWith("/") && isWizardTrigger(cleanContent.trim().split(/\s+/, 1)[0].toLowerCase())) || hasActiveWizard(wizardCtx)) {
+    const reply = await handleWizardInput(wizardCtx, cleanContent.trim());
+    await sendMessage(config.token, channelId, reply);
+    return;
+  }
+
   // Typing indicator loop (Discord typing lasts 10s, fire every 8s)
   const typingInterval = setInterval(() => sendTyping(config.token, channelId), 8000);
 
@@ -623,14 +633,6 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
 
     // Skill routing: detect slash commands and resolve to SKILL.md prompts
     const command = cleanContent.startsWith("/") ? cleanContent.trim().split(/\s+/, 1)[0].toLowerCase() : null;
-
-    // Plugin wizard: intercept /plugin and /claudeclaw:plugin before Claude routing
-    const wizardCtx = { iface: "discord" as const, scopeId: channelId };
-    if ((command && isWizardTrigger(command)) || hasActiveWizard(wizardCtx)) {
-      const reply = await handleWizardInput(wizardCtx, cleanContent.trim());
-      await sendMessage(config.token, channelId, reply);
-      return;
-    }
 
     let skillContext: string | null = null;
     if (command) {

--- a/src/commands/plugin-cli.ts
+++ b/src/commands/plugin-cli.ts
@@ -1,0 +1,119 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { readdir, readFile } from "node:fs/promises";
+
+const SPAWN_TIMEOUT_MS = 30_000;
+
+export type PluginAction =
+  | { kind: "marketplace-add"; source: string }
+  | { kind: "marketplace-list" }
+  | { kind: "marketplace-update"; name?: string }
+  | { kind: "marketplace-remove"; name: string }
+  | { kind: "install"; plugin: string; scope: "user" | "project" }
+  | { kind: "list" }
+  | { kind: "uninstall"; plugin: string }
+  | { kind: "enable"; plugin: string }
+  | { kind: "disable"; plugin: string };
+
+export interface CliResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+export interface PluginManifest {
+  name: string;
+  version: string;
+  description?: string;
+  tools?: string[];
+  permissions?: string[];
+}
+
+function buildArgs(action: PluginAction): string[] {
+  switch (action.kind) {
+    case "marketplace-add":
+      return ["claude", "plugin", "marketplace", "add", action.source];
+    case "marketplace-list":
+      return ["claude", "plugin", "marketplace", "list"];
+    case "marketplace-update":
+      return action.name
+        ? ["claude", "plugin", "marketplace", "update", action.name]
+        : ["claude", "plugin", "marketplace", "update"];
+    case "marketplace-remove":
+      return ["claude", "plugin", "marketplace", "remove", action.name];
+    case "install":
+      return ["claude", "plugin", "install", action.plugin, "-s", action.scope];
+    case "list":
+      return ["claude", "plugin", "list"];
+    case "uninstall":
+      return ["claude", "plugin", "uninstall", action.plugin];
+    case "enable":
+      return ["claude", "plugin", "enable", action.plugin];
+    case "disable":
+      return ["claude", "plugin", "disable", action.plugin];
+  }
+}
+
+export async function runPluginCli(action: PluginAction): Promise<CliResult> {
+  const args = buildArgs(action);
+  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+
+  let killed = false;
+  const timer = setTimeout(() => {
+    killed = true;
+    proc.kill();
+  }, SPAWN_TIMEOUT_MS);
+
+  try {
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
+    return {
+      ok: !killed && exitCode === 0,
+      stdout: stdout.trim(),
+      stderr: killed ? "Command timed out after 30s" : stderr.trim(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Reads plugin.json from the first matching installed marketplace directory.
+// Returns null if not found — wizard will skip the manifest confirmation step.
+export async function readPluginManifest(pluginRef: string): Promise<PluginManifest | null> {
+  const [pluginName, marketplace] = pluginRef.includes("@")
+    ? (pluginRef.split("@", 2) as [string, string])
+    : [pluginRef, undefined];
+
+  const pluginsRoot = join(homedir(), ".claude", "plugins");
+  let marketplaces: string[];
+  try {
+    marketplaces = marketplace ? [marketplace] : await readdir(pluginsRoot);
+  } catch {
+    return null;
+  }
+
+  for (const mp of marketplaces) {
+    const manifestPath = join(pluginsRoot, mp, "plugins", pluginName, "plugin.json");
+    try {
+      const raw = await readFile(manifestPath, "utf8");
+      const json = JSON.parse(raw) as Partial<PluginManifest>;
+      return {
+        name: json.name ?? pluginName,
+        version: json.version ?? "unknown",
+        description: json.description,
+        tools: json.tools,
+        permissions: json.permissions,
+      };
+    } catch {
+      // try next marketplace
+    }
+  }
+
+  return null;
+}
+
+// Exported for testability — returns the argv array for a given action.
+export { buildArgs };

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -1,0 +1,220 @@
+import { runPluginCli, readPluginManifest, type PluginManifest } from "./plugin-cli";
+
+const WIZARD_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+// Commands that trigger the wizard (and their alias).
+const TRIGGER_COMMANDS = new Set(["/plugin", "/claudeclaw:plugin"]);
+
+export interface WizardContext {
+  iface: "discord" | "telegram" | "web";
+  scopeId: string;
+  agentName?: string; // recorded for Phase 2 per-agent scoping
+}
+
+type WizardStep =
+  | { step: "choose-action" }
+  | { step: "marketplace-source" }
+  | { step: "marketplace-name-to-update" }
+  | { step: "marketplace-name-to-remove" }
+  | { step: "install-plugin-ref" }
+  | { step: "install-scope"; plugin: string }
+  | { step: "install-confirm"; plugin: string; scope: "user" | "project"; manifest: PluginManifest | null }
+  | { step: "uninstall-plugin" }
+  | { step: "enable-plugin" }
+  | { step: "disable-plugin" };
+
+interface WizardEntry {
+  state: WizardStep;
+  ctx: WizardContext;
+  expiry: number;
+}
+
+const sessions = new Map<string, WizardEntry>();
+
+function key(ctx: WizardContext): string {
+  return `${ctx.iface}:${ctx.scopeId}`;
+}
+
+function fresh(ctx: WizardContext, state: WizardStep): WizardEntry {
+  return { state, ctx, expiry: Date.now() + WIZARD_TTL_MS };
+}
+
+function isExpired(entry: WizardEntry): boolean {
+  return Date.now() > entry.expiry;
+}
+
+export function isWizardTrigger(text: string): boolean {
+  const first = text.trim().split(/\s+/, 1)[0].toLowerCase();
+  return TRIGGER_COMMANDS.has(first);
+}
+
+export function hasActiveWizard(ctx: WizardContext): boolean {
+  const entry = sessions.get(key(ctx));
+  if (!entry) return false;
+  if (isExpired(entry)) {
+    sessions.delete(key(ctx));
+    return false;
+  }
+  return true;
+}
+
+export function cancelWizard(ctx: WizardContext): void {
+  sessions.delete(key(ctx));
+}
+
+const MENU = `Plugin marketplace — what would you like to do?
+
+1) Add marketplace
+2) Update marketplace
+3) Remove marketplace
+4) Install plugin
+5) Uninstall plugin
+6) Enable plugin
+7) Disable plugin
+8) List installed plugins
+9) List marketplaces
+
+Reply with a number, or 'cancel' to exit.`;
+
+const SCOPE_PROMPT = `Install scope (reply 'cancel' to exit):
+
+1) user — ~/.claude/plugins/ (available across all projects)
+2) project — .claude/plugins/ (this deployment only)
+
+Note: per-agent isolation is not yet enforced; both options are instance-wide in this release.`;
+
+function formatManifest(plugin: string, manifest: PluginManifest | null, scope: "user" | "project"): string {
+  const scopeLabel = scope === "user" ? "user (~/.claude/plugins/)" : "project (.claude/plugins/)";
+  if (!manifest) {
+    return `Install plugin \`${plugin}\` into scope: ${scopeLabel}?\n\nReply 'yes' to confirm or 'cancel' to exit.`;
+  }
+  const lines = [
+    `Install \`${manifest.name}\` v${manifest.version} into scope: ${scopeLabel}?`,
+    "",
+    manifest.description ?? "",
+  ];
+  if (manifest.tools?.length) lines.push(`Tools: ${manifest.tools.join(", ")}`);
+  if (manifest.permissions?.length) lines.push(`Permissions: ${manifest.permissions.join(", ")}`);
+  lines.push("", "Reply 'yes' to confirm or 'cancel' to exit.");
+  return lines.filter((l, i) => !(i > 0 && l === "" && lines[i - 1] === "")).join("\n");
+}
+
+function formatResult(ok: boolean, stdout: string, stderr: string): string {
+  if (ok) {
+    return stdout || "Done.";
+  }
+  const detail = stderr || stdout || "Unknown error.";
+  return `Error: ${detail}`;
+}
+
+export async function handleWizardInput(ctx: WizardContext, rawText: string): Promise<string> {
+  const k = key(ctx);
+  const text = rawText.trim();
+  const lower = text.toLowerCase();
+
+  if (lower === "cancel") {
+    sessions.delete(k);
+    return "Plugin wizard cancelled.";
+  }
+
+  let entry = sessions.get(k);
+  if (!entry || isExpired(entry)) {
+    // New wizard session — must be a trigger command
+    if (!isWizardTrigger(text)) return "Send /plugin to open the plugin wizard.";
+    entry = fresh(ctx, { step: "choose-action" });
+    sessions.set(k, entry);
+    return MENU;
+  }
+
+  // Refresh TTL on each interaction
+  entry.expiry = Date.now() + WIZARD_TTL_MS;
+
+  const { state } = entry;
+
+  switch (state.step) {
+    case "choose-action": {
+      switch (text) {
+        case "1": entry.state = { step: "marketplace-source" }; return "Send the marketplace URL, local path, or GitHub repo (e.g. `owner/repo`):";
+        case "2": entry.state = { step: "marketplace-name-to-update" }; return "Send marketplace name to update (leave blank / send 'all' to update all):";
+        case "3": entry.state = { step: "marketplace-name-to-remove" }; return "Send the marketplace name to remove:";
+        case "4": entry.state = { step: "install-plugin-ref" }; return "Send plugin name (e.g. `my-plugin` or `my-plugin@marketplace-name`):";
+        case "5": entry.state = { step: "uninstall-plugin" }; return "Send the plugin name to uninstall:";
+        case "6": entry.state = { step: "enable-plugin" }; return "Send the plugin name to enable:";
+        case "7": entry.state = { step: "disable-plugin" }; return "Send the plugin name to disable:";
+        case "8": {
+          sessions.delete(k);
+          const r = await runPluginCli({ kind: "list" });
+          return formatResult(r.ok, r.stdout, r.stderr);
+        }
+        case "9": {
+          sessions.delete(k);
+          const r = await runPluginCli({ kind: "marketplace-list" });
+          return formatResult(r.ok, r.stdout, r.stderr);
+        }
+        default:
+          return `Unrecognised option '${text}'. ${MENU}`;
+      }
+    }
+
+    case "marketplace-source": {
+      sessions.delete(k);
+      const r = await runPluginCli({ kind: "marketplace-add", source: text });
+      return formatResult(r.ok, r.stdout, r.stderr);
+    }
+
+    case "marketplace-name-to-update": {
+      sessions.delete(k);
+      const name = lower === "all" || text === "" ? undefined : text;
+      const r = await runPluginCli({ kind: "marketplace-update", name });
+      return formatResult(r.ok, r.stdout, r.stderr);
+    }
+
+    case "marketplace-name-to-remove": {
+      sessions.delete(k);
+      const r = await runPluginCli({ kind: "marketplace-remove", name: text });
+      return formatResult(r.ok, r.stdout, r.stderr);
+    }
+
+    case "install-plugin-ref": {
+      entry.state = { step: "install-scope", plugin: text };
+      return SCOPE_PROMPT;
+    }
+
+    case "install-scope": {
+      const scope = text === "1" ? "user" : text === "2" ? "project" : null;
+      if (!scope) return `Reply '1' for user or '2' for project scope:\n\n${SCOPE_PROMPT}`;
+      const manifest = await readPluginManifest(state.plugin);
+      entry.state = { step: "install-confirm", plugin: state.plugin, scope, manifest };
+      return formatManifest(state.plugin, manifest, scope);
+    }
+
+    case "install-confirm": {
+      if (lower !== "yes") return `Reply 'yes' to install or 'cancel' to exit.`;
+      sessions.delete(k);
+      const r = await runPluginCli({ kind: "install", plugin: state.plugin, scope: state.scope });
+      const msg = formatResult(r.ok, r.stdout, r.stderr);
+      if (r.ok) {
+        return `${msg}\n\nThe plugin is now installed. Skills it provides will be available as /<plugin>:<skill-name> commands.`;
+      }
+      return msg;
+    }
+
+    case "uninstall-plugin": {
+      sessions.delete(k);
+      const r = await runPluginCli({ kind: "uninstall", plugin: text });
+      return formatResult(r.ok, r.stdout, r.stderr);
+    }
+
+    case "enable-plugin": {
+      sessions.delete(k);
+      const r = await runPluginCli({ kind: "enable", plugin: text });
+      return formatResult(r.ok, r.stdout, r.stderr);
+    }
+
+    case "disable-plugin": {
+      sessions.delete(k);
+      const r = await runPluginCli({ kind: "disable", plugin: text });
+      return formatResult(r.ok, r.stdout, r.stderr);
+    }
+  }
+}

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -31,6 +31,17 @@ interface WizardEntry {
 
 const sessions = new Map<string, WizardEntry>();
 
+// Sweep expired entries every 15 minutes so the Map doesn't grow unbounded
+// in a long-running daemon. unref() prevents this timer from keeping the
+// process alive if it would otherwise exit.
+const sweepTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [k, entry] of sessions) {
+    if (now > entry.expiry) sessions.delete(k);
+  }
+}, 15 * 60 * 1000);
+if (sweepTimer.unref) sweepTimer.unref();
+
 function key(ctx: WizardContext): string {
   return `${ctx.iface}:${ctx.scopeId}`;
 }
@@ -74,7 +85,8 @@ const MENU = `Plugin marketplace — what would you like to do?
 8) List installed plugins
 9) List marketplaces
 
-Reply with a number, or 'cancel' to exit.`;
+Reply with a number. Send 'cancel' at any time to exit and return to normal chat.
+(While this wizard is open all messages are routed here, not to Claude.)`;
 
 const SCOPE_PROMPT = `Install scope (reply 'cancel' to exit):
 
@@ -152,7 +164,7 @@ export async function handleWizardInput(ctx: WizardContext, rawText: string): Pr
           return formatResult(r.ok, r.stdout, r.stderr);
         }
         default:
-          return `Unrecognised option '${text}'. ${MENU}`;
+          return `'${text}' is not a valid option. Send 'cancel' to exit the wizard and return to normal chat.\n\n${MENU}`;
       }
     }
 

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -10,6 +10,7 @@ import { initConfig, loadSettings, reloadSettings, resolvePrompt, type Heartbeat
 import { getDayAndMinuteAtOffset } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
 import type { Job } from "../jobs";
+import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -474,6 +475,11 @@ export async function start(args: string[] = []) {
             console.log(`[${ts()}] Jobs reloaded from Web UI`);
           },
           onChat: async (message, onChunk, onUnblock) => {
+            const wizardCtx = { iface: "web" as const, scopeId: "default" };
+            if (isWizardTrigger(message) || hasActiveWizard(wizardCtx)) {
+              onChunk(await handleWizardInput(wizardCtx, message));
+              return;
+            }
             await streamUserMessage("chat", message, onChunk, onUnblock);
           },
         });

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -8,6 +8,7 @@ import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt, listSkills } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
+import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 
 // --- Markdown → Telegram HTML conversion (ported from nanobot) ---
 
@@ -772,6 +773,14 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           console.error(`[Telegram] Failed to transcribe voice for ${label}: ${err instanceof Error ? err.message : err}`);
         }
       }
+    }
+
+    // Plugin wizard: intercept /plugin and /claudeclaw:plugin before Claude routing
+    const wizardCtx = { iface: "telegram" as const, scopeId: String(chatId) };
+    if ((command && isWizardTrigger(command)) || hasActiveWizard(wizardCtx)) {
+      const reply = await handleWizardInput(wizardCtx, text.trim());
+      await sendMessage(config.token, chatId, reply, threadId);
+      return;
     }
 
     // Skill routing: resolve slash commands to SKILL.md prompts


### PR DESCRIPTION
## Summary

Closes #116.

Adds `/plugin` (and `/claudeclaw:plugin`) across Discord, Telegram and the Web UI — a thin wizard wrapper over the existing `claude plugin ...` CLI. No separate installer, no ClawHub-specific registry, no new package format. Claude Code does the heavy lifting; ClaudeClaw just exposes the interface.

- **2 new files**: `plugin-cli.ts` (pure CLI wrapper, ~95 LOC) and `plugin-wizard.ts` (in-memory state machine, ~195 LOC)
- **3 adapter touchpoints**: ~10 LOC each in `discord.ts`, `telegram.ts`, `start.ts` — intercept before `resolveSkillPrompt` so `/plugin` never hits Claude
- **No runner changes** — existing skill resolution already finds plugins under `~/.claude/plugins/` after install

## How it works

1. User sends `/plugin` in any interface
2. Wizard shows 9-item menu (add/update/remove marketplace, install/uninstall/enable/disable plugin, list)
3. Wizard asks for required input one step at a time
4. For `install`: asks for scope (`user` = `~/.claude/plugins/` or `project` = `.claude/plugins/`), then reads plugin manifest from disk (if available) and shows name/version/description/tools/permissions before asking for `yes` confirmation
5. Runs `claude plugin <subcommand> ...` locally, returns stdout/stderr to the chat channel
6. Installed plugin skills are immediately callable as `/<plugin>:<skill-name>` via existing `resolveSkillPrompt`

## Per-agent scope note

Wizard records `agentName` in context (for Phase 2). In this release, both `user` and `project` scopes are instance-wide — true per-agent isolation requires runner spawn-cwd changes, documented in the wizard help text and deferred to a follow-up.

## Test plan

- [ ] `bun test src/__tests__/` — 61 tests pass (31 new), 0 fail
- [ ] `bunx tsc --noEmit` — clean
- [ ] Manual: start daemon, send `/plugin` from web UI → menu appears → add a marketplace → stdout returned
- [ ] Manual: send `/plugin` → install → choose `user` scope → confirm `yes` → plugin installed at `~/.claude/plugins/`
- [ ] Manual: type `/<plugin>:<skill>` → skill resolves (no change to existing resolution path)
- [ ] Manual: send `cancel` mid-wizard → session cleared
- [ ] Manual: bad marketplace URL → stderr surfaced to user
- [ ] Manual: parity check via Discord and Telegram interfaces