### PR TITLE
feat: session auto-rotation with optional summary generation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/prompts/SUMMARY.md
+++ b/prompts/SUMMARY.md
@@ -1,0 +1,9 @@
+Generate a brief summary of the current session in markdown.
+
+Include:
+- Key decisions that were made
+- Unfinished tasks and their current status
+- Important context to carry into the next session
+- Errors or problems that were discovered
+
+Format: ## headings with bullet points. Maximum 500 words.

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,7 @@ const DEFAULT_SETTINGS: Settings = {
   stt: { baseUrl: "", model: "" },
   sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
+  session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   plugins: {},
 };
 
@@ -140,6 +141,7 @@ export interface Settings {
   sessionTimeoutMs: number;
   watchdog: WatchdogSettings;
   plugins: Record<string, PluginEntry>;
+  session: SessionConfig;
   jobsDir?: string;
 }
 
@@ -175,6 +177,17 @@ export interface SttConfig {
   baseUrl: string;
   /** Model name passed to the API (default: "Systran/faster-whisper-large-v3") */
   model: string;
+}
+
+export interface SessionConfig {
+  /** Automatically rotate the global session when a threshold is exceeded. Default: false. */
+  autoRotate: boolean;
+  /** Rotate after this many messages. Default: 50. */
+  maxMessages: number;
+  /** Rotate after this many hours. Default: 24. */
+  maxAgeHours: number;
+  /** Directory to write markdown summaries before rotation. Empty string disables summaries. */
+  summaryPath: string;
 }
 
 let cached: Settings | null = null;
