### PR TITLE
fix(runner): per-agent fallback sessions with persistent context

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/__tests__/messaging.test.ts
+++ b/src/__tests__/messaging.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "bun:test";
+import { extractErrorDetail } from "../messaging";
+
+describe("extractErrorDetail", () => {
+  test("prefers stderr over stdout", () => {
+    expect(extractErrorDetail({ stdout: "some output", stderr: "auth error" })).toBe("auth error");
+  });
+
+  test("parses JSON stdout error when stderr is empty", () => {
+    const stdout = JSON.stringify({ is_error: true, result: "Rate limit exceeded" });
+    expect(extractErrorDetail({ stdout, stderr: "" })).toBe("Rate limit exceeded");
+  });
+
+  test("falls back to raw stdout when not JSON and no stderr", () => {
+    expect(extractErrorDetail({ stdout: "plain error text", stderr: "" })).toBe("plain error text");
+  });
+});

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,7 +1,7 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
-import { resetSession, peekSession } from "../sessions";
+import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -738,6 +738,7 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
 
     if (interaction.data.name === "reset") {
       await resetSession();
+      await resetFallbackSession();
       await respondToInteraction(interaction, {
         content: "Global session reset. Next message starts fresh.",
       });

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,4 +1,5 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
+import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
@@ -696,7 +697,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt, threadId, threadInfo?.agentName);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stdout || result.stderr || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,4 +1,5 @@
 import { writeFile, unlink, mkdir } from "fs/promises";
+import { extractErrorDetail } from "../messaging";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
@@ -520,7 +521,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -532,7 +533,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,7 +1,7 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
-import { resetSession, peekSession } from "../sessions";
+import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -625,6 +625,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
   if (command === "/reset") {
     await resetSession();
+    await resetFallbackSession();
     await sendMessage(config.token, chatId, "Global session reset. Next message starts fresh.", threadId);
     return;
   }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,5 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
+import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
@@ -847,7 +848,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const result = await runUserMessage("telegram", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`, threadId);
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
       const { cleanedText, filePaths } = extractSendFileDirectives(afterReact);

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,23 @@
+/**
+ * Extract a user-facing error detail from a Claude CLI run result.
+ *
+ * Claude CLI sometimes returns human-readable auth/quota failures in JSON
+ * stdout instead of stderr. Prefer stderr when present, otherwise parse the
+ * JSON stdout payload and fall back to raw stdout text.
+ */
+export function extractErrorDetail(result: { stdout: string; stderr: string }): string {
+  const stderr = result.stderr?.trim() || "";
+  if (stderr) return stderr;
+
+  const stdout = result.stdout?.trim() || "";
+  if (!stdout) return "";
+
+  try {
+    const parsed = JSON.parse(stdout);
+    if (parsed?.is_error && parsed?.result) return String(parsed.result).trim();
+    if (parsed?.error?.message) return String(parsed.error.message).trim();
+    if (typeof parsed?.error === "string") return parsed.error.trim();
+  } catch {}
+
+  return stdout;
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -740,7 +740,7 @@ async function execClaude(
   // Capture session ID from stream events and persist for new sessions.
   // Gate only on isNew + sessionId present — not on exitCode, so a session that timed
   // out mid-run is still persisted and can be resumed on the next message.
-  if (!rateLimitMessage && isNew && exec.sessionId) {
+  if (!rateLimitMessage && isNew && exec.sessionId && !usedFallback) {
     sessionId = exec.sessionId;
     if (threadId) {
       await createThreadSession(threadId, sessionId);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,15 @@
 import { mkdir, readFile, writeFile, realpath } from "fs/promises";
 import { join, resolve, sep } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
+import {
+  getSession,
+  createSession,
+  incrementTurn,
+  markCompactWarned,
+  getFallbackSession,
+  createFallbackSession,
+  incrementFallbackTurn,
+} from "./sessions";
 import {
   getThreadSession,
   createThreadSession,
@@ -691,8 +699,26 @@ async function execClaude(
     console.warn(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    exec = await runClaudeStream(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs, spawnCwd);
+    const fallbackSession = await getFallbackSession(agentName);
+    const fallbackArgs = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+    if (fallbackSession) {
+      fallbackArgs.push("--resume", fallbackSession.sessionId);
+    }
+    if (appendParts.length > 0) {
+      fallbackArgs.push("--append-system-prompt", appendParts.join("\n\n"));
+    }
+    exec = await runClaudeStream(fallbackArgs, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs, spawnCwd);
     usedFallback = true;
+    const fallbackRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
+    if (!fallbackRateLimit) {
+      if (!fallbackSession && exec.sessionId) {
+        await createFallbackSession(exec.sessionId, agentName);
+        const label = agentName ? ` (agent ${agentName})` : "";
+        console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${exec.sessionId}${label}`);
+      } else if (fallbackSession) {
+        await incrementFallbackTurn(agentName);
+      }
+    }
   }
 
   const rawStdout = exec.rawStdout;

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -103,6 +103,69 @@ export async function resetSession(agentName?: string): Promise<void> {
   }
 }
 
