### PR TITLE
feat(plugin): Phase 2 — per-agent runtime isolation for plugin spawns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -118,7 +118,7 @@ let applicationId: string | null = null;
 let readyGuildIds: Set<string> | null = null;
 
 // Track known thread channel IDs and their parent channel IDs for multi-session support
-const knownThreads = new Map<string, { parentId: string }>();
+const knownThreads = new Map<string, { parentId: string; agentName?: string }>();
 
 // --- Debug ---
 
@@ -508,7 +508,8 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   // Plugin wizard: intercept /plugin and /claudeclaw:plugin before thread management and Claude routing.
   // Must run here — after auth + non-empty checks but before AI thread intent classification,
   // so an active wizard cannot be bypassed by messages that classify as "hire" / "fire".
-  const wizardCtx = { iface: "discord" as const, scopeId: channelId };
+  const threadInfo = knownThreads.get(channelId);
+  const wizardCtx = { iface: "discord" as const, scopeId: channelId, agentName: threadInfo?.agentName };
   if ((cleanContent.trim().startsWith("/") && isWizardTrigger(cleanContent.trim().split(/\s+/, 1)[0].toLowerCase())) || hasActiveWizard(wizardCtx)) {
     const reply = await handleWizardInput(wizardCtx, cleanContent.trim());
     await sendMessage(config.token, channelId, reply);
@@ -583,7 +584,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
                 auto_archive_duration: 4320, // 3 days
               },
             );
-            knownThreads.set(thread.id, { parentId: channelId });
+            knownThreads.set(thread.id, { parentId: channelId, agentName: threadName });
             // Don't pre-create session — let Claude CLI create it on first message
             // The real UUID will be captured and saved by runner.ts
             await sendMessage(config.token, thread.id, `🧵 Thread **${threadName}** created with independent session. Start chatting!`);
