### PR TITLE
feat: add listenGuilds for guild-wide Discord message listening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -291,6 +291,9 @@ function guildTriggerReason(message: DiscordMessage): string | null {
   const config = getSettings().discord;
   if (config.listenChannels.includes(message.channel_id)) return "listen_channel";
 
+  // Listen guild (respond to all messages in any channel/thread of this guild)
+  if (message.guild_id && config.listenGuilds.includes(message.guild_id)) return "listen_guild";
+
   // Thread whose parent channel is a listen channel
   const threadInfo = knownThreads.get(message.channel_id);
   if (threadInfo && config.listenChannels.includes(threadInfo.parentId)) return "listen_channel_thread";
@@ -1248,6 +1251,9 @@ export function startGateway(debug = false): void {
   console.log(`  Allowed users: ${config.allowedUserIds.length === 0 ? "all" : config.allowedUserIds.join(", ")}`);
   if (config.listenChannels.length > 0) {
     console.log(`  Listen channels: ${config.listenChannels.join(", ")}`);
+  }
+  if (config.listenGuilds.length > 0) {
+    console.log(`  Listen guilds: ${config.listenGuilds.join(", ")}`);
   }
   if (discordDebug) console.log("  Debug: enabled");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,7 +77,7 @@ const DEFAULT_SETTINGS: Settings = {
     forwardToTelegram: true,
   },
   telegram: { token: "", allowedUserIds: [], listenChats: [] },
-  discord: { token: "", allowedUserIds: [], listenChannels: [] },
+  discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
@@ -110,6 +110,7 @@ export interface DiscordConfig {
   token: string;
   allowedUserIds: string[]; // Discord snowflake IDs exceed Number.MAX_SAFE_INTEGER
   listenChannels: string[]; // Channel IDs where bot responds to all messages (no mention needed)
+  listenGuilds: string[]; // Guild IDs where bot responds to all messages in any channel/thread
 }
 
 export type SecurityLevel =
@@ -289,6 +290,9 @@ function parseSettings(
           : [],
       listenChannels: Array.isArray(raw.discord?.listenChannels)
         ? raw.discord.listenChannels.map(String)
+        : [],
+      listenGuilds: Array.isArray(raw.discord?.listenGuilds)
+        ? raw.discord.listenGuilds.map(String)
         : [],
     },
     security: {


### PR DESCRIPTION
## Credit

This is a cleaned-up port of the work originally proposed by **@justmaker** in #89. All credit for the idea and implementation goes to them. PR #89 is being closed in favour of this one to land cleanly on the current master.

## Problem

When using `listenChannels`, threads created in those channels rely on an in-memory `knownThreads` map to track parent-child relationships. This map is volatile — after a daemon restart, threads not already in `sessions.json` become unresponsive because the bot no longer recognises them as belonging to a listened channel.

## Solution

Add `discord.listenGuilds`: an array of guild IDs where the bot responds to **all messages** in any channel or thread, without per-channel setup.

```json
{
  "discord": {
    "listenGuilds": ["123456789012345678"]
  }
}
```

`listenGuilds` bypasses the `knownThreads` dependency entirely — all messages in the guild are handled regardless of thread-tracking state after a restart.

## Changes

- `src/config.ts` — `DiscordConfig.listenGuilds`, `DEFAULT_SETTINGS`, `parseSettings`
- `src/commands/discord.ts` — `listen_guild` trigger in `guildTriggerReason()`, startup log for configured guilds

## Backward compatible

- `listenGuilds` defaults to `[]` — no behaviour change unless configured
- Existing `listenChannels` behaviour is unchanged
- `listenGuilds` is checked after `listenChannels`, so per-channel config is logged/tracked with its existing label