### PR TITLE
feat: daemon-level plugin system with OpenClaw-compatible API

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  PluginManager,
+  getPluginManager,
+  setPluginManager,
+  parsePlugins,
+  type EventContext,
+  type PluginApi,
+} from "../plugins";
+
+const ctx: EventContext = { workspaceDir: "/tmp/test" };
+
+describe("parsePlugins", () => {
+  it("returns empty object for null/undefined", () => {
+    expect(parsePlugins(null)).toEqual({});
+    expect(parsePlugins(undefined)).toEqual({});
+    expect(parsePlugins("string")).toEqual({});
+  });
+
+  it("parses a valid plugin entry", () => {
+    const result = parsePlugins({
+      "claude-mem": { enabled: true, source: "openclaw", config: { workerPort: 37777 } },
+    });
+    expect(result["claude-mem"]).toEqual({
+      enabled: true,
+      source: "openclaw",
+      config: { workerPort: 37777 },
+    });
+  });
+
+  it("defaults enabled to false and source to openclaw", () => {
+    const result = parsePlugins({ "my-plugin": {} });
+    expect(result["my-plugin"].enabled).toBe(false);
+    expect(result["my-plugin"].source).toBe("openclaw");
+    expect(result["my-plugin"].config).toEqual({});
+  });
+
+  it("trims source string", () => {
+    const result = parsePlugins({ p: { source: "  my-source  " } });
+    expect(result["p"].source).toBe("my-source");
+  });
+
+  it("skips non-object entries", () => {
+    const result = parsePlugins({ bad: "not-an-object", good: { enabled: true, source: "x", config: {} } });
+    expect(result["bad"]).toBeUndefined();
+    expect(result["good"]).toBeDefined();
+  });
+});
+
+describe("PluginManager singleton", () => {
+  beforeEach(() => {
+    setPluginManager(null);
+  });
+
+  it("starts as null", () => {
+    expect(getPluginManager()).toBeNull();
+  });
+
+  it("setPluginManager / getPluginManager round-trip", () => {
+    const pm = new PluginManager("/tmp");
+    setPluginManager(pm);
+    expect(getPluginManager()).toBe(pm);
+    setPluginManager(null);
+    expect(getPluginManager()).toBeNull();
+  });
+});
+
+describe("PluginManager event system", () => {
+  let pm: PluginManager;
+
+  beforeEach(() => {
+    pm = new PluginManager("/tmp/test");
+  });
+
+  it("emit returns undefined when no handlers registered", async () => {
+    const result = await pm.emit("agent_end", {}, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("on/emit: handler receives data and ctx", async () => {
+    let received: { data: unknown; ctx: EventContext } | null = null;
+    let api: PluginApi | null = null;
+
+    // Register a plugin manually via the internal api
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("test-plugin", {});
+    api = internalApi;
+    internalApi.on("agent_end", (data, c) => {
+      received = { data, ctx: c };
+    });
+
+    await pm.emit("agent_end", { messages: ["hello"] }, ctx);
+    expect(received).not.toBeNull();
+    expect((received!.data as { messages: unknown[] }).messages).toEqual(["hello"]);
+    expect(received!.ctx).toBe(ctx);
+    expect(api).not.toBeNull();
+  });
+
+  it("before_prompt_build merges appendSystemContext from multiple handlers", async () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p1", {});
+    internalApi.on("before_prompt_build", () => ({ appendSystemContext: "context-a" }));
+
+    const internalApi2 = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p2", {});
+    internalApi2.on("before_prompt_build", () => ({ appendSystemContext: "context-b" }));
+
+    const result = await pm.emit("before_prompt_build", { prompt: "test" }, ctx);
+    expect(result?.appendSystemContext).toBe("context-a\n\ncontext-b");
+  });
+
+  it("before_prompt_build returns undefined when no handler returns appendSystemContext", async () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.on("before_prompt_build", () => ({}));
+
+    const result = await pm.emit("before_prompt_build", {}, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("emitAsync does not throw synchronously even when handler throws", () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.on("agent_end", () => { throw new Error("boom"); });
+    // Must not throw — error is logged via console.warn
+    expect(() => pm.emitAsync("agent_end", {}, ctx)).not.toThrow();
+  });
+
+  it("emitAsync is fire-and-forget (returns void)", () => {
+    const result = pm.emitAsync("agent_end", {}, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("handler errors in emit are swallowed and do not abort subsequent handlers", async () => {
+    let secondCalled = false;
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p1", {});
+    internalApi.on("agent_end", () => { throw new Error("handler error"); });
+
+    const internalApi2 = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p2", {});
+    internalApi2.on("agent_end", () => { secondCalled = true; });
+
+    await pm.emit("agent_end", {}, ctx);
+    expect(secondCalled).toBe(true);
+  });
+});
+
+describe("PluginManager commands", () => {
+  let pm: PluginManager;
+
+  beforeEach(() => {
+    pm = new PluginManager("/tmp/test");
+  });
+
+  it("runCommand returns null for unknown command", async () => {
+    expect(await pm.runCommand("unknown")).toBeNull();
+  });
+
+  it("registerCommand/runCommand round-trip", async () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.registerCommand({ name: "hello", handler: async () => "world" });
+
+    expect(await pm.runCommand("hello")).toBe("world");
+    expect(pm.getCommandNames()).toContain("hello");
+  });
+});
+
+describe("PluginManager services", () => {
+  let pm: PluginManager;
+
+  beforeEach(() => {
+    pm = new PluginManager("/tmp/test");
+  });
+
+  it("startServices/stopServices do not throw when no services registered", async () => {
+    await expect(pm.startServices()).resolves.toBeUndefined();
+    await expect(pm.stopServices()).resolves.toBeUndefined();
+  });
+
+  it("registerService start/stop called", async () => {
+    let started = false;
+    let stopped = false;
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.registerService({
+      id: "my-service",
+      start: async () => { started = true; },
+      stop: async () => { stopped = true; },
+    });
+
+    await pm.startServices();
+    expect(started).toBe(true);
+
+    await pm.stopServices();
+    expect(stopped).toBe(true);
+  });
+});
+
+describe("PluginManager info", () => {
+  it("hasPlugins is false with no loaded plugins", () => {
+    const pm = new PluginManager("/tmp");
+    expect(pm.hasPlugins).toBe(false);
+    expect(pm.loaded).toEqual([]);
+  });
+});
+
+describe("PluginManager path resolution (security)", () => {
+  it("rejects relative-segment source strings (path traversal guard)", async () => {
+    const pm = new PluginManager("/tmp/test");
+    // loadPlugin will call resolvePluginPath which should return null for traversal attempts
+    const resolvePluginPath = (pm as unknown as {
+      resolvePluginPath: (id: string, source: string) => string | null;
+    }).resolvePluginPath.bind(pm);
+
+    expect(resolvePluginPath("p", "../../etc")).toBeNull();
+    expect(resolvePluginPath("p", "../evil")).toBeNull();
+    expect(resolvePluginPath("p", "valid-pkg")).toBeNull(); // null because file doesn't exist, not because of rejection
+  });
+
+  it("accepts valid npm package names", () => {
+    const pm = new PluginManager("/tmp/test");
+    const resolvePluginPath = (pm as unknown as {
+      resolvePluginPath: (id: string, source: string) => string | null;
+    }).resolvePluginPath.bind(pm);
+
+    // These return null only because the files don't exist, not due to validation failure
+    // We verify resolvePluginPath doesn't throw and returns null (not a hard error)
+    expect(() => resolvePluginPath("p", "my-plugin")).not.toThrow();
+    expect(() => resolvePluginPath("p", "@scope/my-plugin")).not.toThrow();
+  });
+
+  it("checkHealth rejects invalid host strings", async () => {
+    const pm = new PluginManager("/tmp/test");
+    const checkHealth = (pm as unknown as {
+      checkHealth: (host: string, port: number) => Promise<boolean>;
+    }).checkHealth.bind(pm);
+
+    expect(await checkHealth("127.0.0.1/admin#", 8080)).toBe(false);
+    expect(await checkHealth("user@evil.com", 8080)).toBe(false);
+    expect(await checkHealth("", 8080)).toBe(false);
+    expect(await checkHealth("127.0.0.1", 0)).toBe(false);
+    expect(await checkHealth("127.0.0.1", 99999)).toBe(false);
+  });
+});

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -11,6 +11,7 @@ import { getDayAndMinuteAtOffset } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
 import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
+import { PluginManager, setPluginManager } from "../plugins";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -332,7 +333,18 @@ export async function start(args: string[] = []) {
   let web: WebServerHandle | null = null;
   let discordStopGateway: (() => void) | null = null;
 
+  // Plugin system — initialize before gateway start
+  const pluginManager = new PluginManager(process.cwd());
+  if (Object.keys(settings.plugins).length > 0) {
+    await pluginManager.loadAll(settings.plugins);
+    await pluginManager.startServices();
+    await pluginManager.emit("gateway_start", {}, { workspaceDir: process.cwd() });
+    setPluginManager(pluginManager);
+  }
+
   async function shutdown() {
+    await pluginManager.stopServices();
+    setPluginManager(null);
     if (discordStopGateway) discordStopGateway();
     if (web) web.stop();
     await teardownStatusline();
@@ -407,6 +419,22 @@ export async function start(args: string[] = []) {
 
   await initDiscord(currentSettings.discord.token);
   if (!discordToken) console.log("  Discord: not configured");
+
+  // Wire channel senders into plugin runtime so plugins can send messages
+  if (pluginManager.hasPlugins) {
+    pluginManager.setChannelSenders({
+      telegram: {
+        sendMessageTelegram: telegramSend
+          ? (chatId: number, text: string) => telegramSend!(chatId, text)
+          : () => Promise.resolve(),
+      },
+      discord: {
+        sendMessageDiscord: discordSendToUser
+          ? (userId: string, text: string) => discordSendToUser!(userId, text)
+          : () => Promise.resolve(),
+      },
+    });
+  }
 
   function isAddrInUse(err: unknown): boolean {
     if (!err || typeof err !== "object") return false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
 import { parseWatchdogConfig, type WatchdogConfig } from "./watchdog";
+import { parsePlugins, type PluginEntry } from "./plugins";
 
 /** Re-exported under the name used in the Settings interface. */
 export type WatchdogSettings = WatchdogConfig;
@@ -82,6 +83,7 @@ const DEFAULT_SETTINGS: Settings = {
   stt: { baseUrl: "", model: "" },
   sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
+  plugins: {},
 };
 
 export interface HeartbeatExcludeWindow {
@@ -137,6 +139,7 @@ export interface Settings {
   stt: SttConfig;
   sessionTimeoutMs: number;
   watchdog: WatchdogSettings;
+  plugins: Record<string, PluginEntry>;
   jobsDir?: string;
 }
 
@@ -310,6 +313,7 @@ function parseSettings(
       ? raw.sessionTimeoutMs
       : DEFAULT_SESSION_TIMEOUT_MS,
     watchdog: parseWatchdogConfig(raw.watchdog),
+    plugins: parsePlugins(raw.plugins),
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,358 @@
+/**
+ * ClaudeClaw Daemon Plugin System
+ *
+ * Provides an OpenClaw-compatible Plugin API for daemon-level plugins.
+ * Plugins hook into lifecycle events that fire AROUND Claude Code invocations
+ * (not inside them — that's handled by Claude Code's native plugin system).
+ *
+ * Usage in settings.json:
+ *   "plugins": {
+ *     "claude-mem": {
+ *       "enabled": true,
+ *       "source": "openclaw",
+ *       "config": { "workerPort": 37777, "project": "myproject" }
+ *     }
+ *   }
+ */
+
+import { join, isAbsolute, resolve } from "path";
+import { existsSync } from "fs";
+
+// ── Event types ──────────────────────────────────────────────────────────────
+
+export type DaemonEvent =
+  | "gateway_start"
+  | "session_start"
+  | "before_agent_start"
+  | "before_prompt_build"
+  | "tool_result_persist"
+  | "agent_end"
+  | "session_end"
+  | "message_received"
+  | "after_compaction";
+
+export interface EventContext {
+  sessionKey?: string;
+  conversationId?: string;
+  channelId?: string;
+  agentId?: string;
+  workspaceDir?: string;
+}
+
+export type EventHandler = (data: unknown, ctx: EventContext) => Promise<unknown> | unknown;
+
+// ── Plugin API types ─────────────────────────────────────────────────────────
+
+export interface PluginService {
+  id: string;
+  start: (ctx: unknown) => Promise<void>;
+  stop: (ctx: unknown) => Promise<void>;
+}
+
+export interface PluginCommand {
+  name: string;
+  description?: string;
+  acceptsArgs?: boolean;
+  handler: (ctx: unknown) => Promise<unknown>;
+}
+
+export interface PluginApi {
+  on(event: string, handler: EventHandler): void;
+  registerService(service: PluginService): void;
+  registerCommand(cmd: PluginCommand): void;
+  runtime: {
+    channel: Record<string, Record<string, (...args: unknown[]) => unknown>>;
+  };
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+    debug: (...args: unknown[]) => void;
+  };
+  pluginConfig: Record<string, unknown>;
+}
+
+export type PluginInitFn = (api: PluginApi) => void | Promise<void>;
+
+// ── Settings types ───────────────────────────────────────────────────────────
+
+export interface PluginEntry {
+  enabled: boolean;
+  /** "openclaw" | npm package name | absolute path to plugin dir */
+  source: string;
+  config: Record<string, unknown>;
+}
+
+// ── Plugin Manager ───────────────────────────────────────────────────────────
+
+export class PluginManager {
+  private handlers = new Map<string, EventHandler[]>();
+  private services = new Map<string, PluginService>();
+  private commands = new Map<string, PluginCommand>();
+  private channelRuntime: Record<string, Record<string, (...args: unknown[]) => unknown>> = {};
+  private workspaceDir: string;
+  private loadedPlugins: string[] = [];
+
+  constructor(workspaceDir: string) {
+    this.workspaceDir = workspaceDir;
+  }
+
+  // ── Loading ────────────────────────────────────────────────────────────
+
+  async loadAll(plugins: Record<string, PluginEntry>): Promise<void> {
+    for (const [id, entry] of Object.entries(plugins)) {
+      if (!entry.enabled) continue;
+      try {
+        await this.loadPlugin(id, entry);
+      } catch (err) {
+        console.error(`[${ts()}] [plugins] Failed to load "${id}":`, err);
+      }
+    }
+  }
+
+  private async loadPlugin(id: string, entry: PluginEntry): Promise<void> {
+    const source = entry.source || "openclaw";
+
+    // For openclaw-source plugins, check worker health first
+    if (source === "openclaw" && entry.config?.workerPort) {
+      const host = (entry.config.workerHost as string) || "127.0.0.1";
+      const port = entry.config.workerPort as number;
+      const healthy = await this.checkHealth(host, port);
+      if (!healthy) {
+        console.warn(`[${ts()}] [plugins] ${id}: worker not running on ${host}:${port}, skipping`);
+        return;
+      }
+    }
+
+    const modulePath = this.resolvePluginPath(id, source);
+    if (!modulePath) {
+      console.warn(`[${ts()}] [plugins] ${id}: could not resolve module (source: ${source})`);
+      return;
+    }
+
+    const api = this.buildApi(id, entry.config || {});
+    const mod = await import(modulePath);
+    const initFn: PluginInitFn = mod.default || mod;
+    if (typeof initFn !== "function") {
+      console.warn(`[${ts()}] [plugins] ${id}: module does not export a function`);
+      return;
+    }
+
+    await initFn(api);
+    this.loadedPlugins.push(id);
+    console.log(`[${ts()}] [plugins] ${id}: loaded (source: ${source})`);
+  }
+
+  private resolvePluginPath(id: string, source: string): string | null {
+    const candidates: string[] = [];
+
+    if (isAbsolute(source)) {
+      const safe = resolve(source);
+      candidates.push(
+        join(safe, "openclaw", "dist", "index.js"),
+        join(safe, "dist", "index.js"),
+        join(safe, "index.js"),
+      );
+    } else if (source === "openclaw") {
+      candidates.push(
+        join(this.workspaceDir, ".claude", "claudeclaw", id, "openclaw", "dist", "index.js"),
+        join(this.workspaceDir, "node_modules", id, "openclaw", "dist", "index.js"),
+        join(process.env.HOME || "", ".openclaw", "extensions", id, "dist", "index.js"),
+      );
+    } else {
+      // Validate npm package name to prevent path traversal via relative segments
+      if (!/^(@[a-z0-9-]+\/)?[a-z0-9][a-z0-9._-]*$/.test(source)) return null;
+      candidates.push(
+        join(this.workspaceDir, "node_modules", source, "dist", "index.js"),
+        join(this.workspaceDir, "node_modules", source, "index.js"),
+      );
+    }
+
+    for (const p of candidates) {
+      if (existsSync(p)) return p;
+    }
+    return null;
+  }
+
+  private async checkHealth(host: string, port: number): Promise<boolean> {
+    // Validate host: hostname chars or IPv6 bracket notation only (no userinfo, paths, etc.)
+    if (!/^[a-zA-Z0-9.\-]+$|^\[[0-9a-fA-F:]+\]$/.test(host)) return false;
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return false;
+    try {
+      const url = new URL(`http://${host}:${port}/api/health`);
+      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private buildApi(pluginId: string, config: Record<string, unknown>): PluginApi {
+    const self = this;
+    return {
+      on(event: string, handler: EventHandler) {
+        const list = self.handlers.get(event) || [];
+        list.push(handler);
+        self.handlers.set(event, list);
+        console.log(`[${ts()}] [plugins] ${pluginId} subscribed to: ${event}`);
+      },
+      registerService(service: PluginService) {
+        self.services.set(service.id, service);
+      },
+      registerCommand(cmd: PluginCommand) {
+        self.commands.set(cmd.name, cmd);
+      },
+      runtime: {
+        channel: self.channelRuntime,
+      },
+      logger: {
+        info: (...args: unknown[]) => console.log(`[${ts()}] [${pluginId}]`, ...args),
+        warn: (...args: unknown[]) => console.warn(`[${ts()}] [${pluginId}]`, ...args),
+        error: (...args: unknown[]) => console.error(`[${ts()}] [${pluginId}]`, ...args),
+        debug: () => {},
+      },
+      pluginConfig: config,
+    };
+  }
+
+  // ── Services ───────────────────────────────────────────────────────────
+
+  async startServices(): Promise<void> {
+    for (const [id, service] of this.services) {
+      try {
+        await service.start({});
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Service ${id} failed to start:`, err);
+      }
+    }
+  }
+
+  async stopServices(): Promise<void> {
+    for (const [, service] of this.services) {
+      try {
+        await service.stop({});
+      } catch {}
+    }
+  }
+
+  // ── Channel runtime ────────────────────────────────────────────────────
+
+  setChannelSenders(senders: Record<string, Record<string, (...args: unknown[]) => unknown>>): void {
+    Object.assign(this.channelRuntime, senders);
+  }
+
+  // ── Event emission ─────────────────────────────────────────────────────
+
+  /**
+   * Emit an event and await all handlers.
+   * For `before_prompt_build`, collects and merges all `appendSystemContext` values.
+   * For other events, returns the last handler's result.
+   */
+  async emit(event: DaemonEvent, data: unknown, ctx: EventContext): Promise<{ appendSystemContext?: string } | undefined> {
+    const handlers = this.handlers.get(event);
+    if (!handlers || handlers.length === 0) return undefined;
+
+    if (event === "before_prompt_build") {
+      const contexts: string[] = [];
+      for (const handler of handlers) {
+        try {
+          const result = await handler(data, ctx) as { appendSystemContext?: string } | undefined;
+          if (result?.appendSystemContext) {
+            contexts.push(result.appendSystemContext);
+          }
+        } catch (err) {
+          console.warn(`[${ts()}] [plugins] Event ${event} handler error:`, err);
+        }
+      }
+      return contexts.length > 0 ? { appendSystemContext: contexts.join("\n\n") } : undefined;
+    }
+
+    let result: unknown;
+    for (const handler of handlers) {
+      try {
+        result = await handler(data, ctx);
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Event ${event} handler error:`, err);
+      }
+    }
+    return result as { appendSystemContext?: string } | undefined;
+  }
+
+  /**
+   * Fire-and-forget emit — does not await handlers.
+   * Use for observations (tool_result_persist) and agent_end.
+   */
+  emitAsync(event: DaemonEvent, data: unknown, ctx: EventContext): void {
+    const handlers = this.handlers.get(event);
+    if (!handlers || handlers.length === 0) return;
+    for (const handler of handlers) {
+      try {
+        Promise.resolve(handler(data, ctx)).catch((err) => {
+          console.warn(`[${ts()}] [plugins] Async event ${event} error:`, err);
+        });
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Sync error in ${event} handler:`, err);
+      }
+    }
+  }
+
+  // ── Commands ───────────────────────────────────────────────────────────
+
+  async runCommand(name: string, args?: string): Promise<string | null> {
+    const cmd = this.commands.get(name);
+    if (!cmd) return null;
+    try {
+      const result = await cmd.handler({ args }) as string | { text?: string } | null | undefined;
+      return typeof result === "string" ? result : (result as { text?: string })?.text ?? JSON.stringify(result);
+    } catch {
+      return null;
+    }
+  }
+
+  getCommandNames(): string[] {
+    return Array.from(this.commands.keys());
+  }
+
+  // ── Info ────────────────────────────────────────────────────────────────
+
+  get loaded(): string[] {
+    return this.loadedPlugins;
+  }
+
+  get hasPlugins(): boolean {
+    return this.loadedPlugins.length > 0;
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let manager: PluginManager | null = null;
+
+export function getPluginManager(): PluginManager | null {
+  return manager;
+}
+
+export function setPluginManager(m: PluginManager | null): void {
+  manager = m;
+}
+
+// ── Config parser ────────────────────────────────────────────────────────────
+
+export function parsePlugins(raw: unknown): Record<string, PluginEntry> {
+  if (!raw || typeof raw !== "object") return {};
+  const result: Record<string, PluginEntry> = {};
+  for (const [id, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    result[id] = {
+      enabled: (e.enabled as boolean) ?? false,
+      source: typeof e.source === "string" ? e.source.trim() : "openclaw",
+      config: e.config && typeof e.config === "object" ? (e.config as Record<string, unknown>) : {},
+    };
+  }
+  return result;
+}
+
+function ts(): string {
+  return new Date().toLocaleTimeString();
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -12,6 +12,7 @@ import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type Securit
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
 import { recordResult, abortReason, clearSession, startSession } from "./watchdog";
+import { getPluginManager, type EventContext } from "./plugins";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
@@ -86,6 +87,15 @@ function emitCompactEvent(event: CompactEvent): void {
   for (const listener of compactListeners) {
     try { listener(event); } catch {}
   }
+}
+
+function pluginCtx(threadId?: string): EventContext {
+  return {
+    sessionKey: threadId || "global",
+    conversationId: threadId || "global",
+    channelId: threadId || "global",
+    workspaceDir: process.cwd(),
+  };
 }
 
 export interface RunResult {
@@ -522,6 +532,11 @@ async function execClaude(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
   );
 
+  // Plugins: before_agent_start — fired before Claude is invoked
+  const pm = getPluginManager();
+  const ctx = pluginCtx(threadId);
+  if (pm) await pm.emit("before_agent_start", { prompt }, ctx);
+
   // New session: use json output to capture Claude's session_id
   // Resumed session: use text output with --resume
   const outputFormat = isNew ? "json" : "text";
@@ -548,6 +563,12 @@ async function execClaude(
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
     }
+  }
+
+  // Plugins: before_prompt_build — lets plugins inject system context
+  if (pm) {
+    const pluginResult = await pm.emit("before_prompt_build", { prompt }, ctx);
+    if (pluginResult?.appendSystemContext) appendParts.push(pluginResult.appendSystemContext);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -608,6 +629,13 @@ async function execClaude(
     exitCode,
   };
 
+  // Plugins: agent_end — fire-and-forget, does not block response
+  if (pm && exitCode === 0) {
+    pm.emitAsync("agent_end", {
+      messages: [{ role: "assistant", content: stdout }],
+    }, ctx);
+  }
+
   const output = [
     `# ${name}`,
     `Date: ${new Date().toISOString()}`,
@@ -658,6 +686,7 @@ async function execClaude(
       spawnCwd
     );
     emitCompactEvent({ type: "auto-compact-done", success: compactOk });
+    if (compactOk && pm) pm.emitAsync("after_compaction", {}, ctx);
 
     if (compactOk) {
       console.log(`[${new Date().toLocaleTimeString()}] Retrying ${name} after compact...`);
@@ -725,6 +754,11 @@ async function streamClaude(
   const { security, model, api } = getSettings();
   const securityArgs = buildSecurityArgs(security);
 
+  // Plugins: before_agent_start
+  const streamPm = getPluginManager();
+  const streamCtx = pluginCtx();
+  if (streamPm) await streamPm.emit("before_agent_start", { prompt }, streamCtx);
+
   // stream-json gives us events as they happen — text before tool calls,
   // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
   // --verbose is required for stream-json to produce output in -p (print) mode.
@@ -741,6 +775,12 @@ async function streamClaude(
       const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
       if (claudeMd.trim()) appendParts.push(claudeMd.trim());
     } catch {}
+  }
+
+  // Plugins: before_prompt_build
+  if (streamPm) {
+    const pluginResult = await streamPm.emit("before_prompt_build", { prompt }, streamCtx);
+    if (pluginResult?.appendSystemContext) appendParts.push(pluginResult.appendSystemContext);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -809,6 +849,13 @@ async function streamClaude(
               hasActivity = true;
             } else if (block.type === "tool_use") {
               hasActivity = true;
+              if (streamPm && block.name) {
+                streamPm.emitAsync("tool_result_persist", {
+                  toolName: block.name,
+                  params: block.input ?? {},
+                  message: { content: [{ type: "text", text: JSON.stringify(block.input ?? {}).slice(0, 500) }] },
+                }, streamCtx);
+              }
             }
           }
           if (hasActivity) maybeUnblock();
@@ -830,6 +877,9 @@ async function streamClaude(
   await proc.exited;
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
+
+  // Plugins: agent_end
+  if (streamPm) streamPm.emitAsync("agent_end", { messages: [] }, streamCtx);
 
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name}`);
 }


### PR DESCRIPTION
## Summary

Adds a daemon-level plugin system that lets external packages hook into ClaudeClaw lifecycle events without modifying the daemon source.

**Rebased onto master post-#145.** Plugin hooks now thread through the `stream-json` `execClaude` and `streamClaude` paths only — the `runClaudeOnce` json/text path is not reintroduced.

### New: \`src/plugins.ts\`

- \`PluginManager\` class with singleton accessors (\`getPluginManager\` / \`setPluginManager\`)
- Lifecycle events: \`before_agent_start\`, \`before_prompt_build\`, \`tool_result_persist\`, \`agent_end\`, \`after_compaction\`, and more
- \`before_prompt_build\` collects \`appendSystemContext\` from all handlers and merges with \`\n\n\`
- \`resolvePluginPath\`: \`isAbsolute()\` guard + npm name regex prevents path traversal
- \`checkHealth\`: host regex + port range validation prevents SSRF
- \`emitAsync\`: sync handler errors logged via \`console.warn\` (not silently swallowed)

### Changed: \`src/runner.ts\` (stream-json paths only)

- **\`execClaude\`**: \`before_agent_start\` → \`before_prompt_build\` (injects \`appendSystemContext\` before \`--append-system-prompt\` build) → \`agent_end\` (on exit 0) → \`after_compaction\` (on successful auto-compact)
- **\`streamClaude\`**: \`before_agent_start\` → \`before_prompt_build\` → \`tool_result_persist\` (on real \`tool_use\` blocks with \`block.name\`) → \`agent_end\`

### Changed: \`src/commands/start.ts\`

Plugin manager lifecycle: \`loadAll\` → \`startServices\` on daemon start; \`stopServices\` → \`setPluginManager(null)\` on shutdown.

### Changed: \`src/config.ts\`

\`plugins: {}\` default + \`parsePlugins()\` wired into \`loadSettings()\`.

### New: \`src/__tests__/plugins.test.ts\`

22 tests: \`parsePlugins\`, singleton, event system, commands, services, and security (path traversal, \`checkHealth\` validation).

## Validation

- \`bun test src/__tests__/plugins.test.ts\` → 22/22 pass
- \`bunx tsc --noEmit\` → clean