### PR TITLE
fix(runner): prevent memory leaks causing OOM in long-running daemons

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -98,6 +98,8 @@ const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
 // Global queue for non-thread messages (backward compatible)
+// Reset to a fresh resolved promise after each task to avoid holding
+// references to every previous result (memory leak).
 let globalQueue: Promise<unknown> = Promise.resolve();
 // Per-thread queues — each thread runs independently in parallel
 const threadQueues = new Map<string, Promise<unknown>>();
@@ -106,11 +108,11 @@ function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
   if (threadId) {
     const current = threadQueues.get(threadId) ?? Promise.resolve();
     const task = current.then(fn, fn);
-    threadQueues.set(threadId, task.catch(() => {}));
+    threadQueues.set(threadId, task.then(() => {}, () => {}));
     return task;
   }
   const task = globalQueue.then(fn, fn);
-  globalQueue = task.catch(() => {});
+  globalQueue = task.then(() => {}, () => {});
   return task;
 }
 
@@ -153,6 +155,44 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
   return childEnv;
 }
 
+// Cap stdout/stderr to prevent unbounded memory growth.
+// 10 MB is far beyond any real Claude response; protects against runaway streams only.
+const MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+async function collectStream(stream: ReadableStream<Uint8Array>, maxBytes: number): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (totalBytes < maxBytes) {
+        const space = maxBytes - totalBytes;
+        if (value.byteLength <= space) {
+          chunks.push(value);
+          totalBytes += value.byteLength;
+        } else {
+          chunks.push(value.subarray(0, space));
+          totalBytes = maxBytes;
+          // cap reached — keep draining without storing so the child process isn't blocked
+        }
+      }
+      // beyond cap: read and discard to keep the pipe flowing
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+
 async function runClaudeOnce(
   baseArgs: string[],
   model: string,
@@ -172,18 +212,21 @@ async function runClaudeOnce(
     ...(cwd ? { cwd } : {}),
   });
 
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+    timeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
   });
 
   try {
     const [rawStdout, stderr] = await Promise.race([
       Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+        collectStream(proc.stdout as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
+        collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
       ]),
       timeoutPromise,
     ]) as [string, string];
+
+    if (timeoutId) clearTimeout(timeoutId);
     await proc.exited;
 
     return {
@@ -192,6 +235,7 @@ async function runClaudeOnce(
       exitCode: proc.exitCode ?? 1,
     };
   } catch (err) {
+    if (timeoutId) clearTimeout(timeoutId);
     // Kill the hung process
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
@@ -263,11 +307,12 @@ async function runClaudeStream(
   };
 
   const readStderr = async () => {
-    stderr = await new Response(proc.stderr).text();
+    stderr = await collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES);
   };
 
+  let streamJsonTimeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+    streamJsonTimeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
   });
 
   try {
@@ -275,9 +320,11 @@ async function runClaudeStream(
       Promise.all([readStdout(), readStderr()]),
       timeoutPromise,
     ]);
+    if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
     await proc.exited;
     return { rawStdout: resultText, stderr: stderr.trim(), exitCode: proc.exitCode ?? 1, sessionId };
   } catch (err) {
+    if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Closes #67 — addresses TerrysPOV's review feedback.

## Changes

**Queue chain reference reset** — `task.catch(() => {})` → `task.then(() => {}, () => {})` in both `globalQueue` and `threadQueues`. The catch form passes through fulfilled values, keeping a reference chain to every prior task result and preventing GC from reclaiming them.

**Timer cleanup** — `clearTimeout(timeoutId)` called in both success and error paths of `runClaudeOnce`. The original code left the timer live after the race resolved, leaking a timer reference per invocation.

**Capped stream collection with pipe drain** — replaces unbounded `new Response(proc.stdout).text()` in both execution paths (`runClaudeOnce` and the stream-json path added in #139). The `collectStream` helper caps output at 10 MB, but unlike the original PR #67 implementation, it **continues reading and discarding** after the cap rather than breaking. Breaking left the child blocked on a full pipe with no timeout left to recover — this version drains the pipe so the child exits normally.

The stream-json `readStderr` path (added after #67 was submitted) had the same unbounded read and an unprotected timeout, so both are fixed here for consistency.

## Background

In production (24/7 systemd daemon), these leaks caused the bun process to grow from ~43 MB to 23 GB over several days before OOM kill. After applying fixes, memory stays stable at ~43 MB.