+// --- Fallback session management ---
+// Fallback sessions are stored alongside primary sessions but keyed separately.
+// They persist across rate-limit events so the fallback provider accumulates context.
+
+const FALLBACK_SESSION_FILE = join(HEARTBEAT_DIR, "session_fallback.json");
+
+function fallbackSessionPathFor(agentName?: string): string {
+  if (agentName) return join(getAgentsDir(), agentName, "session_fallback.json");
+  return FALLBACK_SESSION_FILE;
+}
+
+async function loadFallbackSession(agentName?: string): Promise<GlobalSession | null> {
+  try {
+    return await Bun.file(fallbackSessionPathFor(agentName)).json();
+  } catch {
+    return null;
+  }
+}
+
+async function saveFallbackSession(session: GlobalSession, agentName?: string): Promise<void> {
+  await Bun.write(fallbackSessionPathFor(agentName), JSON.stringify(session, null, 2) + "\n");
+}
+
+export async function getFallbackSession(
+  agentName?: string
+): Promise<{ sessionId: string; turnCount: number } | null> {
+  const existing = await loadFallbackSession(agentName);
+  if (existing) {
+    if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+    existing.lastUsedAt = new Date().toISOString();
+    await saveFallbackSession(existing, agentName);
+    return { sessionId: existing.sessionId, turnCount: existing.turnCount };
+  }
+  return null;
+}
+
+export async function createFallbackSession(sessionId: string, agentName?: string): Promise<void> {
+  await saveFallbackSession({
+    sessionId,
+    createdAt: new Date().toISOString(),
+    lastUsedAt: new Date().toISOString(),
+    turnCount: 0,
+    compactWarned: false,
+  }, agentName);
+}
+
+export async function incrementFallbackTurn(agentName?: string): Promise<number> {
+  const existing = await loadFallbackSession(agentName);
+  if (!existing) return 0;
+  if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+  existing.turnCount += 1;
+  await saveFallbackSession(existing, agentName);
+  return existing.turnCount;
+}
+
+export async function resetFallbackSession(agentName?: string): Promise<void> {
+  try {
+    await unlink(fallbackSessionPathFor(agentName));
+  } catch {
+    // already gone
+  }
+}
+
 export async function backupSession(): Promise<string | null> {
   const existing = await loadSession();
   if (!existing) return null;


### PR DESCRIPTION
## Problem

When the primary Claude provider is rate-limited, the fallback retried using the same `args` array — which included `--resume <primary-session-id>`. The fallback provider has no knowledge of that session ID, so it either errored or silently started a fresh session while discarding context.

Additionally, error messages surfaced to users via Telegram/Discord were always drawn from stderr, but Claude CLI sometimes writes structured error details (auth failures, quota messages) into stdout in JSON format instead.

## Changes

**Per-agent fallback sessions (`sessions.ts`)**

Adds `getFallbackSession`, `createFallbackSession`, `incrementFallbackTurn`, and `resetFallbackSession`, all scoped per-agent, mirroring the existing primary session pattern. Fallback sessions persist across rate-limit events so the fallback provider accumulates context (same as primary).

**Rewritten fallback block (`runner.ts`)**

When falling back:
- Builds a fresh `fallbackArgs` array (no primary `--resume` ID)
- Loads the existing fallback session for the agent (if any) and resumes it, or starts a new one
- Persists/increments the fallback session after a successful fallback run
- Imports `getFallbackSession`, `createFallbackSession`, `incrementFallbackTurn` from sessions

**`extractErrorDetail` (`messaging.ts`)**

New helper that accepts `{ stdout, stderr }` and returns the most useful error string: prefers stderr, then tries to parse JSON stdout for structured error fields (`is_error`/`result`, `error.message`, `error`), falls back to raw stdout. Three unit tests in `src/__tests__/messaging.test.ts`.

**Error forwarding (`start.ts`, `discord.ts`, `telegram.ts`)**

Replaces `result.stderr || "Unknown"` and `result.stdout || result.stderr || "Unknown error"` with `extractErrorDetail(result) || "Unknown [error]"` at all four error-reporting sites.

## Addresses

Closes #76