### PR TITLE
Combine clock, prompt, Discord, and runner stability fixes

### DIFF
--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -281,7 +281,7 @@ function guildTriggerReason(message: DiscordMessage): string | null {
   if (botUserId && message.referenced_message?.author?.id === botUserId) return "reply_to_bot";
 
   // Mention via mentions array
-  if (botUserId && message.mentions.some((m) => m.id === botUserId)) return "mention";
+  if (botUserId && message.mentions?.some((m) => m.id === botUserId)) return "mention";
 
   // Mention in content (fallback)
   if (botUserId && message.content.includes(`<@${botUserId}>`)) return "mention_in_content";

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -1,4 +1,4 @@
-import { runUserMessage } from "../runner";
+import { runUserMessage, ensureProjectClaudeMd } from "../runner";
 import { getSession } from "../sessions";
 import { loadSettings, initConfig } from "../config";
 
@@ -14,6 +14,7 @@ export async function send(args: string[]) {
 
   await initConfig();
   await loadSettings();
+  await ensureProjectClaudeMd();
 
   const session = await getSession();
   if (!session) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -7,7 +7,7 @@ import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs } from "../jobs";
 import { writePidFile, cleanupPidFile, checkExistingDaemon } from "../pid";
 import { initConfig, loadSettings, reloadSettings, resolvePrompt, type HeartbeatConfig, type Settings } from "../config";
-import { getDayAndMinuteAtOffset } from "../timezone";
+import { getDayAndMinuteAtOffset, buildClockPromptPrefix } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
 import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
@@ -581,7 +581,8 @@ export async function start(args: string[] = []) {
             .filter((part) => part.length > 0)
             .join("\n\n");
           if (!mergedPrompt) return null;
-          return run("heartbeat", mergedPrompt);
+          const clock = buildClockPromptPrefix(new Date(), currentSettings.timezoneOffsetMinutes);
+          return run("heartbeat", `${clock}\n${mergedPrompt}`);
         })
         .then((r) => {
           if (!r) return;
@@ -718,16 +719,17 @@ export async function start(args: string[] = []) {
   function runJob(job: (typeof currentJobs)[0]) {
     const timeoutMs = job.timeoutSeconds ? job.timeoutSeconds * 1000 : undefined;
     resolvePrompt(job.prompt)
-      .then((prompt) =>
-        run(
+      .then((prompt) => {
+        const clock = buildClockPromptPrefix(new Date(), currentSettings.timezoneOffsetMinutes);
+        return run(
           job.name,
-          prompt,
+          `${clock}\n${prompt}`,
           job.agent ? `agent:${job.agent}` : job.name,
           job.model,
           timeoutMs,
           job.agent
-        )
-      )
+        );
+      })
       .then((r) => {
         if (r.exitCode === 0) {
           jobRetryState.delete(job.name);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -98,6 +98,8 @@ const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
 // Global queue for non-thread messages (backward compatible)
+// Reset to a fresh resolved promise after each task to avoid holding
+// references to every previous result (memory leak).
 let globalQueue: Promise<unknown> = Promise.resolve();
 // Per-thread queues — each thread runs independently in parallel
 const threadQueues = new Map<string, Promise<unknown>>();
@@ -106,11 +108,11 @@ function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
   if (threadId) {
     const current = threadQueues.get(threadId) ?? Promise.resolve();
     const task = current.then(fn, fn);
-    threadQueues.set(threadId, task.catch(() => {}));
+    threadQueues.set(threadId, task.then(() => {}, () => {}));
     return task;
   }
   const task = globalQueue.then(fn, fn);
-  globalQueue = task.catch(() => {});
+  globalQueue = task.then(() => {}, () => {});
   return task;
 }
 
@@ -153,6 +155,44 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
   return childEnv;
 }
 
+// Cap stdout/stderr to prevent unbounded memory growth.
+// 10 MB is far beyond any real Claude response; protects against runaway streams only.
+const MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+async function collectStream(stream: ReadableStream<Uint8Array>, maxBytes: number): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (totalBytes < maxBytes) {
+        const space = maxBytes - totalBytes;
+        if (value.byteLength <= space) {
+          chunks.push(value);
+          totalBytes += value.byteLength;
+        } else {
+          chunks.push(value.subarray(0, space));
+          totalBytes = maxBytes;
+          // cap reached — keep draining without storing so the child process isn't blocked
+        }
+      }
+      // beyond cap: read and discard to keep the pipe flowing
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+
 async function runClaudeOnce(
   baseArgs: string[],
   model: string,
@@ -172,18 +212,21 @@ async function runClaudeOnce(
     ...(cwd ? { cwd } : {}),
   });
 
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+    timeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
   });
 
   try {
     const [rawStdout, stderr] = await Promise.race([
       Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+        collectStream(proc.stdout as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
+        collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
       ]),
       timeoutPromise,
     ]) as [string, string];
+
+    if (timeoutId) clearTimeout(timeoutId);
     await proc.exited;
 
     return {
@@ -192,6 +235,7 @@ async function runClaudeOnce(
       exitCode: proc.exitCode ?? 1,
     };
   } catch (err) {
+    if (timeoutId) clearTimeout(timeoutId);
     // Kill the hung process
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
@@ -263,11 +307,12 @@ async function runClaudeStream(
   };
 
   const readStderr = async () => {
-    stderr = await new Response(proc.stderr).text();
+    stderr = await collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES);
   };
 
+  let streamJsonTimeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+    streamJsonTimeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
   });
 
   try {
@@ -275,9 +320,11 @@ async function runClaudeStream(
       Promise.all([readStdout(), readStderr()]),
       timeoutPromise,
     ]);
+    if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
     await proc.exited;
     return { rawStdout: resultText, stderr: stderr.trim(), exitCode: proc.exitCode ?? 1, sessionId };
   } catch (err) {
+    if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
     const message = err instanceof Error ? err.message : String(err);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -612,23 +612,20 @@ async function execClaude(
     args.push("--resume", existing.sessionId);
   }
 
-  // Build the appended system prompt: prompt files + directory scoping
+  // Build the appended system prompt: CLAUDE.md + directory scoping
   // This is passed on EVERY invocation (not just new sessions) because
   // --append-system-prompt does not persist across --resume.
-  const promptContent = await loadPrompts();
+  // Prompt files (IDENTITY.md, USER.md, SOUL.md) are already embedded in
+  // CLAUDE.md by ensureProjectClaudeMd(), which runs before every call.
   const appendParts: string[] = [
     "You are running inside ClaudeClaw.",
   ];
-  if (promptContent) appendParts.push(promptContent);
 
-  // Load the project's CLAUDE.md if it exists
-  if (existsSync(PROJECT_CLAUDE_MD)) {
-    try {
-      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
-      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
-    } catch (e) {
-      console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
-    }
+  try {
+    const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+    if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+  } catch (e) {
+    console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -813,16 +810,12 @@ async function streamClaude(
 
   if (existing) args.push("--resume", existing.sessionId);
 
-  const promptContent = await loadPrompts();
   const appendParts: string[] = ["You are running inside ClaudeClaw."];
-  if (promptContent) appendParts.push(promptContent);
 
-  if (existsSync(PROJECT_CLAUDE_MD)) {
-    try {
-      const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
-      if (claudeMd.trim()) appendParts.push(claudeMd.trim());
-    } catch {}
-  }
+  try {
+    const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
+    if (claudeMd.trim()) appendParts.push(claudeMd.trim());
+  } catch {}
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
   if (appendParts.length > 0) {


### PR DESCRIPTION
## Summary

Combines the functional changes from:

- #92 by @christian-drescher: add a fresh clock prefix to heartbeat and job prompts
- #94 by @christian-drescher: avoid repeatedly appending prompt templates and ensure `CLAUDE.md` exists for `send`
- #141 by @squirblej: make Discord mention handling null-safe
- #142 by @squirblej: cap child output collection, clear timeout handles, and avoid retaining queue-chain results

The individual plugin/marketplace version-bump commits were intentionally omitted so this combined PR does not carry duplicate/racing release metadata bumps.

## Attribution

Original authorship is preserved on the cherry-picked/manual commits. The #142 functional commit retains its original author and includes @squirblej as a co-author because the PR was contributed by Jack Bertram.

## Verification

- `bun test`
- `bunx tsc --noEmit`
