### PR TITLE
feat(web): session history browser

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1058,18 +1058,15 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
       var loadMoreBtn = document.getElementById("load-more-btn");
       if (!loadMore) {
         try {
-          // Fetch last N messages
+          // Single fetch: last N messages + total count in one response.
           var res = await fetch("/api/sessions/" + sessionId + "/messages?limit=" + BROWSE_PAGE + "&offset=-1");
-          var msgs = await res.json();
+          var data = await res.json();
+          var msgs = data.messages;
           if (!Array.isArray(msgs)) return;
+          browseTotalCount = typeof data.total === "number" ? data.total : msgs.length;
+          browseOffset = Math.max(0, browseTotalCount - BROWSE_PAGE);
           chatHistory = msgs.map(function(m) { return { role: m.role, text: m.text }; });
           renderChatHistory();
-
-          // Fetch total count for "load older" button
-          var countRes = await fetch("/api/sessions/" + sessionId + "/messages?limit=1000000&offset=0");
-          var allMsgs = await countRes.json();
-          browseTotalCount = Array.isArray(allMsgs) ? allMsgs.length : 0;
-          browseOffset = Math.max(0, browseTotalCount - BROWSE_PAGE);
           if (loadMoreContainer) loadMoreContainer.hidden = browseOffset <= 0;
           if (loadMoreBtn && browseOffset > 0) loadMoreBtn.textContent = "Load older (" + browseOffset + " more)";
         } catch (e) {}
@@ -1079,7 +1076,8 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         if (limit <= 0) return;
         try {
           var res2 = await fetch("/api/sessions/" + sessionId + "/messages?limit=" + limit + "&offset=" + newOffset);
-          var older = await res2.json();
+          var data2 = await res2.json();
+          var older = data2.messages;
           if (!Array.isArray(older)) return;
           var chatMsgsEl = document.getElementById("chat-messages");
           var scrollHeightBefore = chatMsgsEl ? chatMsgsEl.scrollHeight : 0;

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -973,7 +973,150 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     }
 
     if (tabDashboardBtn) tabDashboardBtn.addEventListener("click", () => setActiveTab("dashboard"));
-    if (tabChatBtn) tabChatBtn.addEventListener("click", () => setActiveTab("chat"));
+    if (tabChatBtn) tabChatBtn.addEventListener("click", function() { setActiveTab("chat"); loadSessions(); });
+
+    // --- Session browser ---
+
+    var activeBrowseSessionId = null;
+    var browseOffset = 0;
+    var browseTotalCount = 0;
+    var BROWSE_PAGE = 10;
+
+    function escapeHtml(text) {
+      var d = document.createElement("div");
+      d.textContent = text;
+      return d.innerHTML;
+    }
+
+    function formatSessionTime(isoStr) {
+      if (!isoStr) return "";
+      try {
+        var d = new Date(isoStr);
+        var now = new Date();
+        if (d.toDateString() === now.toDateString()) {
+          return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+        }
+        return d.toLocaleDateString([], { month: "short", day: "numeric" });
+      } catch { return ""; }
+    }
+
+    async function loadSessions() {
+      var listEl = document.getElementById("session-list");
+      if (!listEl) return;
+      try {
+        var res = await fetch("/api/sessions");
+        var sessions = await res.json();
+        if (!Array.isArray(sessions) || sessions.length === 0) {
+          listEl.innerHTML = '<div class="session-loading">No sessions yet</div>';
+          return;
+        }
+        listEl.innerHTML = "";
+        sessions.forEach(function(s) {
+          var item = document.createElement("div");
+          item.className = "session-item" + (s.id === activeBrowseSessionId ? " active" : "");
+          var preview = escapeHtml(s.lastMessage || s.firstMessage || "(empty)");
+          var channel = s.channel && s.channel !== "web" ? s.channel : "";
+          item.innerHTML =
+            '<div class="session-item-header">'
+            + '<span class="session-agent">' + escapeHtml(s.agent || "global") + "</span>"
+            + (channel ? '<span class="session-channel">' + escapeHtml(channel) + "</span>" : "")
+            + "</div>"
+            + '<div class="session-preview">' + preview + "</div>"
+            + '<div class="session-time">' + formatSessionTime(s.lastUsedAt) + " · " + (s.turnCount || 0) + " turns</div>";
+          item.addEventListener("click", function() { browseSession(s.id); });
+          listEl.appendChild(item);
+        });
+      } catch (e) {
+        listEl.innerHTML = '<div class="session-loading">Failed to load</div>';
+      }
+    }
+
+    async function browseSession(sessionId) {
+      activeBrowseSessionId = sessionId;
+      browseOffset = 0;
+      browseTotalCount = 0;
+
+      // Update sidebar highlight
+      document.querySelectorAll(".session-item").forEach(function(el) {
+        el.classList.toggle("active", el.dataset && el.dataset.sid === sessionId);
+      });
+      // Re-render sidebar to apply active class correctly
+      loadSessions();
+
+      // Show history banner
+      var banner = document.getElementById("chat-history-banner");
+      if (banner) banner.hidden = false;
+
+      // Load messages
+      chatHistory = [];
+      renderChatHistory();
+      await loadBrowseMessages(sessionId, false);
+    }
+
+    async function loadBrowseMessages(sessionId, loadMore) {
+      var loadMoreContainer = document.getElementById("load-more-container");
+      var loadMoreBtn = document.getElementById("load-more-btn");
+      if (!loadMore) {
+        try {
+          // Fetch last N messages
+          var res = await fetch("/api/sessions/" + sessionId + "/messages?limit=" + BROWSE_PAGE + "&offset=-1");
+          var msgs = await res.json();
+          if (!Array.isArray(msgs)) return;
+          chatHistory = msgs.map(function(m) { return { role: m.role, text: m.text }; });
+          renderChatHistory();
+
+          // Fetch total count for "load older" button
+          var countRes = await fetch("/api/sessions/" + sessionId + "/messages?limit=1000000&offset=0");
+          var allMsgs = await countRes.json();
+          browseTotalCount = Array.isArray(allMsgs) ? allMsgs.length : 0;
+          browseOffset = Math.max(0, browseTotalCount - BROWSE_PAGE);
+          if (loadMoreContainer) loadMoreContainer.hidden = browseOffset <= 0;
+          if (loadMoreBtn && browseOffset > 0) loadMoreBtn.textContent = "Load older (" + browseOffset + " more)";
+        } catch (e) {}
+      } else {
+        var newOffset = Math.max(0, browseOffset - BROWSE_PAGE);
+        var limit = browseOffset - newOffset;
+        if (limit <= 0) return;
+        try {
+          var res2 = await fetch("/api/sessions/" + sessionId + "/messages?limit=" + limit + "&offset=" + newOffset);
+          var older = await res2.json();
+          if (!Array.isArray(older)) return;
+          var chatMsgsEl = document.getElementById("chat-messages");
+          var scrollHeightBefore = chatMsgsEl ? chatMsgsEl.scrollHeight : 0;
+          chatHistory = older.map(function(m) { return { role: m.role, text: m.text }; }).concat(chatHistory);
+          browseOffset = newOffset;
+          renderChatHistory();
+          if (chatMsgsEl) chatMsgsEl.scrollTop = chatMsgsEl.scrollHeight - scrollHeightBefore;
+          if (loadMoreContainer) loadMoreContainer.hidden = browseOffset <= 0;
+          if (loadMoreBtn && browseOffset > 0) loadMoreBtn.textContent = "Load older (" + browseOffset + " more)";
+        } catch (e) {}
+      }
+    }
+
+    var newSessionBtn = document.getElementById("new-session-btn");
+    if (newSessionBtn) {
+      newSessionBtn.addEventListener("click", function() {
+        activeBrowseSessionId = null;
+        chatHistory = [];
+        renderChatHistory();
+        var banner = document.getElementById("chat-history-banner");
+        if (banner) banner.hidden = true;
+        var loadMoreContainer = document.getElementById("load-more-container");
+        if (loadMoreContainer) loadMoreContainer.hidden = true;
+        document.querySelectorAll(".session-item").forEach(function(el) { el.classList.remove("active"); });
+        if (chatInput) chatInput.focus();
+      });
+    }
+
+    var loadMoreBtn = document.getElementById("load-more-btn");
+    if (loadMoreBtn) {
+      loadMoreBtn.addEventListener("click", function() {
+        if (activeBrowseSessionId) loadBrowseMessages(activeBrowseSessionId, true);
+      });
+    }
+
+    // Load sessions on initial render
+    loadSessions();
 
     renderChatHistory();
 

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1371,4 +1371,156 @@ export const pageStyles = String.raw`    :root {
       .pill:nth-last-child(2) {
         border-bottom: 0;
       }
-    }`;
+    }
+
+/* --- Session browser layout --- */
+.chat-layout {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.chat-sidebar {
+  width: 260px;
+  min-width: 260px;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.chat-sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.chat-sidebar-header h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.new-session-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.new-session-btn:hover {
+  opacity: 0.85;
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.session-item {
+  padding: 9px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+}
+
+.session-item:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+.session-item.active {
+  background: rgba(255,255,255,0.08);
+  border-left: 3px solid var(--accent);
+  padding-left: 11px;
+}
+
+.session-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 3px;
+}
+
+.session-agent {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.session-channel {
+  font-size: 10px;
+  color: var(--fg-dim);
+  background: rgba(255,255,255,0.1);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.session-preview {
+  font-size: 12px;
+  color: var(--fg-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-time {
+  font-size: 10px;
+  color: var(--fg-dim);
+  margin-top: 2px;
+}
+
+.session-loading {
+  padding: 16px;
+  text-align: center;
+  color: var(--fg-dim);
+  font-size: 12px;
+}
+
+.chat-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.chat-history-banner {
+  padding: 5px 14px;
+  font-size: 11px;
+  color: var(--fg-dim);
+  background: rgba(255,255,255,0.04);
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.load-more-container {
+  text-align: center;
+  padding: 6px;
+  flex-shrink: 0;
+}
+
+.load-more-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg-dim);
+  padding: 4px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.load-more-btn:hover {
+  background: rgba(255,255,255,0.05);
+}
+
+@media (max-width: 600px) {
+  .chat-layout { flex-direction: column; }
+  .chat-sidebar { width: 100%; min-width: 100%; max-height: 180px; border-right: none; border-bottom: 1px solid var(--border); }
+}
+`;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -185,20 +185,39 @@ ${pageStyles}
     </section>
     </div>
     <div id="chat-panel" class="chat-panel" hidden>
-      <div id="chat-messages" class="chat-messages"></div>
-      <div class="chat-input-area">
-        <form id="chat-form" class="chat-form">
-          <textarea
-            id="chat-input"
-            class="chat-input"
-            placeholder="Message Claude..."
-            rows="1"
-            autocomplete="off"
-          ></textarea>
-          <button id="chat-cancel" class="chat-cancel" type="button" hidden>Cancel</button>
-          <button id="chat-send" class="chat-send" type="submit">Send</button>
-        </form>
-      </div>
+      <div class="chat-layout">
+        <div class="chat-sidebar" id="chat-sidebar">
+          <div class="chat-sidebar-header">
+            <h3>Sessions</h3>
+            <button id="new-session-btn" class="new-session-btn" type="button">+ New</button>
+          </div>
+          <div id="session-list" class="session-list">
+            <div class="session-loading">Loading…</div>
+          </div>
+        </div>
+        <div class="chat-main">
+          <div id="chat-history-banner" class="chat-history-banner" hidden>
+            Viewing history — new messages go to current session
+          </div>
+          <div id="load-more-container" class="load-more-container" hidden>
+            <button id="load-more-btn" class="load-more-btn" type="button">Load older messages</button>
+          </div>
+          <div id="chat-messages" class="chat-messages"></div>
+          <div class="chat-input-area">
+            <form id="chat-form" class="chat-form">
+              <textarea
+                id="chat-input"
+                class="chat-input"
+                placeholder="Message Claude..."
+                rows="1"
+                autocomplete="off"
+              ></textarea>
+              <button id="chat-cancel" class="chat-cancel" type="button" hidden>Cancel</button>
+              <button id="chat-send" class="chat-send" type="submit">Send</button>
+            </form>
+          </div>
+        </div><!-- chat-main -->
+      </div><!-- chat-layout -->
     </div>
   </main>
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -168,7 +168,7 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
 
       if (url.pathname.startsWith("/api/sessions/") && url.pathname.endsWith("/messages") && req.method === "GET") {
         const sessionId = url.pathname.slice("/api/sessions/".length, -"/messages".length);
-        const limit = clampInt(url.searchParams.get("limit"), 10, 1, 200);
+        const limit = clampInt(url.searchParams.get("limit"), 10, 1, 2000);
         const rawOffset = url.searchParams.get("offset");
         const offset = rawOffset === "-1" ? -1 : clampInt(rawOffset, 0, 0, 100_000);
         try {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -5,6 +5,7 @@ import { buildState, buildTechnicalInfo, sanitizeSettings } from "./services/sta
 import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/settings";
 import { createQuickJob, deleteJob } from "./services/jobs";
 import { readLogs } from "./services/logs";
+import { listSessions, readSessionMessages, listAgents } from "./services/sessions";
 
 export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
   const server = Bun.serve({
@@ -147,6 +148,34 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       if (url.pathname === "/api/logs") {
         const tail = clampInt(url.searchParams.get("tail"), 200, 20, 2000);
         return json(await readLogs(tail));
+      }
+
+      if (url.pathname === "/api/sessions" && req.method === "GET") {
+        try {
+          return json(await listSessions());
+        } catch (err) {
+          return json({ ok: false, error: String(err) });
+        }
+      }
+
+      if (url.pathname === "/api/agents" && req.method === "GET") {
+        try {
+          return json(await listAgents());
+        } catch (err) {
+          return json({ ok: false, error: String(err) });
+        }
+      }
+
+      if (url.pathname.startsWith("/api/sessions/") && url.pathname.endsWith("/messages") && req.method === "GET") {
+        const sessionId = url.pathname.slice("/api/sessions/".length, -"/messages".length);
+        const limit = clampInt(url.searchParams.get("limit"), 10, 1, 200);
+        const rawOffset = url.searchParams.get("offset");
+        const offset = rawOffset === "-1" ? -1 : clampInt(rawOffset, 0, 0, 100_000);
+        try {
+          return json(await readSessionMessages(sessionId, limit, offset));
+        } catch (err) {
+          return json({ ok: false, error: String(err) });
+        }
       }
 
       if (url.pathname === "/api/chat" && req.method === "POST") {

--- a/src/ui/services/sessions.ts
+++ b/src/ui/services/sessions.ts
@@ -188,19 +188,24 @@ export async function listSessions(): Promise<SessionInfo[]> {
   return sessions;
 }
 
+export interface MessagesResult {
+  messages: ChatMessage[];
+  total: number;
+}
+
 export async function readSessionMessages(
   sessionId: string,
   limit = 10,
   offset = 0,
-): Promise<ChatMessage[]> {
+): Promise<MessagesResult> {
   // Validate UUID shape before constructing file path (prevent path traversal).
-  if (!UUID_RE.test(sessionId)) return [];
+  if (!UUID_RE.test(sessionId)) return { messages: [], total: 0 };
 
   const filePath = join(getProjectDir(), `${sessionId}.jsonl`);
-  if (!existsSync(filePath)) return [];
+  if (!existsSync(filePath)) return { messages: [], total: 0 };
 
   const content = await readFile(filePath, "utf-8");
-  const messages: ChatMessage[] = [];
+  const all: ChatMessage[] = [];
 
   for (const line of content.split("\n")) {
     if (!line.trim()) continue;
@@ -209,14 +214,14 @@ export async function readSessionMessages(
       if (entry.type === "user") {
         const text = extractUserText(line);
         if (text) {
-          messages.push({ role: "user", text, timestamp: entry.timestamp ?? "", uuid: entry.uuid });
+          all.push({ role: "user", text, timestamp: entry.timestamp ?? "", uuid: entry.uuid });
         }
       } else if (entry.type === "assistant") {
         const parts = (entry.message?.content ?? [])
           .filter((c: any) => c.type === "text" && c.text)
           .map((c: any) => c.text as string);
         if (parts.length > 0) {
-          messages.push({
+          all.push({
             role: "assistant",
             text: parts.join("\n"),
             timestamp: entry.timestamp ?? "",
@@ -227,8 +232,9 @@ export async function readSessionMessages(
     } catch {}
   }
 
-  if (offset === -1) return messages.slice(-limit);
-  return messages.slice(offset, offset + limit);
+  const total = all.length;
+  const messages = offset === -1 ? all.slice(-limit) : all.slice(offset, offset + limit);
+  return { messages, total };
 }
 
 export async function listAgents(): Promise<Array<{ id: string; name: string }>> {

--- a/src/ui/services/sessions.ts
+++ b/src/ui/services/sessions.ts
@@ -1,0 +1,249 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { getAgentsDir } from "../../config";
+
+export interface SessionInfo {
+  id: string;
+  agent: string;
+  channel: "web" | "discord" | "agent" | "unknown";
+  lastUsedAt: string;
+  createdAt: string;
+  turnCount: number;
+  firstMessage: string;
+  lastMessage: string;
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: string;
+  uuid?: string;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DISCORD_SNOWFLAKE_RE = /^\d{17,19}$/;
+
+// Must match Claude Code's JSONL directory sanitizer (slashes, backslashes, dots → dashes).
+function getProjectDir(): string {
+  const sanitized = process.cwd().replace(/[/\\.]/g, "-");
+  return join(homedir(), ".claude", "projects", sanitized);
+}
+
+function extractUserText(line: string): string {
+  if (!line.trim()) return "";
+  try {
+    const entry = JSON.parse(line);
+    if (entry.type !== "user") return "";
+    const msg = entry.message;
+    let raw = "";
+    if (typeof msg?.content === "string") {
+      raw = msg.content;
+    } else if (Array.isArray(msg?.content)) {
+      raw = msg.content
+        .filter((c: any) => c.type === "text")
+        .map((c: any) => c.text as string)
+        .join("\n");
+    }
+    // Strip ClaudeClaw-injected prefix blocks, keep the user's actual text in full.
+    raw = raw
+      .replace(/^\[[\d-]+ [\d:]+ UTC[^\]]*\]\n/m, "")
+      .replace(/^\[(?:WhatsApp|Slack|Discord)[^\]]*\]\n/m, "")
+      .replace(/^## Slack Directives[\s\S]*?(?=\n[A-Z\[]|\n$)/m, "")
+      .trim();
+    return raw;
+  } catch {
+    return "";
+  }
+}
+
+// Single file read to get both the first and last user message (for sidebar preview).
+async function peekMessages(sessionId: string): Promise<{ first: string; last: string }> {
+  if (!UUID_RE.test(sessionId)) return { first: "", last: "" };
+  const filePath = join(getProjectDir(), `${sessionId}.jsonl`);
+  if (!existsSync(filePath)) return { first: "", last: "" };
+  let first = "";
+  let last = "";
+  try {
+    const content = await readFile(filePath, "utf-8");
+    for (const line of content.split("\n")) {
+      const text = extractUserText(line);
+      if (text) {
+        if (!first) first = text.substring(0, 100);
+        last = text.substring(0, 100);
+      }
+    }
+  } catch {}
+  return { first, last };
+}
+
+export async function listSessions(): Promise<SessionInfo[]> {
+  const cwd = process.cwd();
+  const sessionFile = join(cwd, ".claude", "claudeclaw", "session.json");
+  const sessionsFile = join(cwd, ".claude", "claudeclaw", "sessions.json");
+
+  const sessions: SessionInfo[] = [];
+  const knownIds = new Set<string>();
+
+  // Global web session
+  try {
+    if (existsSync(sessionFile)) {
+      const data = JSON.parse(await readFile(sessionFile, "utf-8"));
+      if (UUID_RE.test(data.sessionId)) {
+        const { first, last } = await peekMessages(data.sessionId);
+        sessions.push({
+          id: data.sessionId,
+          agent: "global",
+          channel: "web",
+          lastUsedAt: data.lastUsedAt || data.createdAt,
+          createdAt: data.createdAt,
+          turnCount: data.turnCount ?? 0,
+          firstMessage: first,
+          lastMessage: last,
+        });
+        knownIds.add(data.sessionId);
+      }
+    }
+  } catch {}
+
+  // Per-agent sessions — agents/<name>/session.json
+  try {
+    const agentsDir = getAgentsDir();
+    const entries = await readdir(agentsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const agentSessionFile = join(agentsDir, entry.name, "session.json");
+      if (!existsSync(agentSessionFile)) continue;
+      try {
+        const data = JSON.parse(await readFile(agentSessionFile, "utf-8"));
+        if (!UUID_RE.test(data.sessionId) || knownIds.has(data.sessionId)) continue;
+        const { first, last } = await peekMessages(data.sessionId);
+        sessions.push({
+          id: data.sessionId,
+          agent: entry.name,
+          channel: "agent",
+          lastUsedAt: data.lastUsedAt || data.createdAt,
+          createdAt: data.createdAt,
+          turnCount: data.turnCount ?? 0,
+          firstMessage: first,
+          lastMessage: last,
+        });
+        knownIds.add(data.sessionId);
+      } catch {}
+    }
+  } catch {}
+
+  // Thread sessions (Discord snowflakes; skip unrecognised thread ID formats)
+  try {
+    if (existsSync(sessionsFile)) {
+      const data = JSON.parse(await readFile(sessionsFile, "utf-8"));
+      for (const [threadId, thread] of Object.entries(data.threads ?? {})) {
+        const t = thread as any;
+        if (!UUID_RE.test(t.sessionId) || knownIds.has(t.sessionId)) continue;
+        if (!DISCORD_SNOWFLAKE_RE.test(threadId)) continue;
+        const { first, last } = await peekMessages(t.sessionId);
+        sessions.push({
+          id: t.sessionId,
+          agent: "global",
+          channel: "discord",
+          lastUsedAt: t.lastUsedAt || t.createdAt,
+          createdAt: t.createdAt,
+          turnCount: t.turnCount ?? 0,
+          firstMessage: first,
+          lastMessage: last,
+        });
+        knownIds.add(t.sessionId);
+      }
+    }
+  } catch {}
+
+  // Orphan JSONL sessions not tracked by any session file (up to 20 most recent)
+  try {
+    const projectDir = getProjectDir();
+    const files = (await readdir(projectDir)).filter(f => f.endsWith(".jsonl"));
+    const candidates = files
+      .map(f => basename(f, ".jsonl"))
+      .filter(id => UUID_RE.test(id) && !knownIds.has(id))
+      .slice(-20);
+    for (const id of candidates) {
+      try {
+        const fileStat = await stat(join(projectDir, `${id}.jsonl`));
+        const { first, last } = await peekMessages(id);
+        sessions.push({
+          id,
+          agent: "unknown",
+          channel: "unknown",
+          lastUsedAt: fileStat.mtime.toISOString(),
+          createdAt: fileStat.birthtime.toISOString(),
+          turnCount: 0,
+          firstMessage: first,
+          lastMessage: last,
+        });
+      } catch {}
+    }
+  } catch {}
+
+  sessions.sort((a, b) => new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime());
+  return sessions;
+}
+
+export async function readSessionMessages(
+  sessionId: string,
+  limit = 10,
+  offset = 0,
+): Promise<ChatMessage[]> {
+  // Validate UUID shape before constructing file path (prevent path traversal).
+  if (!UUID_RE.test(sessionId)) return [];
+
+  const filePath = join(getProjectDir(), `${sessionId}.jsonl`);
+  if (!existsSync(filePath)) return [];
+
+  const content = await readFile(filePath, "utf-8");
+  const messages: ChatMessage[] = [];
+
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === "user") {
+        const text = extractUserText(line);
+        if (text) {
+          messages.push({ role: "user", text, timestamp: entry.timestamp ?? "", uuid: entry.uuid });
+        }
+      } else if (entry.type === "assistant") {
+        const parts = (entry.message?.content ?? [])
+          .filter((c: any) => c.type === "text" && c.text)
+          .map((c: any) => c.text as string);
+        if (parts.length > 0) {
+          messages.push({
+            role: "assistant",
+            text: parts.join("\n"),
+            timestamp: entry.timestamp ?? "",
+            uuid: entry.uuid,
+          });
+        }
+      }
+    } catch {}
+  }
+
+  if (offset === -1) return messages.slice(-limit);
+  return messages.slice(offset, offset + limit);
+}
+
+export async function listAgents(): Promise<Array<{ id: string; name: string }>> {
+  const agentsDir = getAgentsDir();
+  const agents: Array<{ id: string; name: string }> = [{ id: "mike", name: "mike" }];
+  const seen = new Set<string>(["mike"]);
+
+  try {
+    const entries = await readdir(agentsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || seen.has(entry.name)) continue;
+      seen.add(entry.name);
+      agents.push({ id: entry.name, name: entry.name });
+    }
+  } catch {}
+
+  return agents;
+}


### PR DESCRIPTION
Closes #85

Clean port of #85 (saravmajestic) with all correctness issues from squirblej's review (final comment on #85) applied. Attributing both contributors.

## What this PR does

Adds a **read-only session history browser** to the web chat UI:

- Session sidebar listing all active sessions (global, per-agent, Discord threads, orphaned JSONL files), sorted by last used
- Click a session to view its full transcript with paginated "Load older" support
- "+ New" button clears the history view and returns to live chat
- Three new API endpoints: `GET /api/sessions`, `GET /api/sessions/:id/messages`, `GET /api/agents`

## Fixes applied from squirblej's review

| Issue | Fix |
|---|---|
| Wrong agent directory (`listAgents` read `.claude/agents/`) | Uses `getAgentsDir()` from config — `agents/<name>/` |
| All sessions labelled `mike` | Reads `agents/<name>/session.json` per-agent; labels by agent name |
| Fabricated channel taxonomy (`slk:`, `whatsapp`) | Discord snowflake detection (`/^\d{17,19}$/`); no other channels fabricated |
| `getProjectDir()` incomplete sanitizer | Replaces `/`, `\`, and `.` to handle dotted path segments |
| Double JSONL read per session | Single file read extracts both first and last message |
| Multi-line message truncation (`.split("\n").pop()`) | Full text kept after prefix-block strip |
| Path traversal in `/api/sessions/:id/messages` | UUID shape validated before file path is constructed |
| `json(x, 500)` wrong signature | All error responses use single-arg `json({ ok: false, error })` |
| Dead `#agent-selector` sidebar element | Removed |
| `setActiveTab` monkey-patch | Direct second event listener on the chat tab button |

## What's NOT included

Requires extending `streamClaude` to accept `sessionId`/`agentName` — flagged by squirblej as the core wiring problem:

- **Session resume**: sending a new message into a selected historical session
- **Agent targeting**: routing the web chat to a specific agent

The sidebar shows history only. The chat input continues to go to the current active session; a "Viewing history" banner makes this explicit.

## Validation

- `bun install` ✓
- `bun test` — 86 pass, 0 fail ✓
- `bunx tsc --noEmit` ✓
- `git diff --check origin/master...HEAD` ✓

## Attribution

Original PR #85 concept and API endpoint structure: saravmajestic
Comprehensive bug analysis that informed all fixes: squirblej