@@ -1047,8 +1048,8 @@ function handleDispatch(token: string, eventName: string, data: any): void {
 
     case "THREAD_CREATE":
       if (data.id && data.parent_id) {
-        knownThreads.set(data.id, { parentId: data.parent_id });
-        debugLog(`Thread tracked: ${data.id} (parent: ${data.parent_id})`);
+        knownThreads.set(data.id, { parentId: data.parent_id, agentName: data.name ?? undefined });
+        debugLog(`Thread tracked: ${data.id} (parent: ${data.parent_id} name: ${data.name ?? "unknown"})`);
         if (getSettings().discord.listenChannels.includes(data.parent_id)) {
           discordApi(token, "PUT", `/channels/${data.id}/thread-members/@me`).catch((err) =>
             console.error(`[Discord] Failed to join thread ${data.id}: ${err}`),
@@ -1076,7 +1077,8 @@ function handleDispatch(token: string, eventName: string, data: any): void {
           );
           debugLog(`Thread archived and cleaned up: ${data.id}`);
         } else {
-          knownThreads.set(data.id, { parentId: data.parent_id });
+          const existing = knownThreads.get(data.id);
+          knownThreads.set(data.id, { parentId: data.parent_id, agentName: data.name ?? existing?.agentName });
         }
       }
       break;
@@ -1084,7 +1086,7 @@ function handleDispatch(token: string, eventName: string, data: any): void {
     case "THREAD_LIST_SYNC":
       if (data.threads) {
         for (const thread of data.threads) {
-          knownThreads.set(thread.id, { parentId: thread.parent_id });
+          knownThreads.set(thread.id, { parentId: thread.parent_id, agentName: thread.name ?? undefined });
         }
       }
       break;

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, safeAgentSlug } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
@@ -119,6 +119,17 @@ let readyGuildIds: Set<string> | null = null;
 
 // Track known thread channel IDs and their parent channel IDs for multi-session support
 const knownThreads = new Map<string, { parentId: string; agentName?: string }>();
+
+// Upsert knownThreads, preserving any existing agentName when a new one is not supplied.
+// Always use this instead of knownThreads.set() to avoid accidental data loss on recovery paths.
+function upsertThread(id: string, parentId: string, rawName?: string): void {
+  const existing = knownThreads.get(id);
+  let agentName: string | undefined;
+  if (rawName) {
+    try { agentName = safeAgentSlug(rawName); } catch { /* unsanitizable name — no agent scoping */ }
+  }
+  knownThreads.set(id, { parentId, agentName: agentName ?? existing?.agentName });
+}
 
 // --- Debug ---
 
@@ -246,9 +257,9 @@ async function rejoinThreads(token: string): Promise<void> {
       await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
       if (!knownThreads.has(ts.threadId)) {
-        const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
+        const ch = await discordApi<{ parent_id?: string; name?: string }>(token, "GET", `/channels/${ts.threadId}`);
         if (ch.parent_id) {
-          knownThreads.set(ts.threadId, { parentId: ch.parent_id });
+          upsertThread(ts.threadId, ch.parent_id, ch.name);
         }
       }
       console.log(`[Discord] Rejoined thread: ${ts.threadId}`);
@@ -450,10 +461,10 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const persisted = await peekThreadSession(channelId);
     if (persisted) {
       try {
-        const ch = await discordApi<{ parent_id?: string }>(config.token, "GET", `/channels/${channelId}`);
+        const ch = await discordApi<{ parent_id?: string; name?: string }>(config.token, "GET", `/channels/${channelId}`);
         if (ch.parent_id) {
-          knownThreads.set(channelId, { parentId: ch.parent_id });
-          debugLog(`Thread recovered from sessions.json: ${channelId} (parent: ${ch.parent_id})`);
+          upsertThread(channelId, ch.parent_id, ch.name);
+          debugLog(`Thread recovered from sessions.json: ${channelId} (parent: ${ch.parent_id} name: ${ch.name ?? "unknown"})`);
         }
       } catch (err) {
         debugLog(`Thread recovery failed for ${channelId}: ${err}`);
@@ -584,7 +595,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
                 auto_archive_duration: 4320, // 3 days
               },
             );
-            knownThreads.set(thread.id, { parentId: channelId, agentName: threadName });
+            upsertThread(thread.id, channelId, threadName);
             // Don't pre-create session — let Claude CLI create it on first message
             // The real UUID will be captured and saved by runner.ts
             await sendMessage(config.token, thread.id, `🧵 Thread **${threadName}** created with independent session. Start chatting!`);
@@ -732,7 +743,8 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
 
     if (interaction.data.name === "compact") {
       await respondToInteraction(interaction, { content: "⏳ Compacting session..." });
-      const result = await compactCurrentSession();
+      const compactThreadInfo = interaction.channel_id ? knownThreads.get(interaction.channel_id) : undefined;
+      const result = await compactCurrentSession(compactThreadInfo?.agentName);
       await fetch(
         `${DISCORD_API}/webhooks/${applicationId}/${interaction.token}/messages/@original`,
         {
@@ -1031,7 +1043,7 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       if (data.threads) {
         console.log(`[Discord] GUILD_CREATE: ${data.threads.length} active threads in guild ${data.id}`);
         for (const thread of data.threads) {
-          knownThreads.set(thread.id, { parentId: thread.parent_id });
+          upsertThread(thread.id, thread.parent_id, thread.name);
           console.log(`[Discord]   thread: ${thread.id} name="${thread.name}" parent=${thread.parent_id}`);
         }
       } else {
@@ -1048,7 +1060,7 @@ function handleDispatch(token: string, eventName: string, data: any): void {
 
     case "THREAD_CREATE":
       if (data.id && data.parent_id) {
-        knownThreads.set(data.id, { parentId: data.parent_id, agentName: data.name ?? undefined });
+        upsertThread(data.id, data.parent_id, data.name);
         debugLog(`Thread tracked: ${data.id} (parent: ${data.parent_id} name: ${data.name ?? "unknown"})`);
         if (getSettings().discord.listenChannels.includes(data.parent_id)) {
           discordApi(token, "PUT", `/channels/${data.id}/thread-members/@me`).catch((err) =>
@@ -1077,8 +1089,7 @@ function handleDispatch(token: string, eventName: string, data: any): void {
           );
           debugLog(`Thread archived and cleaned up: ${data.id}`);
         } else {
-          const existing = knownThreads.get(data.id);
-          knownThreads.set(data.id, { parentId: data.parent_id, agentName: data.name ?? existing?.agentName });
+          upsertThread(data.id, data.parent_id, data.name);
         }
       }
       break;
@@ -1086,7 +1097,7 @@ function handleDispatch(token: string, eventName: string, data: any): void {
     case "THREAD_LIST_SYNC":
       if (data.threads) {
         for (const thread of data.threads) {
-          knownThreads.set(thread.id, { parentId: thread.parent_id, agentName: thread.name ?? undefined });
+          upsertThread(thread.id, thread.parent_id, thread.name);
         }
       }
       break;

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, safeAgentSlug } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
@@ -128,7 +128,7 @@ function upsertThread(id: string, parentId: string, rawName?: string): void {
   const existing = knownThreads.get(id);
   let agentName: string | undefined;
   if (rawName) {
-    try { agentName = `${safeAgentSlug(rawName)}-${id}`; } catch { /* unsanitizable — no agent scoping */ }
+    try { agentName = agentDirKey(rawName, id); } catch { /* unsanitizable — no agent scoping */ }
   }
   knownThreads.set(id, { parentId, agentName: agentName ?? existing?.agentName });
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, safeAgentSlug } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, safeAgentSlug } from "../runner";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
@@ -121,12 +121,14 @@ let readyGuildIds: Set<string> | null = null;
 const knownThreads = new Map<string, { parentId: string; agentName?: string }>();
 
 // Upsert knownThreads, preserving any existing agentName when a new one is not supplied.
+// The agentName key is "<slug>-<threadId>" to guarantee uniqueness across threads whose
+// display names would otherwise map to the same slug.
 // Always use this instead of knownThreads.set() to avoid accidental data loss on recovery paths.
 function upsertThread(id: string, parentId: string, rawName?: string): void {
   const existing = knownThreads.get(id);
   let agentName: string | undefined;
   if (rawName) {
-    try { agentName = safeAgentSlug(rawName); } catch { /* unsanitizable name — no agent scoping */ }
+    try { agentName = `${safeAgentSlug(rawName)}-${id}`; } catch { /* unsanitizable — no agent scoping */ }
   }
   knownThreads.set(id, { parentId, agentName: agentName ?? existing?.agentName });
 }
@@ -743,8 +745,11 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
 
     if (interaction.data.name === "compact") {
       await respondToInteraction(interaction, { content: "⏳ Compacting session..." });
-      const compactThreadInfo = interaction.channel_id ? knownThreads.get(interaction.channel_id) : undefined;
-      const result = await compactCurrentSession(compactThreadInfo?.agentName);
+      const compactChannelId = interaction.channel_id;
+      const compactThreadInfo = compactChannelId ? knownThreads.get(compactChannelId) : undefined;
+      const result = compactChannelId && compactThreadInfo
+        ? await compactCurrentThreadSession(compactChannelId, compactThreadInfo.agentName)
+        : await compactCurrentSession();
       await fetch(
         `${DISCORD_API}/webhooks/${applicationId}/${interaction.token}/messages/@original`,
         {

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -680,7 +680,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const prefixedPrompt = promptParts.join("\n");
     // Use thread-specific session if message is in a known thread
     const threadId = knownThreads.has(channelId) ? channelId : undefined;
-    const result = await runUserMessage("discord", prefixedPrompt, threadId);
+    const result = await runUserMessage("discord", prefixedPrompt, threadId, threadInfo?.agentName);
 
     if (result.exitCode !== 0) {
       await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stdout || result.stderr || "Unknown error"}`);

--- a/src/commands/plugin-cli.ts
+++ b/src/commands/plugin-cli.ts
@@ -54,9 +54,9 @@ function buildArgs(action: PluginAction): string[] {
   }
 }
 
-export async function runPluginCli(action: PluginAction): Promise<CliResult> {
+export async function runPluginCli(action: PluginAction, cwd?: string): Promise<CliResult> {
   const args = buildArgs(action);
-  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe", ...(cwd ? { cwd } : {}) });
 
   let killed = false;
   const timer = setTimeout(() => {

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -1,4 +1,5 @@
 import { runPluginCli, readPluginManifest, type PluginManifest } from "./plugin-cli";
+import { ensureAgentDir } from "../runner";
 
 const WIZARD_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -88,12 +89,12 @@ const MENU = `Plugin marketplace — what would you like to do?
 Reply with a number. Send 'cancel' at any time to exit and return to normal chat.
 (While this wizard is open all messages are routed here, not to Claude.)`;
 
-const SCOPE_PROMPT = `Install scope (reply 'cancel' to exit):
-
-1) user — ~/.claude/plugins/ (available across all projects)
-2) project — .claude/plugins/ (this deployment only)
-
-Note: per-agent isolation is not yet enforced; both options are instance-wide in this release.`;
+function buildScopePrompt(agentName?: string): string {
+  const projectNote = agentName
+    ? `2) project — agents/${agentName}/.claude/plugins/ (this agent only)`
+    : "2) project — .claude/plugins/ (this deployment only)";
+  return `Install scope (reply 'cancel' to exit):\n\n1) user — ~/.claude/plugins/ (available to all agents)\n${projectNote}\n`;
+}
 
 function formatManifest(plugin: string, manifest: PluginManifest | null, scope: "user" | "project"): string {
   const scopeLabel = scope === "user" ? "user (~/.claude/plugins/)" : "project (.claude/plugins/)";
@@ -189,12 +190,12 @@ export async function handleWizardInput(ctx: WizardContext, rawText: string): Pr
 
     case "install-plugin-ref": {
       entry.state = { step: "install-scope", plugin: text };
-      return SCOPE_PROMPT;
+      return buildScopePrompt(ctx.agentName);
     }
 
     case "install-scope": {
       const scope = text === "1" ? "user" : text === "2" ? "project" : null;
-      if (!scope) return `Reply '1' for user or '2' for project scope:\n\n${SCOPE_PROMPT}`;
+      if (!scope) return `Reply '1' for user or '2' for project scope:\n\n${buildScopePrompt(ctx.agentName)}`;
       const manifest = await readPluginManifest(state.plugin);
       entry.state = { step: "install-confirm", plugin: state.plugin, scope, manifest };
       return formatManifest(state.plugin, manifest, scope);
@@ -203,10 +204,16 @@ export async function handleWizardInput(ctx: WizardContext, rawText: string): Pr
     case "install-confirm": {
       if (lower !== "yes") return `Reply 'yes' to install or 'cancel' to exit.`;
       sessions.delete(k);
-      const r = await runPluginCli({ kind: "install", plugin: state.plugin, scope: state.scope });
+      const cwd = state.scope === "project" && ctx.agentName
+        ? await ensureAgentDir(ctx.agentName)
+        : undefined;
+      const r = await runPluginCli({ kind: "install", plugin: state.plugin, scope: state.scope }, cwd);
       const msg = formatResult(r.ok, r.stdout, r.stderr);
       if (r.ok) {
-        return `${msg}\n\nThe plugin is now installed. Skills it provides will be available as /<plugin>:<skill-name> commands.`;
+        const location = state.scope === "project" && ctx.agentName
+          ? `agents/${ctx.agentName}/.claude/plugins/`
+          : "~/.claude/plugins/";
+        return `${msg}\n\nInstalled to ${location}. Skills it provides will be available as /<plugin>:<skill-name> commands.`;
       }
       return msg;
     }

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -1,5 +1,5 @@
 import { runPluginCli, readPluginManifest, type PluginManifest } from "./plugin-cli";
-import { ensureAgentDir } from "../runner";
+import { ensureAgentDir, safeAgentSlug } from "../runner";
 
 const WIZARD_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -90,9 +90,12 @@ Reply with a number. Send 'cancel' at any time to exit and return to normal chat
 (While this wizard is open all messages are routed here, not to Claude.)`;
 
 function buildScopePrompt(agentName?: string): string {
-  const projectNote = agentName
-    ? `2) project — agents/${agentName}/.claude/plugins/ (this agent only)`
-    : "2) project — .claude/plugins/ (this deployment only)";
+  let projectNote = "2) project — .claude/plugins/ (this deployment only)";
+  if (agentName) {
+    try {
+      projectNote = `2) project — agents/${safeAgentSlug(agentName)}/.claude/plugins/ (this agent only)`;
+    } catch { /* unsanitizable name — fall back to generic */ }
+  }
   return `Install scope (reply 'cancel' to exit):\n\n1) user — ~/.claude/plugins/ (available to all agents)\n${projectNote}\n`;
 }
 
@@ -211,7 +214,7 @@ export async function handleWizardInput(ctx: WizardContext, rawText: string): Pr
       const msg = formatResult(r.ok, r.stdout, r.stderr);
       if (r.ok) {
         const location = state.scope === "project" && ctx.agentName
-          ? `agents/${ctx.agentName}/.claude/plugins/`
+          ? `agents/${safeAgentSlug(ctx.agentName)}/.claude/plugins/`
           : "~/.claude/plugins/";
         return `${msg}\n\nInstalled to ${location}. Skills it provides will be available as /<plugin>:<skill-name> commands.`;
       }

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -1,5 +1,5 @@
 import { runPluginCli, readPluginManifest, type PluginManifest } from "./plugin-cli";
-import { ensureAgentDir, safeAgentSlug } from "../runner";
+import { ensureAgentDir } from "../runner";
 
 const WIZARD_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -90,12 +90,10 @@ Reply with a number. Send 'cancel' at any time to exit and return to normal chat
 (While this wizard is open all messages are routed here, not to Claude.)`;
 
 function buildScopePrompt(agentName?: string): string {
-  let projectNote = "2) project — .claude/plugins/ (this deployment only)";
-  if (agentName) {
-    try {
-      projectNote = `2) project — agents/${safeAgentSlug(agentName)}/.claude/plugins/ (this agent only)`;
-    } catch { /* unsanitizable name — fall back to generic */ }
-  }
+  // agentName is already a normalised key (from agentDirKey) — display it directly.
+  const projectNote = agentName
+    ? `2) project — agents/${agentName}/.claude/plugins/ (this agent only)`
+    : "2) project — .claude/plugins/ (this deployment only)";
   return `Install scope (reply 'cancel' to exit):\n\n1) user — ~/.claude/plugins/ (available to all agents)\n${projectNote}\n`;
 }
 
@@ -214,7 +212,7 @@ export async function handleWizardInput(ctx: WizardContext, rawText: string): Pr
       const msg = formatResult(r.ok, r.stdout, r.stderr);
       if (r.ok) {
         const location = state.scope === "project" && ctx.agentName
-          ? `agents/${safeAgentSlug(ctx.agentName)}/.claude/plugins/`
+          ? `agents/${ctx.agentName}/.claude/plugins/`
           : "~/.claude/plugins/";
         return `${msg}\n\nInstalled to ${location}. Skills it provides will be available as /<plugin>:<skill-name> commands.`;
       }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readFile, writeFile, realpath } from "fs/promises";
 import { join, resolve, sep } from "path";
 import { existsSync } from "fs";
 import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
@@ -239,17 +239,26 @@ export function agentDirKey(rawName: string, threadId: string): string {
 
 // Returns the working directory for a named agent's Claude spawn.
 // Works with any agent name — Discord-generated keys (from agentDirKey) or
-// raw filesystem directory names used by scheduled jobs. The only security
-// constraint is the resolve-under-agents/ check, which blocks path traversal
-// regardless of character set.
+// raw filesystem directory names used by scheduled jobs.
+// Security: uses realpath() after mkdir so symlinks are resolved before the
+// containment check. A lexical path.resolve() check is not sufficient because
+// a symlinked agents/<name> can point outside the repo and pass lexical checks.
 export async function ensureAgentDir(name: string): Promise<string> {
   const agentsRoot = join(PROJECT_DIR, "agents");
   const dir = join(agentsRoot, name);
+  // Lexical pre-check: reject obvious traversal before touching the filesystem
   if (!resolve(dir).startsWith(resolve(agentsRoot) + sep)) {
     throw new Error(`Agent directory "${dir}" would escape the agents root — rejecting`);
   }
   await mkdir(dir, { recursive: true });
-  return dir;
+  // Post-mkdir realpath check: resolves symlinks so a symlinked agent directory
+  // that points outside agents/ is caught even if it passed the lexical check.
+  const realDir = await realpath(dir);
+  const realRoot = await realpath(agentsRoot);
+  if (!realDir.startsWith(realRoot + sep)) {
+    throw new Error(`Agent directory "${realDir}" resolves outside the agents root via symlink — rejecting`);
+  }
+  return realDir;
 }
 
 const DIR_SCOPE_PROMPT = [

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -158,7 +158,8 @@ async function runClaudeOnce(
   model: string,
   api: string,
   baseEnv: Record<string, string>,
-  timeoutMs: number = DEFAULT_SESSION_TIMEOUT_MS
+  timeoutMs: number = DEFAULT_SESSION_TIMEOUT_MS,
+  cwd?: string
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();
@@ -168,6 +169,7 @@ async function runClaudeOnce(
     stdout: "pipe",
     stderr: "pipe",
     env: buildChildEnv(baseEnv, model, api),
+    ...(cwd ? { cwd } : {}),
   });
 
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -206,6 +208,14 @@ async function runClaudeOnce(
 }
 
 const PROJECT_DIR = process.cwd();
+
+// Returns the working directory for a named agent's Claude spawn.
+// The agent directory is created on first use so the spawn never fails on a missing cwd.
+export async function ensureAgentDir(agentName: string): Promise<string> {
+  const dir = join(PROJECT_DIR, "agents", agentName);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
 
 const DIR_SCOPE_PROMPT = [
   `CRITICAL SECURITY CONSTRAINT: You are scoped to the project directory: ${PROJECT_DIR}`,
@@ -463,8 +473,9 @@ async function execClaude(
   }
 
   const baseEnv = cleanSpawnEnv();
+  const spawnCwd = agentName ? await ensureAgentDir(agentName) : undefined;
 
-  let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+  let exec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs, spawnCwd);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
   let usedFallback = false;
 
@@ -472,7 +483,7 @@ async function execClaude(
     console.warn(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs);
+    exec = await runClaudeOnce(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs, spawnCwd);
     usedFallback = true;
   }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -238,14 +238,13 @@ export function agentDirKey(rawName: string, threadId: string): string {
 }
 
 // Returns the working directory for a named agent's Claude spawn.
-// Accepts an already-normalised key (from agentDirKey or safeAgentSlug) — does NOT
-// re-slug, so the threadId suffix is preserved. Verifies the result stays under agents/.
-export async function ensureAgentDir(key: string): Promise<string> {
-  if (!/^[a-z0-9_-]+$/.test(key)) {
-    throw new Error(`Agent key "${key}" contains unsafe characters`);
-  }
+// Works with any agent name — Discord-generated keys (from agentDirKey) or
+// raw filesystem directory names used by scheduled jobs. The only security
+// constraint is the resolve-under-agents/ check, which blocks path traversal
+// regardless of character set.
+export async function ensureAgentDir(name: string): Promise<string> {
   const agentsRoot = join(PROJECT_DIR, "agents");
-  const dir = join(agentsRoot, key);
+  const dir = join(agentsRoot, name);
   if (!resolve(dir).startsWith(resolve(agentsRoot) + sep)) {
     throw new Error(`Agent directory "${dir}" would escape the agents root — rejecting`);
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -344,7 +344,8 @@ export async function runCompact(
   api: string,
   baseEnv: Record<string, string>,
   securityArgs: string[],
-  timeoutMs: number
+  timeoutMs: number,
+  cwd?: string
 ): Promise<boolean> {
   const compactArgs = [
     "claude", "-p", "/compact",
@@ -353,7 +354,7 @@ export async function runCompact(
     ...securityArgs,
   ];
   console.log(`[${new Date().toLocaleTimeString()}] Running /compact on session ${sessionId.slice(0, 8)}...`);
-  const result = await runClaudeOnce(compactArgs, model, api, baseEnv, timeoutMs);
+  const result = await runClaudeOnce(compactArgs, model, api, baseEnv, timeoutMs, cwd);
   const success = result.exitCode === 0;
   console.log(`[${new Date().toLocaleTimeString()}] Compact ${success ? "succeeded" : `failed (exit ${result.exitCode})`}`);
   return success;
@@ -372,13 +373,15 @@ export async function compactCurrentSession(agentName?: string): Promise<{ succe
   const baseEnv = cleanSpawnEnv();
   const timeoutMs = settings.sessionTimeoutMs;
 
+  const compactCwd = agentName ? await ensureAgentDir(agentName) : undefined;
   const ok = await runCompact(
     existing.sessionId,
     settings.model,
     settings.api,
     baseEnv,
     securityArgs,
-    timeoutMs
+    timeoutMs,
+    compactCwd
   );
 
   return ok
@@ -571,13 +574,14 @@ async function execClaude(
       primaryConfig.api,
       baseEnv,
       securityArgs,
-      timeoutMs
+      timeoutMs,
+      spawnCwd
     );
     emitCompactEvent({ type: "auto-compact-done", success: compactOk });
 
     if (compactOk) {
       console.log(`[${new Date().toLocaleTimeString()}] Retrying ${name} after compact...`);
-      const retryExec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs);
+      const retryExec = await runClaudeOnce(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs, spawnCwd);
       const retryResult: RunResult = {
         stdout: retryExec.rawStdout,
         stderr: retryExec.stderr,
@@ -770,8 +774,8 @@ function prefixUserMessageWithClock(prompt: string): string {
   }
 }
 
-export async function runUserMessage(name: string, prompt: string, threadId?: string): Promise<RunResult> {
-  return run(name, prefixUserMessageWithClock(prompt), threadId);
+export async function runUserMessage(name: string, prompt: string, threadId?: string, agentName?: string): Promise<RunResult> {
+  return run(name, prefixUserMessageWithClock(prompt), threadId, undefined, undefined, agentName);
 }
 
 /**

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -210,8 +210,8 @@ async function runClaudeOnce(
 const PROJECT_DIR = process.cwd();
 
 // Converts a raw agent/thread display name to a safe filesystem segment.
-// Only [a-z0-9_-] characters are allowed; spaces and other separators become hyphens.
-// Exported so callers can show the canonical form in UI before creating the directory.
+// Converts a display name to a safe filesystem segment (no unique suffix).
+// Exported for display-only use (e.g. showing the human-readable name in UI).
 export function safeAgentSlug(raw: string): string {
   const slug = raw
     .toLowerCase()
@@ -222,12 +222,30 @@ export function safeAgentSlug(raw: string): string {
   return slug;
 }
 
+// Builds a guaranteed-unique, filesystem-safe directory key for an agent thread.
+// Truncates the display slug to leave room for "-<threadId>" so the suffix is
+// NEVER truncated away on a second slugging pass.
+export function agentDirKey(rawName: string, threadId: string): string {
+  const suffix = `-${threadId}`;
+  const maxSlugLen = Math.max(1, 64 - suffix.length);
+  const slug = rawName
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maxSlugLen);
+  if (!slug) throw new Error(`Agent name "${rawName}" cannot be converted to a safe path segment`);
+  return `${slug}${suffix}`;
+}
+
 // Returns the working directory for a named agent's Claude spawn.
-// Sanitizes the name and verifies the result stays under PROJECT_DIR/agents/.
-export async function ensureAgentDir(agentName: string): Promise<string> {
+// Accepts an already-normalised key (from agentDirKey or safeAgentSlug) — does NOT
+// re-slug, so the threadId suffix is preserved. Verifies the result stays under agents/.
+export async function ensureAgentDir(key: string): Promise<string> {
+  if (!/^[a-z0-9_-]+$/.test(key)) {
+    throw new Error(`Agent key "${key}" contains unsafe characters`);
+  }
   const agentsRoot = join(PROJECT_DIR, "agents");
-  const dir = join(agentsRoot, safeAgentSlug(agentName));
-  // Belt-and-suspenders: confirm we haven't escaped the agents/ root
+  const dir = join(agentsRoot, key);
   if (!resolve(dir).startsWith(resolve(agentsRoot) + sep)) {
     throw new Error(`Agent directory "${dir}" would escape the agents root — rejecting`);
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -407,6 +407,36 @@ export async function compactCurrentSession(agentName?: string): Promise<{ succe
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
+// Compact a Discord thread session by threadId. Uses getThreadSession (not getSession)
+// because Discord threads have their own session store. agentName is used only for cwd isolation.
+export async function compactCurrentThreadSession(
+  threadId: string,
+  agentName?: string
+): Promise<{ success: boolean; message: string }> {
+  const existing = await getThreadSession(threadId);
+  if (!existing) return { success: false, message: "No active session to compact." };
+
+  const settings = getSettings();
+  const securityArgs = buildSecurityArgs(settings.security);
+  const baseEnv = cleanSpawnEnv();
+  const timeoutMs = settings.sessionTimeoutMs;
+
+  const compactCwd = agentName ? await ensureAgentDir(agentName) : undefined;
+  const ok = await runCompact(
+    existing.sessionId,
+    settings.model,
+    settings.api,
+    baseEnv,
+    securityArgs,
+    timeoutMs,
+    compactCwd
+  );
+
+  return ok
+    ? { success: true, message: `✅ Thread session compact complete (${existing.sessionId.slice(0, 8)})` }
+    : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
+}
+
 async function execClaude(
   name: string,
   prompt: string,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { join } from "path";
+import { join, resolve, sep } from "path";
 import { existsSync } from "fs";
 import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
 import {
@@ -209,10 +209,28 @@ async function runClaudeOnce(
 
 const PROJECT_DIR = process.cwd();
 
+// Converts a raw agent/thread display name to a safe filesystem segment.
+// Only [a-z0-9_-] characters are allowed; spaces and other separators become hyphens.
+// Exported so callers can show the canonical form in UI before creating the directory.
+export function safeAgentSlug(raw: string): string {
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  if (!slug) throw new Error(`Agent name "${raw}" cannot be converted to a safe path segment`);
+  return slug;
+}
+
 // Returns the working directory for a named agent's Claude spawn.
-// The agent directory is created on first use so the spawn never fails on a missing cwd.
+// Sanitizes the name and verifies the result stays under PROJECT_DIR/agents/.
 export async function ensureAgentDir(agentName: string): Promise<string> {
-  const dir = join(PROJECT_DIR, "agents", agentName);
+  const agentsRoot = join(PROJECT_DIR, "agents");
+  const dir = join(agentsRoot, safeAgentSlug(agentName));
+  // Belt-and-suspenders: confirm we haven't escaped the agents/ root
+  if (!resolve(dir).startsWith(resolve(agentsRoot) + sep)) {
+    throw new Error(`Agent directory "${dir}" would escape the agents root — rejecting`);
+  }
   await mkdir(dir, { recursive: true });
   return dir;
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -251,10 +251,16 @@ export async function ensureAgentDir(name: string): Promise<string> {
     throw new Error(`Agent directory "${dir}" would escape the agents root — rejecting`);
   }
   await mkdir(dir, { recursive: true });
-  // Post-mkdir realpath check: resolves symlinks so a symlinked agent directory
-  // that points outside agents/ is caught even if it passed the lexical check.
-  const realDir = await realpath(dir);
+  // Post-mkdir realpath checks resolve symlinks at every level.
+  // We verify two things:
+  //   1. agents/ itself resolves inside PROJECT_DIR (catches a symlinked agents/ root)
+  //   2. agents/<name> resolves inside agents/ (catches a symlinked individual agent dir)
+  const realProjectDir = await realpath(PROJECT_DIR);
   const realRoot = await realpath(agentsRoot);
+  const realDir = await realpath(dir);
+  if (!realRoot.startsWith(realProjectDir + sep)) {
+    throw new Error(`agents/ root "${realRoot}" resolves outside the project directory via symlink — rejecting`);
+  }
   if (!realDir.startsWith(realRoot + sep)) {
     throw new Error(`Agent directory "${realDir}" resolves outside the agents root via symlink — rejecting`);
   }


### PR DESCRIPTION
## Summary

Follow-up to #136. Implements per-agent plugin isolation so that plugins installed with `-s project` scope land in and are resolved from the individual agent's directory, not the shared deployment root.

- **`runner.ts`**: Named agent spawns now use `agents/<name>/` as their working directory. `ensureAgentDir(agentName)` creates the directory on first use. Claude Code resolves `.claude/plugins/` and `.claude/skills/` relative to `cwd`, so plugins installed per-agent are visible only to that agent.
- **`plugin-cli.ts`**: `runPluginCli` accepts an optional `cwd` to scope the install subprocess.
- **`plugin-wizard.ts`**: When an `agentName` is known, the scope prompt shows `agents/<name>/.claude/plugins/` for option 2. The install-confirm step passes the agent's directory as `cwd` so the install lands in the right place. Confirmation message reports the actual install location.
- **`discord.ts`**: `knownThreads` extended to store `agentName` alongside `parentId`. Populated at thread creation (hire flow) and on gateway events: `THREAD_CREATE`, `THREAD_UPDATE`, `THREAD_LIST_SYNC`. The wizard context now carries `agentName` for any thread with a known name.

Telegram has no agent-threading concept and is intentionally unchanged.

## Test plan

- [ ] `bun test` — 61 tests pass, 0 fail
- [ ] `bunx tsc --noEmit` — clean
- [ ] Manual: hire an agent thread in Discord, open `/plugin` in that thread → scope prompt shows `agents/<name>/`
- [ ] Manual: install with project scope in an agent thread → plugin lands in `agents/<name>/.claude/plugins/`
- [ ] Manual: global session DM → scope prompt shows `.claude/plugins/` (no agent scoping)
- [ ] Manual: named agent Claude spawn uses `agents/<name>/` as cwd — existing session, job, heartbeat behaviour unchanged