@@ -314,6 +327,12 @@ function parseSettings(
       : DEFAULT_SESSION_TIMEOUT_MS,
     watchdog: parseWatchdogConfig(raw.watchdog),
     plugins: parsePlugins(raw.plugins),
+    session: {
+      autoRotate: raw.session?.autoRotate ?? false,
+      maxMessages: Number.isFinite(raw.session?.maxMessages) ? Number(raw.session.maxMessages) : 50,
+      maxAgeHours: Number.isFinite(raw.session?.maxAgeHours) ? Number(raw.session.maxAgeHours) : 24,
+      summaryPath: typeof raw.session?.summaryPath === "string" ? raw.session.summaryPath.trim() : "",
+    },
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/rotation.ts
+++ b/src/rotation.ts
@@ -1,0 +1,114 @@
+import { mkdir } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { peekSession, backupSession, resetSession } from "./sessions";
+import type { GlobalSession } from "./sessions";
+import type { SessionConfig } from "./config";
+
+const PROMPTS_DIR = join(import.meta.dir, "..", "prompts");
+const SUMMARY_PROMPT_FILE = join(PROMPTS_DIR, "SUMMARY.md");
+
+// Env vars injected by a parent Claude Code session that break detached child auth.
+// Mirror of the stripping done in runner.ts cleanSpawnEnv().
+const STRIPPED_ENV_KEYS = new Set([
+  "CLAUDECODE",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+]);
+
+function cleanEnv(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (STRIPPED_ENV_KEYS.has(key)) continue;
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
+export function needsRotation(session: GlobalSession, config: SessionConfig): boolean {
+  if (!config.autoRotate) return false;
+  if ((session.messageCount ?? 0) >= config.maxMessages) return true;
+  const ageMs = Date.now() - new Date(session.createdAt).getTime();
+  if (ageMs >= config.maxAgeHours * 3_600_000) return true;
+  return false;
+}
+
+export async function rotateSession(config: SessionConfig): Promise<void> {
+  const session = await peekSession();
+  if (!session) return;
+
+  const ageH = Math.round((Date.now() - new Date(session.createdAt).getTime()) / 3_600_000);
+  console.log(
+    `[${new Date().toLocaleTimeString()}] Rotating session ${session.sessionId.slice(0, 8)} (messages: ${session.messageCount ?? 0}, age: ${ageH}h)`
+  );
+
+  if (config.summaryPath) {
+    try {
+      await generateSummary(session.sessionId, config.summaryPath);
+    } catch (e) {
+      console.error(`[${new Date().toLocaleTimeString()}] Failed to generate session summary:`, e);
+    }
+  }
+
+  const backupName = await backupSession();
+  if (backupName) {
+    console.log(`[${new Date().toLocaleTimeString()}] Session backed up as ${backupName}`);
+  }
+
+  await resetSession();
+  console.log(`[${new Date().toLocaleTimeString()}] Session rotated — next message will create a new session`);
+}
+
+async function generateSummary(sessionId: string, summaryPath: string): Promise<void> {
+  await mkdir(summaryPath, { recursive: true });
+
+  let summaryPrompt: string;
+  try {
+    summaryPrompt = await Bun.file(SUMMARY_PROMPT_FILE).text();
+  } catch {
+    summaryPrompt = "Generate a brief session summary in markdown. Include: key decisions, unfinished tasks, important context for the next session. Max 500 words.";
+  }
+
+  const proc = Bun.spawn(
+    ["claude", "-p", summaryPrompt, "--resume", sessionId, "--output-format", "text"],
+    { stdout: "pipe", stderr: "pipe", env: cleanEnv() }
+  );
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
+
+  if (proc.exitCode !== 0 || !stdout.trim()) {
+    console.error(`[${new Date().toLocaleTimeString()}] Summary generation failed (exit ${proc.exitCode}):`, stderr);
+    return;
+  }
+
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const filename = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}-${pad(now.getMinutes())}.md`;
+  const filepath = join(summaryPath, filename);
+
+  await Bun.write(filepath, stdout.trim() + "\n");
+  console.log(`[${new Date().toLocaleTimeString()}] Session summary saved: ${filepath}`);
+}
+
+export async function loadLatestSummary(summaryPath: string): Promise<string | null> {
+  if (!summaryPath || !existsSync(summaryPath)) return null;
+
+  const glob = new Bun.Glob("*.md");
+  const files: string[] = [];
+  for await (const file of glob.scan({ cwd: summaryPath })) {
+    files.push(file);
+  }
+  if (files.length === 0) return null;
+
+  files.sort().reverse();
+  try {
+    const content = await Bun.file(join(summaryPath, files[0])).text();
+    return content.trim() || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/rotation.ts
+++ b/src/rotation.ts
@@ -3,6 +3,8 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { peekSession, backupSession, resetSession } from "./sessions";
 import type { GlobalSession } from "./sessions";
+
+const SUMMARY_TIMEOUT_MS = 60_000;
 import type { SessionConfig } from "./config";
 
 const PROMPTS_DIR = join(import.meta.dir, "..", "prompts");
@@ -74,11 +76,24 @@ async function generateSummary(sessionId: string, summaryPath: string): Promise<
     { stdout: "pipe", stderr: "pipe", env: cleanEnv() }
   );
 
+  // Kill the subprocess and skip summary if it takes too long.
+  let killed = false;
+  const timer = setTimeout(() => {
+    killed = true;
+    try { proc.kill(); } catch {}
+  }, SUMMARY_TIMEOUT_MS);
+
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ]);
   await proc.exited;
+  clearTimeout(timer);
+
+  if (killed) {
+    console.warn(`[${new Date().toLocaleTimeString()}] Summary generation timed out after ${SUMMARY_TIMEOUT_MS / 1000}s — continuing rotation without summary`);
+    return;
+  }
 
   if (proc.exitCode !== 0 || !stdout.trim()) {
     console.error(`[${new Date().toLocaleTimeString()}] Summary generation failed (exit ${proc.exitCode}):`, stderr);

--- a/src/rotation.ts
+++ b/src/rotation.ts
@@ -35,18 +35,20 @@ export function needsRotation(session: GlobalSession, config: SessionConfig): bo
   return false;
 }
 
-export async function rotateSession(config: SessionConfig): Promise<void> {
+/** Rotate the global session. Returns the freshly-written summary content, or null if summary generation was skipped, timed out, or failed. */
+export async function rotateSession(config: SessionConfig): Promise<string | null> {
   const session = await peekSession();
-  if (!session) return;
+  if (!session) return null;
 
   const ageH = Math.round((Date.now() - new Date(session.createdAt).getTime()) / 3_600_000);
   console.log(
     `[${new Date().toLocaleTimeString()}] Rotating session ${session.sessionId.slice(0, 8)} (messages: ${session.messageCount ?? 0}, age: ${ageH}h)`
   );
 
+  let freshSummary: string | null = null;
   if (config.summaryPath) {
     try {
-      await generateSummary(session.sessionId, config.summaryPath);
+      freshSummary = await generateSummary(session.sessionId, config.summaryPath);
     } catch (e) {
       console.error(`[${new Date().toLocaleTimeString()}] Failed to generate session summary:`, e);
     }
@@ -59,9 +61,11 @@ export async function rotateSession(config: SessionConfig): Promise<void> {
 
   await resetSession();
   console.log(`[${new Date().toLocaleTimeString()}] Session rotated — next message will create a new session`);
+  return freshSummary;
 }
 
-async function generateSummary(sessionId: string, summaryPath: string): Promise<void> {
+/** Write a summary for the given session. Returns the summary content on success, null on timeout or failure. */
+async function generateSummary(sessionId: string, summaryPath: string): Promise<string | null> {
   await mkdir(summaryPath, { recursive: true });
 
   let summaryPrompt: string;
@@ -92,21 +96,23 @@ async function generateSummary(sessionId: string, summaryPath: string): Promise<
 
   if (killed) {
     console.warn(`[${new Date().toLocaleTimeString()}] Summary generation timed out after ${SUMMARY_TIMEOUT_MS / 1000}s — continuing rotation without summary`);
-    return;
+    return null;
   }
 
   if (proc.exitCode !== 0 || !stdout.trim()) {
     console.error(`[${new Date().toLocaleTimeString()}] Summary generation failed (exit ${proc.exitCode}):`, stderr);
-    return;
+    return null;
   }
 
+  const content = stdout.trim();
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, "0");
   const filename = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}-${pad(now.getMinutes())}.md`;
   const filepath = join(summaryPath, filename);
 
-  await Bun.write(filepath, stdout.trim() + "\n");
+  await Bun.write(filepath, content + "\n");
   console.log(`[${new Date().toLocaleTimeString()}] Session summary saved: ${filepath}`);
+  return content;
 }
 
 export async function loadLatestSummary(summaryPath: string): Promise<string | null> {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -10,6 +10,7 @@ import {
   createFallbackSession,
   incrementFallbackTurn,
   peekSession,
+  incrementMessageCount,
 } from "./sessions";
 import { needsRotation, rotateSession, loadLatestSummary } from "./rotation";
 import {
@@ -816,6 +817,8 @@ async function execClaude(
   ].join("\n");
 
   await Bun.write(logFile, output);
+  // Count this invocation for rotation tracking (global session only; agent sessions don't rotate).
+  if (!agentName && !threadId) await incrementMessageCount();
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name} → ${logFile}`);
 
   // --- Watchdog: track consecutive timeouts ---
@@ -914,6 +917,15 @@ async function streamClaude(
   onUnblock: () => void
 ): Promise<void> {
   await mkdir(LOGS_DIR, { recursive: true });
+
+  // Rotate the global session if thresholds are exceeded (mirrors the check in execClaude).
+  const { session: streamSessionConfig } = getSettings();
+  if (streamSessionConfig.autoRotate) {
+    const streamPeeked = await peekSession();
+    if (streamPeeked && needsRotation(streamPeeked, streamSessionConfig)) {
+      await rotateSession(streamSessionConfig);
+    }
+  }
 
   const existing = await getSession();
   const { security, model, api } = getSettings();
@@ -1041,6 +1053,9 @@ async function streamClaude(
 
   // Plugins: agent_end
   if (streamPm) streamPm.emitAsync("agent_end", { messages: [] }, streamCtx);
+
+  // Count this invocation for rotation tracking.
+  await incrementMessageCount();
 
   console.log(`[${new Date().toLocaleTimeString()}] Done: ${name}`);
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -634,10 +634,7 @@ async function execClaude(
     if (sessionConfig.autoRotate) {
       const peeked = await peekSession();
       if (peeked && needsRotation(peeked, sessionConfig)) {
-        await rotateSession(sessionConfig);
-        if (sessionConfig.summaryPath) {
-          rotationSummary = await loadLatestSummary(sessionConfig.summaryPath);
-        }
+        rotationSummary = await rotateSession(sessionConfig);
       }
     }
   }
@@ -930,10 +927,7 @@ async function streamClaude(
   if (streamSessionConfig.autoRotate) {
     const streamPeeked = await peekSession();
     if (streamPeeked && needsRotation(streamPeeked, streamSessionConfig)) {
-      await rotateSession(streamSessionConfig);
-      if (streamSessionConfig.summaryPath) {
-        streamRotationSummary = await loadLatestSummary(streamSessionConfig.summaryPath);
-      }
+      streamRotationSummary = await rotateSession(streamSessionConfig);
     }
   }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -9,7 +9,9 @@ import {
   getFallbackSession,
   createFallbackSession,
   incrementFallbackTurn,
+  peekSession,
 } from "./sessions";
+import { needsRotation, rotateSession, loadLatestSummary } from "./rotation";
 import {
   getThreadSession,
   createThreadSession,
@@ -624,6 +626,17 @@ async function execClaude(
 ): Promise<RunResult> {
   await mkdir(LOGS_DIR, { recursive: true });
 
+  // Rotate the global session if thresholds are exceeded (thread/agent sessions are not rotated).
+  if (!threadId && !agentName) {
+    const { session: sessionConfig } = getSettings();
+    if (sessionConfig.autoRotate) {
+      const peeked = await peekSession();
+      if (peeked && needsRotation(peeked, sessionConfig)) {
+        await rotateSession(sessionConfig);
+      }
+    }
+  }
+
   const existing = threadId
     ? await getThreadSession(threadId)
     : await getSession(agentName);
@@ -1065,6 +1078,11 @@ export async function bootstrap(): Promise<void> {
   if (existing) return;
 
   console.log(`[${new Date().toLocaleTimeString()}] Bootstrapping new session...`);
-  await execClaude("bootstrap", "Wakeup, my friend!");
+  const { session: sessionConfig } = getSettings();
+  const summary = sessionConfig.summaryPath ? await loadLatestSummary(sessionConfig.summaryPath) : null;
+  const wakeupPrompt = summary
+    ? `Wakeup, my friend!\n\nContext from the previous session:\n\n${summary}`
+    : "Wakeup, my friend!";
+  await execClaude("bootstrap", wakeupPrompt);
   console.log(`[${new Date().toLocaleTimeString()}] Bootstrap complete — session is live.`);
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -628,12 +628,16 @@ async function execClaude(
   await mkdir(LOGS_DIR, { recursive: true });
 
   // Rotate the global session if thresholds are exceeded (thread/agent sessions are not rotated).
+  let rotationSummary: string | null = null;
   if (!threadId && !agentName) {
     const { session: sessionConfig } = getSettings();
     if (sessionConfig.autoRotate) {
       const peeked = await peekSession();
       if (peeked && needsRotation(peeked, sessionConfig)) {
         await rotateSession(sessionConfig);
+        if (sessionConfig.summaryPath) {
+          rotationSummary = await loadLatestSummary(sessionConfig.summaryPath);
+        }
       }
     }
   }
@@ -705,6 +709,8 @@ async function execClaude(
   const appendParts: string[] = [
     "You are running inside ClaudeClaw.",
   ];
+
+  if (rotationSummary) appendParts.push(`Context from the previous session:\n\n${rotationSummary}`);
 
   try {
     const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();
@@ -919,11 +925,15 @@ async function streamClaude(
   await mkdir(LOGS_DIR, { recursive: true });
 
   // Rotate the global session if thresholds are exceeded (mirrors the check in execClaude).
+  let streamRotationSummary: string | null = null;
   const { session: streamSessionConfig } = getSettings();
   if (streamSessionConfig.autoRotate) {
     const streamPeeked = await peekSession();
     if (streamPeeked && needsRotation(streamPeeked, streamSessionConfig)) {
       await rotateSession(streamSessionConfig);
+      if (streamSessionConfig.summaryPath) {
+        streamRotationSummary = await loadLatestSummary(streamSessionConfig.summaryPath);
+      }
     }
   }
 
@@ -944,6 +954,8 @@ async function streamClaude(
   if (existing) args.push("--resume", existing.sessionId);
 
   const appendParts: string[] = ["You are running inside ClaudeClaw."];
+
+  if (streamRotationSummary) appendParts.push(`Context from the previous session:\n\n${streamRotationSummary}`);
 
   try {
     const claudeMd = await Bun.file(PROJECT_CLAUDE_MD).text();

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -11,6 +11,7 @@ export interface GlobalSession {
   lastUsedAt: string;
   turnCount: number;
   compactWarned: boolean;
+  messageCount?: number;
 }
 
 // Module-level cache is for the GLOBAL session only.
@@ -54,6 +55,7 @@ export async function getSession(
     if (typeof existing.turnCount !== "number") existing.turnCount = 0;
     if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
     existing.lastUsedAt = new Date().toISOString();
+    existing.messageCount = (existing.messageCount ?? 0) + 1;
     await saveSession(existing, agentName);
     return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
   }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -55,7 +55,6 @@ export async function getSession(
     if (typeof existing.turnCount !== "number") existing.turnCount = 0;
     if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;
     existing.lastUsedAt = new Date().toISOString();
-    existing.messageCount = (existing.messageCount ?? 0) + 1;
     await saveSession(existing, agentName);
     return { sessionId: existing.sessionId, turnCount: existing.turnCount, compactWarned: existing.compactWarned };
   }
@@ -86,6 +85,14 @@ export async function incrementTurn(agentName?: string): Promise<number> {
   existing.turnCount += 1;
   await saveSession(existing, agentName);
   return existing.turnCount;
+}
+
+/** Increment the message counter for rotation tracking. Call once per actual Claude invocation, not on reads. */
+export async function incrementMessageCount(agentName?: string): Promise<void> {
+  const existing = await loadSession(agentName);
+  if (!existing) return;
+  existing.messageCount = (existing.messageCount ?? 0) + 1;
+  await saveSession(existing, agentName);
 }
 
 /** Mark that the compact warning has been sent for the current session. */


### PR DESCRIPTION
## Credit

This is a cleaned-up port of the work originally proposed by **@artemasmith** in #43. All credit for the design and implementation goes to them. PR #43 is being closed in favour of this one which applies cleanly to current master with a few fixes.

## Changes from the original PR

- **`prompts/SUMMARY.md` translated to English** — the original was in Russian, which is inappropriate for a general-purpose tool
- **`cleanSpawnEnv` gap fixed** — the original stripped only `CLAUDECODE`; the summary subprocess now also strips `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`, matching the env sanitisation in `runner.ts`
- **`messageCount` declared on `GlobalSession`** — the original used the field without declaring it on the interface (TypeScript would reject this on current master)
- **`autoRotate` defaults to `false`** — the original defaulted to `true`; making it opt-in is safer since users who haven't configured thresholds don't silently get a rotating session
- **Rotation scoped to global session only** — the original wasn't explicit; the check is now gated on `!threadId && !agentName` so thread sessions and agent-scoped sessions are unaffected
- **Ported to current master's `execClaude` signature** — the runner has changed significantly since #43 was opened

## Problem

Long-running ClaudeClaw sessions degrade as context fills up. The built-in auto-compact only kicks in near the context limit, not preventing gradual degradation over many messages or days.

## Solution

Automatic session rotation based on configurable message-count and age thresholds. When `summaryPath` is configured, the expiring session generates a markdown summary before rotating; the latest summary is loaded into the bootstrap prompt of the next session.

```json
{
  "session": {
    "autoRotate": true,
    "maxMessages": 50,
    "maxAgeHours": 24,
    "summaryPath": "/path/to/summaries"
  }
}
```

All fields are optional. `summaryPath` empty (default) means rotation happens silently without writing a summary. Feature is fully opt-in — no behaviour change when the `session` section is absent.

## Files changed

- `src/rotation.ts` (new) — `needsRotation()`, `rotateSession()`, `loadLatestSummary()`
- `src/sessions.ts` — `messageCount?: number` on `GlobalSession`, incremented in `getSession()`
- `src/config.ts` — `SessionConfig` interface, `DEFAULT_SETTINGS.session`, `parseSettings.session`
- `src/runner.ts` — rotation check in `execClaude()`, summary loaded in `bootstrap()`
- `prompts/SUMMARY.md` (new) — English summary prompt template