### PR TITLE
fix(discord): null-safe optional chaining on message.mentions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -281,7 +281,7 @@ function guildTriggerReason(message: DiscordMessage): string | null {
   if (botUserId && message.referenced_message?.author?.id === botUserId) return "reply_to_bot";
 
   // Mention via mentions array
-  if (botUserId && message.mentions.some((m) => m.id === botUserId)) return "mention";
+  if (botUserId && message.mentions?.some((m) => m.id === botUserId)) return "mention";
 
   // Mention in content (fallback)
   if (botUserId && message.content.includes(`<@${botUserId}>`)) return "mention_in_content";


### PR DESCRIPTION
Closes #88 — narrow version addressing TerrysPOV's review feedback.

## What changed

Single character fix: `message.mentions.some(...)` → `message.mentions?.some(...)` in `guildTriggerReason()`.

Discord gateway `MESSAGE_CREATE` events occasionally omit the `mentions` array entirely. The missing property caused an uncaught `TypeError` that put systemd-managed daemons into a restart loop.

## What was dropped from #88

- **`sessionTimeoutMs` changes** — already present on current master via the `parseSettings` work merged with #129. Carrying them forward would be a no-op at best and a conflict at worst.
- **`.gitignore` change** — the original PR had a missing newline that produced `AGENTS.md__pycache__/` as a single entry, which would corrupt `.gitignore`.

## Verification

`bunx tsc --noEmit` passes on this branch.