### PR TITLE
Combine fallback sessions, daemon plugins, and contributing guide

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to ClaudeClaw
+
+Thanks for contributing. ClaudeClaw is a lightweight, open-source Claude Code daemon — keep that in mind when choosing where your work belongs.
+
+---
+
+## Where does your contribution belong?
+
+Not everything should come here. ClaudeClaw has a sister project, [**ClaudeClaw+**](https://github.com/TerrysPOV/ClaudeClaw-Plus), for heavier and more opinionated work. Use this table to decide:
+
+| This contribution is... | Contribute to |
+|---|---|
+| A bug fix or small improvement | **ClaudeClaw** (you're in the right place) |
+| A new adapter or integration | **ClaudeClaw** |
+| Lightweight and broadly useful | **ClaudeClaw** |
+| A new subsystem (governance, orchestration, policy, persistent memory) | **[ClaudeClaw+](https://github.com/TerrysPOV/ClaudeClaw-Plus)** |
+| A large architectural change that adds significant runtime weight | **ClaudeClaw+** |
+| Something opinionated that most users wouldn't opt into | **ClaudeClaw+** |
+
+ClaudeClaw+ syncs from this repo daily, so everything here lands there too. If you're unsure, open an issue on either repo and we'll point you in the right direction.
+
+---
+
+## Before opening a PR
+
+- Check the [open issues](https://github.com/moazbuilds/claudeclaw/issues) and existing PRs to avoid duplication
+- For anything beyond a small fix, open an issue first to discuss the approach
+- Keep the "lightweight" principle in mind: ClaudeClaw runs on low-spec machines, so avoid adding heavy dependencies or new long-lived processes without a strong reason
+
+---
+
+## Validation
+
+Before opening a PR:
+
+- [ ] Run the relevant checks locally
+- [ ] Update any docs or setup guidance affected by your change
+
+---
+
+## Plugin version bumps (CI-enforced)
+
+If your PR changes shipped plugin files under `src/`, `commands/`, `prompts/`, or `.claude-plugin/`, bump the version metadata:
+
+```bash
+bun run bump:plugin-version
+bun run bump:marketplace-version
+```
+
+Typical rule:
+- bump `.claude-plugin/plugin.json` when shipped plugin content changes
+- bump `.claude-plugin/marketplace.json` when marketplace metadata should reflect the new version
+
+Docs-only and other non-shipped changes do not require these bumps. (CI will tell you if you missed one.)
+
+---
+
+## Code of conduct
+
+Be decent. Critique code, not people.

--- a/src/__tests__/messaging.test.ts
+++ b/src/__tests__/messaging.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from "bun:test";
+import { extractErrorDetail } from "../messaging";
+
+describe("extractErrorDetail", () => {
+  test("prefers stderr over stdout", () => {
+    expect(extractErrorDetail({ stdout: "some output", stderr: "auth error" })).toBe("auth error");
+  });
+
+  test("parses JSON stdout error when stderr is empty", () => {
+    const stdout = JSON.stringify({ is_error: true, result: "Rate limit exceeded" });
+    expect(extractErrorDetail({ stdout, stderr: "" })).toBe("Rate limit exceeded");
+  });
+
+  test("falls back to raw stdout when not JSON and no stderr", () => {
+    expect(extractErrorDetail({ stdout: "plain error text", stderr: "" })).toBe("plain error text");
+  });
+});

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  PluginManager,
+  getPluginManager,
+  setPluginManager,
+  parsePlugins,
+  type EventContext,
+  type PluginApi,
+} from "../plugins";
+
+const ctx: EventContext = { workspaceDir: "/tmp/test" };
+
+describe("parsePlugins", () => {
+  it("returns empty object for null/undefined", () => {
+    expect(parsePlugins(null)).toEqual({});
+    expect(parsePlugins(undefined)).toEqual({});
+    expect(parsePlugins("string")).toEqual({});
+  });
+
+  it("parses a valid plugin entry", () => {
+    const result = parsePlugins({
+      "claude-mem": { enabled: true, source: "openclaw", config: { workerPort: 37777 } },
+    });
+    expect(result["claude-mem"]).toEqual({
+      enabled: true,
+      source: "openclaw",
+      config: { workerPort: 37777 },
+    });
+  });
+
+  it("defaults enabled to false and source to openclaw", () => {
+    const result = parsePlugins({ "my-plugin": {} });
+    expect(result["my-plugin"].enabled).toBe(false);
+    expect(result["my-plugin"].source).toBe("openclaw");
+    expect(result["my-plugin"].config).toEqual({});
+  });
+
+  it("trims source string", () => {
+    const result = parsePlugins({ p: { source: "  my-source  " } });
+    expect(result["p"].source).toBe("my-source");
+  });
+
+  it("skips non-object entries", () => {
+    const result = parsePlugins({ bad: "not-an-object", good: { enabled: true, source: "x", config: {} } });
+    expect(result["bad"]).toBeUndefined();
+    expect(result["good"]).toBeDefined();
+  });
+});
+
+describe("PluginManager singleton", () => {
+  beforeEach(() => {
+    setPluginManager(null);
+  });
+
+  it("starts as null", () => {
+    expect(getPluginManager()).toBeNull();
+  });
+
+  it("setPluginManager / getPluginManager round-trip", () => {
+    const pm = new PluginManager("/tmp");
+    setPluginManager(pm);
+    expect(getPluginManager()).toBe(pm);
+    setPluginManager(null);
+    expect(getPluginManager()).toBeNull();
+  });
+});
+
+describe("PluginManager event system", () => {
+  let pm: PluginManager;
+
+  beforeEach(() => {
+    pm = new PluginManager("/tmp/test");
+  });
+
+  it("emit returns undefined when no handlers registered", async () => {
+    const result = await pm.emit("agent_end", {}, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("on/emit: handler receives data and ctx", async () => {
+    let received: { data: unknown; ctx: EventContext } | null = null;
+    let api: PluginApi | null = null;
+
+    // Register a plugin manually via the internal api
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("test-plugin", {});
+    api = internalApi;
+    internalApi.on("agent_end", (data, c) => {
+      received = { data, ctx: c };
+    });
+
+    await pm.emit("agent_end", { messages: ["hello"] }, ctx);
+    expect(received).not.toBeNull();
+    expect((received!.data as { messages: unknown[] }).messages).toEqual(["hello"]);
+    expect(received!.ctx).toBe(ctx);
+    expect(api).not.toBeNull();
+  });
+
+  it("before_prompt_build merges appendSystemContext from multiple handlers", async () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p1", {});
+    internalApi.on("before_prompt_build", () => ({ appendSystemContext: "context-a" }));
+
+    const internalApi2 = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p2", {});
+    internalApi2.on("before_prompt_build", () => ({ appendSystemContext: "context-b" }));
+
+    const result = await pm.emit("before_prompt_build", { prompt: "test" }, ctx);
+    expect(result?.appendSystemContext).toBe("context-a\n\ncontext-b");
+  });
+
+  it("before_prompt_build returns undefined when no handler returns appendSystemContext", async () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.on("before_prompt_build", () => ({}));
+
+    const result = await pm.emit("before_prompt_build", {}, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("emitAsync does not throw synchronously even when handler throws", () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.on("agent_end", () => { throw new Error("boom"); });
+    // Must not throw — error is logged via console.warn
+    expect(() => pm.emitAsync("agent_end", {}, ctx)).not.toThrow();
+  });
+
+  it("emitAsync is fire-and-forget (returns void)", () => {
+    const result = pm.emitAsync("agent_end", {}, ctx);
+    expect(result).toBeUndefined();
+  });
+
+  it("handler errors in emit are swallowed and do not abort subsequent handlers", async () => {
+    let secondCalled = false;
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p1", {});
+    internalApi.on("agent_end", () => { throw new Error("handler error"); });
+
+    const internalApi2 = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p2", {});
+    internalApi2.on("agent_end", () => { secondCalled = true; });
+
+    await pm.emit("agent_end", {}, ctx);
+    expect(secondCalled).toBe(true);
+  });
+});
+
+describe("PluginManager commands", () => {
+  let pm: PluginManager;
+
+  beforeEach(() => {
+    pm = new PluginManager("/tmp/test");
+  });
+
+  it("runCommand returns null for unknown command", async () => {
+    expect(await pm.runCommand("unknown")).toBeNull();
+  });
+
+  it("registerCommand/runCommand round-trip", async () => {
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.registerCommand({ name: "hello", handler: async () => "world" });
+
+    expect(await pm.runCommand("hello")).toBe("world");
+    expect(pm.getCommandNames()).toContain("hello");
+  });
+});
+
+describe("PluginManager services", () => {
+  let pm: PluginManager;
+
+  beforeEach(() => {
+    pm = new PluginManager("/tmp/test");
+  });
+
+  it("startServices/stopServices do not throw when no services registered", async () => {
+    await expect(pm.startServices()).resolves.toBeUndefined();
+    await expect(pm.stopServices()).resolves.toBeUndefined();
+  });
+
+  it("registerService start/stop called", async () => {
+    let started = false;
+    let stopped = false;
+    const internalApi = (pm as unknown as {
+      buildApi: (id: string, cfg: Record<string, unknown>) => PluginApi;
+    }).buildApi("p", {});
+    internalApi.registerService({
+      id: "my-service",
+      start: async () => { started = true; },
+      stop: async () => { stopped = true; },
+    });
+
+    await pm.startServices();
+    expect(started).toBe(true);
+
+    await pm.stopServices();
+    expect(stopped).toBe(true);
+  });
+});
+
+describe("PluginManager info", () => {
+  it("hasPlugins is false with no loaded plugins", () => {
+    const pm = new PluginManager("/tmp");
+    expect(pm.hasPlugins).toBe(false);
+    expect(pm.loaded).toEqual([]);
+  });
+});
+
+describe("PluginManager path resolution (security)", () => {
+  it("rejects relative-segment source strings (path traversal guard)", async () => {
+    const pm = new PluginManager("/tmp/test");
+    // loadPlugin will call resolvePluginPath which should return null for traversal attempts
+    const resolvePluginPath = (pm as unknown as {
+      resolvePluginPath: (id: string, source: string) => string | null;
+    }).resolvePluginPath.bind(pm);
+
+    expect(resolvePluginPath("p", "../../etc")).toBeNull();
+    expect(resolvePluginPath("p", "../evil")).toBeNull();
+    expect(resolvePluginPath("p", "valid-pkg")).toBeNull(); // null because file doesn't exist, not because of rejection
+  });
+
+  it("accepts valid npm package names", () => {
+    const pm = new PluginManager("/tmp/test");
+    const resolvePluginPath = (pm as unknown as {
+      resolvePluginPath: (id: string, source: string) => string | null;
+    }).resolvePluginPath.bind(pm);
+
+    // These return null only because the files don't exist, not due to validation failure
+    // We verify resolvePluginPath doesn't throw and returns null (not a hard error)
+    expect(() => resolvePluginPath("p", "my-plugin")).not.toThrow();
+    expect(() => resolvePluginPath("p", "@scope/my-plugin")).not.toThrow();
+  });
+
+  it("checkHealth rejects invalid host strings", async () => {
+    const pm = new PluginManager("/tmp/test");
+    const checkHealth = (pm as unknown as {
+      checkHealth: (host: string, port: number) => Promise<boolean>;
+    }).checkHealth.bind(pm);
+
+    expect(await checkHealth("127.0.0.1/admin#", 8080)).toBe(false);
+    expect(await checkHealth("user@evil.com", 8080)).toBe(false);
+    expect(await checkHealth("", 8080)).toBe(false);
+    expect(await checkHealth("127.0.0.1", 0)).toBe(false);
+    expect(await checkHealth("127.0.0.1", 99999)).toBe(false);
+  });
+});

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,7 +1,7 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
-import { resetSession, peekSession } from "../sessions";
+import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -738,6 +738,7 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
 
     if (interaction.data.name === "reset") {
       await resetSession();
+      await resetFallbackSession();
       await respondToInteraction(interaction, {
         content: "Global session reset. Next message starts fresh.",
       });

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,4 +1,5 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
+import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
@@ -696,7 +697,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const result = await runUserMessage("discord", prefixedPrompt, threadId, threadInfo?.agentName);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${result.stdout || result.stderr || "Unknown error"}`);
+      await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);
     } else {
       const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
       if (reactionEmoji) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -12,6 +12,7 @@ import { getDayAndMinuteAtOffset, buildClockPromptPrefix } from "../timezone";
 import { startWebUi, type WebServerHandle } from "../web";
 import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
+import { PluginManager, setPluginManager } from "../plugins";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -333,7 +334,16 @@ export async function start(args: string[] = []) {
   let web: WebServerHandle | null = null;
   let discordStopGateway: (() => void) | null = null;
 
+  // Plugin system — initialize before gateway start
+  const pluginManager = new PluginManager(process.cwd());
+  if (Object.keys(settings.plugins).length > 0) {
+    await pluginManager.loadAll(settings.plugins);
+    setPluginManager(pluginManager);
+  }
+
   async function shutdown() {
+    await pluginManager.stopServices();
+    setPluginManager(null);
     if (discordStopGateway) discordStopGateway();
     if (web) web.stop();
     await teardownStatusline();
@@ -408,6 +418,24 @@ export async function start(args: string[] = []) {
 
   await initDiscord(currentSettings.discord.token);
   if (!discordToken) console.log("  Discord: not configured");
+
+  // Wire channel senders into plugin runtime so plugins can send messages
+  if (pluginManager.hasPlugins) {
+    pluginManager.setChannelSenders({
+      telegram: {
+        sendMessageTelegram: telegramSend
+          ? (chatId: number, text: string) => telegramSend!(chatId, text)
+          : () => Promise.resolve(),
+      },
+      discord: {
+        sendMessageDiscord: discordSendToUser
+          ? (userId: string, text: string) => discordSendToUser!(userId, text)
+          : () => Promise.resolve(),
+      },
+    });
+    await pluginManager.startServices();
+    await pluginManager.emit("gateway_start", {}, { workspaceDir: process.cwd() });
+  }
 
   function isAddrInUse(err: unknown): boolean {
     if (!err || typeof err !== "object") return false;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,4 +1,5 @@
 import { writeFile, unlink, mkdir } from "fs/promises";
+import { extractErrorDetail } from "../messaging";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
@@ -520,7 +521,7 @@ export async function start(args: string[] = []) {
     if (!telegramSend || currentSettings.telegram.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.telegram.allowedUserIds) {
       telegramSend(userId, text).catch((err) =>
         console.error(`[Telegram] Failed to forward to ${userId}: ${err}`)
@@ -532,7 +533,7 @@ export async function start(args: string[] = []) {
     if (!discordSendToUser || currentSettings.discord.allowedUserIds.length === 0) return;
     const text = result.exitCode === 0
       ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
-      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${result.stderr || "Unknown"}`;
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
     for (const userId of currentSettings.discord.allowedUserIds) {
       discordSendToUser(userId, text).catch((err) =>
         console.error(`[Discord] Failed to forward to ${userId}: ${err}`)

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,7 +1,7 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
-import { resetSession, peekSession } from "../sessions";
+import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -625,6 +625,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
   if (command === "/reset") {
     await resetSession();
+    await resetFallbackSession();
     await sendMessage(config.token, chatId, "Global session reset. Next message starts fresh.", threadId);
     return;
   }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,5 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
+import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { resetSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
@@ -847,7 +848,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const result = await runUserMessage("telegram", prefixedPrompt);
 
     if (result.exitCode !== 0) {
-      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      await sendMessage(config.token, chatId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`, threadId);
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
       const { cleanedText, filePaths } = extractSendFileDirectives(afterReact);

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
 import { parseWatchdogConfig, type WatchdogConfig } from "./watchdog";
+import { parsePlugins, type PluginEntry } from "./plugins";
 
 /** Re-exported under the name used in the Settings interface. */
 export type WatchdogSettings = WatchdogConfig;
@@ -82,6 +83,7 @@ const DEFAULT_SETTINGS: Settings = {
   stt: { baseUrl: "", model: "" },
   sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
+  plugins: {},
 };
 
 export interface HeartbeatExcludeWindow {
@@ -137,6 +139,7 @@ export interface Settings {
   stt: SttConfig;
   sessionTimeoutMs: number;
   watchdog: WatchdogSettings;
+  plugins: Record<string, PluginEntry>;
   jobsDir?: string;
 }
 
@@ -310,6 +313,7 @@ function parseSettings(
       ? raw.sessionTimeoutMs
       : DEFAULT_SESSION_TIMEOUT_MS,
     watchdog: parseWatchdogConfig(raw.watchdog),
+    plugins: parsePlugins(raw.plugins),
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -1,0 +1,23 @@
+/**
+ * Extract a user-facing error detail from a Claude CLI run result.
+ *
+ * Claude CLI sometimes returns human-readable auth/quota failures in JSON
+ * stdout instead of stderr. Prefer stderr when present, otherwise parse the
+ * JSON stdout payload and fall back to raw stdout text.
+ */
+export function extractErrorDetail(result: { stdout: string; stderr: string }): string {
+  const stderr = result.stderr?.trim() || "";
+  if (stderr) return stderr;
+
+  const stdout = result.stdout?.trim() || "";
+  if (!stdout) return "";
+
+  try {
+    const parsed = JSON.parse(stdout);
+    if (parsed?.is_error && parsed?.result) return String(parsed.result).trim();
+    if (parsed?.error?.message) return String(parsed.error.message).trim();
+    if (typeof parsed?.error === "string") return parsed.error.trim();
+  } catch {}
+
+  return stdout;
+}

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,358 @@
+/**
+ * ClaudeClaw Daemon Plugin System
+ *
+ * Provides an OpenClaw-compatible Plugin API for daemon-level plugins.
+ * Plugins hook into lifecycle events that fire AROUND Claude Code invocations
+ * (not inside them — that's handled by Claude Code's native plugin system).
+ *
+ * Usage in settings.json:
+ *   "plugins": {
+ *     "claude-mem": {
+ *       "enabled": true,
+ *       "source": "openclaw",
+ *       "config": { "workerPort": 37777, "project": "myproject" }
+ *     }
+ *   }
+ */
+
+import { join, isAbsolute, resolve } from "path";
+import { existsSync } from "fs";
+
+// ── Event types ──────────────────────────────────────────────────────────────
+
+export type DaemonEvent =
+  | "gateway_start"
+  | "session_start"
+  | "before_agent_start"
+  | "before_prompt_build"
+  | "tool_result_persist"
+  | "agent_end"
+  | "session_end"
+  | "message_received"
+  | "after_compaction";
+
+export interface EventContext {
+  sessionKey?: string;
+  conversationId?: string;
+  channelId?: string;
+  agentId?: string;
+  workspaceDir?: string;
+}
+
+export type EventHandler = (data: unknown, ctx: EventContext) => Promise<unknown> | unknown;
+
+// ── Plugin API types ─────────────────────────────────────────────────────────
+
+export interface PluginService {
+  id: string;
+  start: (ctx: unknown) => Promise<void>;
+  stop: (ctx: unknown) => Promise<void>;
+}
+
+export interface PluginCommand {
+  name: string;
+  description?: string;
+  acceptsArgs?: boolean;
+  handler: (ctx: unknown) => Promise<unknown>;
+}
+
+export interface PluginApi {
+  on(event: string, handler: EventHandler): void;
+  registerService(service: PluginService): void;
+  registerCommand(cmd: PluginCommand): void;
+  runtime: {
+    channel: Record<string, Record<string, (...args: unknown[]) => unknown>>;
+  };
+  logger: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+    debug: (...args: unknown[]) => void;
+  };
+  pluginConfig: Record<string, unknown>;
+}
+
+export type PluginInitFn = (api: PluginApi) => void | Promise<void>;
+
+// ── Settings types ───────────────────────────────────────────────────────────
+
+export interface PluginEntry {
+  enabled: boolean;
+  /** "openclaw" | npm package name | absolute path to plugin dir */
+  source: string;
+  config: Record<string, unknown>;
+}
+
+// ── Plugin Manager ───────────────────────────────────────────────────────────
+
+export class PluginManager {
+  private handlers = new Map<string, EventHandler[]>();
+  private services = new Map<string, PluginService>();
+  private commands = new Map<string, PluginCommand>();
+  private channelRuntime: Record<string, Record<string, (...args: unknown[]) => unknown>> = {};
+  private workspaceDir: string;
+  private loadedPlugins: string[] = [];
+
+  constructor(workspaceDir: string) {
+    this.workspaceDir = workspaceDir;
+  }
+
+  // ── Loading ────────────────────────────────────────────────────────────
+
+  async loadAll(plugins: Record<string, PluginEntry>): Promise<void> {
+    for (const [id, entry] of Object.entries(plugins)) {
+      if (!entry.enabled) continue;
+      try {
+        await this.loadPlugin(id, entry);
+      } catch (err) {
+        console.error(`[${ts()}] [plugins] Failed to load "${id}":`, err);
+      }
+    }
+  }
+
+  private async loadPlugin(id: string, entry: PluginEntry): Promise<void> {
+    const source = entry.source || "openclaw";
+
+    // For openclaw-source plugins, check worker health first
+    if (source === "openclaw" && entry.config?.workerPort) {
+      const host = (entry.config.workerHost as string) || "127.0.0.1";
+      const port = entry.config.workerPort as number;
+      const healthy = await this.checkHealth(host, port);
+      if (!healthy) {
+        console.warn(`[${ts()}] [plugins] ${id}: worker not running on ${host}:${port}, skipping`);
+        return;
+      }
+    }
+
+    const modulePath = this.resolvePluginPath(id, source);
+    if (!modulePath) {
+      console.warn(`[${ts()}] [plugins] ${id}: could not resolve module (source: ${source})`);
+      return;
+    }
+
+    const api = this.buildApi(id, entry.config || {});
+    const mod = await import(modulePath);
+    const initFn: PluginInitFn = mod.default || mod;
+    if (typeof initFn !== "function") {
+      console.warn(`[${ts()}] [plugins] ${id}: module does not export a function`);
+      return;
+    }
+
+    await initFn(api);
+    this.loadedPlugins.push(id);
+    console.log(`[${ts()}] [plugins] ${id}: loaded (source: ${source})`);
+  }
+
+  private resolvePluginPath(id: string, source: string): string | null {
+    const candidates: string[] = [];
+
+    if (isAbsolute(source)) {
+      const safe = resolve(source);
+      candidates.push(
+        join(safe, "openclaw", "dist", "index.js"),
+        join(safe, "dist", "index.js"),
+        join(safe, "index.js"),
+      );
+    } else if (source === "openclaw") {
+      candidates.push(
+        join(this.workspaceDir, ".claude", "claudeclaw", id, "openclaw", "dist", "index.js"),
+        join(this.workspaceDir, "node_modules", id, "openclaw", "dist", "index.js"),
+        join(process.env.HOME || "", ".openclaw", "extensions", id, "dist", "index.js"),
+      );
+    } else {
+      // Validate npm package name to prevent path traversal via relative segments
+      if (!/^(@[a-z0-9-]+\/)?[a-z0-9][a-z0-9._-]*$/.test(source)) return null;
+      candidates.push(
+        join(this.workspaceDir, "node_modules", source, "dist", "index.js"),
+        join(this.workspaceDir, "node_modules", source, "index.js"),
+      );
+    }
+
+    for (const p of candidates) {
+      if (existsSync(p)) return p;
+    }
+    return null;
+  }
+
+  private async checkHealth(host: string, port: number): Promise<boolean> {
+    // Validate host: hostname chars or IPv6 bracket notation only (no userinfo, paths, etc.)
+    if (!/^[a-zA-Z0-9.\-]+$|^\[[0-9a-fA-F:]+\]$/.test(host)) return false;
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return false;
+    try {
+      const url = new URL(`http://${host}:${port}/api/health`);
+      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private buildApi(pluginId: string, config: Record<string, unknown>): PluginApi {
+    const self = this;
+    return {
+      on(event: string, handler: EventHandler) {
+        const list = self.handlers.get(event) || [];
+        list.push(handler);
+        self.handlers.set(event, list);
+        console.log(`[${ts()}] [plugins] ${pluginId} subscribed to: ${event}`);
+      },
+      registerService(service: PluginService) {
+        self.services.set(service.id, service);
+      },
+      registerCommand(cmd: PluginCommand) {
+        self.commands.set(cmd.name, cmd);
+      },
+      runtime: {
+        channel: self.channelRuntime,
+      },
+      logger: {
+        info: (...args: unknown[]) => console.log(`[${ts()}] [${pluginId}]`, ...args),
+        warn: (...args: unknown[]) => console.warn(`[${ts()}] [${pluginId}]`, ...args),
+        error: (...args: unknown[]) => console.error(`[${ts()}] [${pluginId}]`, ...args),
+        debug: () => {},
+      },
+      pluginConfig: config,
+    };
+  }
+
+  // ── Services ───────────────────────────────────────────────────────────
+
+  async startServices(): Promise<void> {
+    for (const [id, service] of this.services) {
+      try {
+        await service.start({});
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Service ${id} failed to start:`, err);
+      }
+    }
+  }
+
+  async stopServices(): Promise<void> {
+    for (const [, service] of this.services) {
+      try {
+        await service.stop({});
+      } catch {}
+    }
+  }
+
+  // ── Channel runtime ────────────────────────────────────────────────────
+
+  setChannelSenders(senders: Record<string, Record<string, (...args: unknown[]) => unknown>>): void {
+    Object.assign(this.channelRuntime, senders);
+  }
+
+  // ── Event emission ─────────────────────────────────────────────────────
+
+  /**
+   * Emit an event and await all handlers.
+   * For `before_prompt_build`, collects and merges all `appendSystemContext` values.
+   * For other events, returns the last handler's result.
+   */
+  async emit(event: DaemonEvent, data: unknown, ctx: EventContext): Promise<{ appendSystemContext?: string } | undefined> {
+    const handlers = this.handlers.get(event);
+    if (!handlers || handlers.length === 0) return undefined;
+
+    if (event === "before_prompt_build") {
+      const contexts: string[] = [];
+      for (const handler of handlers) {
+        try {
+          const result = await handler(data, ctx) as { appendSystemContext?: string } | undefined;
+          if (result?.appendSystemContext) {
+            contexts.push(result.appendSystemContext);
+          }
+        } catch (err) {
+          console.warn(`[${ts()}] [plugins] Event ${event} handler error:`, err);
+        }
+      }
+      return contexts.length > 0 ? { appendSystemContext: contexts.join("\n\n") } : undefined;
+    }
+
+    let result: unknown;
+    for (const handler of handlers) {
+      try {
+        result = await handler(data, ctx);
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Event ${event} handler error:`, err);
+      }
+    }
+    return result as { appendSystemContext?: string } | undefined;
+  }
+
+  /**
+   * Fire-and-forget emit — does not await handlers.
+   * Use for observations (tool_result_persist) and agent_end.
+   */
+  emitAsync(event: DaemonEvent, data: unknown, ctx: EventContext): void {
+    const handlers = this.handlers.get(event);
+    if (!handlers || handlers.length === 0) return;
+    for (const handler of handlers) {
+      try {
+        Promise.resolve(handler(data, ctx)).catch((err) => {
+          console.warn(`[${ts()}] [plugins] Async event ${event} error:`, err);
+        });
+      } catch (err) {
+        console.warn(`[${ts()}] [plugins] Sync error in ${event} handler:`, err);
+      }
+    }
+  }
+
+  // ── Commands ───────────────────────────────────────────────────────────
+
+  async runCommand(name: string, args?: string): Promise<string | null> {
+    const cmd = this.commands.get(name);
+    if (!cmd) return null;
+    try {
+      const result = await cmd.handler({ args }) as string | { text?: string } | null | undefined;
+      return typeof result === "string" ? result : (result as { text?: string })?.text ?? JSON.stringify(result);
+    } catch {
+      return null;
+    }
+  }
+
+  getCommandNames(): string[] {
+    return Array.from(this.commands.keys());
+  }
+
+  // ── Info ────────────────────────────────────────────────────────────────
+
+  get loaded(): string[] {
+    return this.loadedPlugins;
+  }
+
+  get hasPlugins(): boolean {
+    return this.loadedPlugins.length > 0;
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let manager: PluginManager | null = null;
+
+export function getPluginManager(): PluginManager | null {
+  return manager;
+}
+
+export function setPluginManager(m: PluginManager | null): void {
+  manager = m;
+}
+
+// ── Config parser ────────────────────────────────────────────────────────────
+
+export function parsePlugins(raw: unknown): Record<string, PluginEntry> {
+  if (!raw || typeof raw !== "object") return {};
+  const result: Record<string, PluginEntry> = {};
+  for (const [id, entry] of Object.entries(raw as Record<string, unknown>)) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    result[id] = {
+      enabled: (e.enabled as boolean) ?? false,
+      source: typeof e.source === "string" ? e.source.trim() : "openclaw",
+      config: e.config && typeof e.config === "object" ? (e.config as Record<string, unknown>) : {},
+    };
+  }
+  return result;
+}
+
+function ts(): string {
+  return new Date().toLocaleTimeString();
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -740,7 +740,7 @@ async function execClaude(
   // Capture session ID from stream events and persist for new sessions.
   // Gate only on isNew + sessionId present — not on exitCode, so a session that timed
   // out mid-run is still persisted and can be resumed on the next message.
-  if (!rateLimitMessage && isNew && exec.sessionId) {
+  if (!rateLimitMessage && isNew && exec.sessionId && !usedFallback) {
     sessionId = exec.sessionId;
     if (threadId) {
       await createThreadSession(threadId, sessionId);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,15 @@
 import { mkdir, readFile, writeFile, realpath } from "fs/promises";
 import { join, resolve, sep } from "path";
 import { existsSync } from "fs";
-import { getSession, createSession, incrementTurn, markCompactWarned } from "./sessions";
+import {
+  getSession,
+  createSession,
+  incrementTurn,
+  markCompactWarned,
+  getFallbackSession,
+  createFallbackSession,
+  incrementFallbackTurn,
+} from "./sessions";
 import {
   getThreadSession,
   createThreadSession,
@@ -691,8 +699,26 @@ async function execClaude(
     console.warn(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    exec = await runClaudeStream(args, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs, spawnCwd);
+    const fallbackSession = await getFallbackSession(agentName);
+    const fallbackArgs = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+    if (fallbackSession) {
+      fallbackArgs.push("--resume", fallbackSession.sessionId);
+    }
+    if (appendParts.length > 0) {
+      fallbackArgs.push("--append-system-prompt", appendParts.join("\n\n"));
+    }
+    exec = await runClaudeStream(fallbackArgs, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs, spawnCwd);
     usedFallback = true;
+    const fallbackRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
+    if (!fallbackRateLimit) {
+      if (!fallbackSession && exec.sessionId) {
+        await createFallbackSession(exec.sessionId, agentName);
+        const label = agentName ? ` (agent ${agentName})` : "";
+        console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${exec.sessionId}${label}`);
+      } else if (fallbackSession) {
+        await incrementFallbackTurn(agentName);
+      }
+    }
   }
 
   const rawStdout = exec.rawStdout;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -20,6 +20,7 @@ import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type Securit
 import { buildClockPromptPrefix } from "./timezone";
 import { selectModel } from "./model-router";
 import { recordResult, abortReason, clearSession, startSession } from "./watchdog";
+import { getPluginManager, type EventContext } from "./plugins";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
@@ -94,6 +95,16 @@ function emitCompactEvent(event: CompactEvent): void {
   for (const listener of compactListeners) {
     try { listener(event); } catch {}
   }
+}
+
+function pluginCtx(threadId?: string, agentName?: string): EventContext {
+  return {
+    sessionKey: threadId || "global",
+    conversationId: threadId || "global",
+    channelId: threadId || "global",
+    agentId: agentName,
+    workspaceDir: process.cwd(),
+  };
 }
 
 export interface RunResult {
@@ -656,6 +667,11 @@ async function execClaude(
     `[${new Date().toLocaleTimeString()}] Running: ${name} (${isNew ? "new session" : `resume ${existing.sessionId.slice(0, 8)}`}, security: ${security.level})`
   );
 
+  // Plugins: before_agent_start — fired before Claude is invoked.
+  const pm = getPluginManager();
+  const ctx = pluginCtx(threadId, agentName);
+  if (pm) await pm.emit("before_agent_start", { prompt }, ctx);
+
   // stream-json emits NDJSON events as Claude works, including during subagent (Task tool)
   // orchestration. This keeps the process alive and producing output rather than silently
   // blocking until all spawned agents finish. --verbose is required for stream-json in
@@ -681,6 +697,12 @@ async function execClaude(
     if (claudeMd.trim()) appendParts.push(claudeMd.trim());
   } catch (e) {
     console.error(`[${new Date().toLocaleTimeString()}] Failed to read project CLAUDE.md:`, e);
+  }
+
+  // Plugins: before_prompt_build — lets plugins inject system context
+  if (pm) {
+    const pluginResult = await pm.emit("before_prompt_build", { prompt }, ctx);
+    if (pluginResult?.appendSystemContext) appendParts.push(pluginResult.appendSystemContext);
   }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
@@ -759,6 +781,13 @@ async function execClaude(
     exitCode,
   };
 
+  // Plugins: agent_end — fire-and-forget, does not block response
+  if (pm && exitCode === 0) {
+    pm.emitAsync("agent_end", {
+      messages: [{ role: "assistant", content: stdout }],
+    }, ctx);
+  }
+
   const output = [
     `# ${name}`,
     `Date: ${new Date().toISOString()}`,
@@ -809,6 +838,7 @@ async function execClaude(
       spawnCwd
     );
     emitCompactEvent({ type: "auto-compact-done", success: compactOk });
+    if (compactOk && pm) pm.emitAsync("after_compaction", {}, ctx);
 
     if (compactOk) {
       console.log(`[${new Date().toLocaleTimeString()}] Retrying ${name} after compact...`);
@@ -876,6 +906,11 @@ async function streamClaude(
   const { security, model, api } = getSettings();
   const securityArgs = buildSecurityArgs(security);
 
+  // Plugins: before_agent_start
+  const streamPm = getPluginManager();
+  const streamCtx = pluginCtx();
+  if (streamPm) await streamPm.emit("before_agent_start", { prompt }, streamCtx);
+
   // stream-json gives us events as they happen — text before tool calls,
   // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
   // --verbose is required for stream-json to produce output in -p (print) mode.
@@ -889,6 +924,12 @@ async function streamClaude(
     const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
     if (claudeMd.trim()) appendParts.push(claudeMd.trim());
   } catch {}
+
+  // Plugins: before_prompt_build
+  if (streamPm) {
+    const pluginResult = await streamPm.emit("before_prompt_build", { prompt }, streamCtx);
+    if (pluginResult?.appendSystemContext) appendParts.push(pluginResult.appendSystemContext);
+  }
 
   if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
   if (appendParts.length > 0) {
@@ -956,6 +997,13 @@ async function streamClaude(
               hasActivity = true;
             } else if (block.type === "tool_use") {
               hasActivity = true;
+              if (streamPm && block.name) {
+                streamPm.emitAsync("tool_result_persist", {
+                  toolName: block.name,
+                  params: block.input ?? {},
+                  message: { content: [{ type: "text", text: JSON.stringify(block.input ?? {}).slice(0, 500) }] },
+                }, streamCtx);
+              }
             }
           }
           if (hasActivity) maybeUnblock();
@@ -977,6 +1025,9 @@ async function streamClaude(
   await proc.exited;
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
+
+  // Plugins: agent_end
+  if (streamPm) streamPm.emitAsync("agent_end", { messages: [] }, streamCtx);
 
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name}`);
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -103,6 +103,69 @@ export async function resetSession(agentName?: string): Promise<void> {
   }
 }
 
+// --- Fallback session management ---
+// Fallback sessions are stored alongside primary sessions but keyed separately.
+// They persist across rate-limit events so the fallback provider accumulates context.
+
+const FALLBACK_SESSION_FILE = join(HEARTBEAT_DIR, "session_fallback.json");
+
+function fallbackSessionPathFor(agentName?: string): string {
+  if (agentName) return join(getAgentsDir(), agentName, "session_fallback.json");
+  return FALLBACK_SESSION_FILE;
+}
+
+async function loadFallbackSession(agentName?: string): Promise<GlobalSession | null> {
+  try {
+    return await Bun.file(fallbackSessionPathFor(agentName)).json();
+  } catch {
+    return null;
+  }
+}
+
+async function saveFallbackSession(session: GlobalSession, agentName?: string): Promise<void> {
+  await Bun.write(fallbackSessionPathFor(agentName), JSON.stringify(session, null, 2) + "\n");
+}
+
+export async function getFallbackSession(
+  agentName?: string
+): Promise<{ sessionId: string; turnCount: number } | null> {
+  const existing = await loadFallbackSession(agentName);
+  if (existing) {
+    if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+    existing.lastUsedAt = new Date().toISOString();
+    await saveFallbackSession(existing, agentName);
+    return { sessionId: existing.sessionId, turnCount: existing.turnCount };
+  }
+  return null;
+}
+
+export async function createFallbackSession(sessionId: string, agentName?: string): Promise<void> {
+  await saveFallbackSession({
+    sessionId,
+    createdAt: new Date().toISOString(),
+    lastUsedAt: new Date().toISOString(),
+    turnCount: 0,
+    compactWarned: false,
+  }, agentName);
+}
+
+export async function incrementFallbackTurn(agentName?: string): Promise<number> {
+  const existing = await loadFallbackSession(agentName);
+  if (!existing) return 0;
+  if (typeof existing.turnCount !== "number") existing.turnCount = 0;
+  existing.turnCount += 1;
+  await saveFallbackSession(existing, agentName);
+  return existing.turnCount;
+}
+
+export async function resetFallbackSession(agentName?: string): Promise<void> {
+  try {
+    await unlink(fallbackSessionPathFor(agentName));
+  } catch {
+    // already gone
+  }
+}
+
 export async function backupSession(): Promise<string | null> {
   const existing = await loadSession();
   if (!existing) return null;


### PR DESCRIPTION
## Summary

Combines the functional changes from:

- #143 by @squirblej: per-agent fallback sessions, structured error detail extraction, and reset handling for fallback context
- #144 by @TerrysPOV: daemon-level plugin system with lifecycle events and OpenClaw-compatible API surface
- #146 by @moazbuilds: CONTRIBUTING.md with guidance on lightweight ClaudeClaw contributions and ClaudeClaw+ scope

## Integration notes

- #143 has been re-reviewed after the fallback-session fix and rebased onto current `master`.
- #144 is still conflicting as a standalone PR, so its intended plugin-system changes were ported onto the current `stream-json` runner path in this combined branch rather than reintroducing the old json/text execution path.
- Plugin service startup and `gateway_start` now run after Telegram/Discord channel senders are wired, so plugins can use the channel runtime during startup events.
- Plugin event context now includes `agentId` when an agent-scoped run is available.

## Verification

- `bun test`
- `bunx tsc --noEmit`
- `git diff --check origin/master..HEAD`
