### PR TITLE
feat: add sub-agent lifecycle events to web chat stream

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -503,13 +503,13 @@ export async function start(args: string[] = []) {
             updateState();
             console.log(`[${ts()}] Jobs reloaded from Web UI`);
           },
-          onChat: async (message, onChunk, onUnblock) => {
+          onChat: async (message, onChunk, onUnblock, onAgentEvent) => {
             const wizardCtx = { iface: "web" as const, scopeId: "default" };
             if (isWizardTrigger(message) || hasActiveWizard(wizardCtx)) {
               onChunk(await handleWizardInput(wizardCtx, message));
               return;
             }
-            await streamUserMessage("chat", message, onChunk, onUnblock);
+            await streamUserMessage("chat", message, onChunk, onUnblock, onAgentEvent);
           },
         });
       } catch (err) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1037,13 +1037,15 @@ async function streamClaude(
               textEmitted = true;
               hasActivity = true;
             }
-            // Detect Agent tool spawns
+            // Detect Agent tool spawns and emit lifecycle event
             if (block.type === "tool_use" && block.name === "Agent" && block.id && onAgentEvent) {
               const description = String(block.input?.description ?? block.input?.prompt ?? "Running background task...");
               pendingAgents.set(block.id, description);
               onAgentEvent({ type: "spawn", id: block.id, description });
               hasActivity = true;
-            } else if (block.type === "tool_use") {
+            }
+            // Always emit plugin observation for all tool_use blocks (including Agent)
+            if (block.type === "tool_use") {
               hasActivity = true;
               if (streamPm && block.name) {
                 streamPm.emitAsync("tool_result_persist", {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -116,6 +116,13 @@ export interface RunResult {
   exitCode: number;
 }
 
+export interface AgentStreamEvent {
+  type: "spawn" | "done";
+  id: string;
+  description: string;
+  result?: string;
+}
+
 const RATE_LIMIT_PATTERN = /you.ve hit your limit|out of extra usage/i;
 
 // Serial queue — prevents concurrent --resume on the same session
@@ -917,7 +924,8 @@ async function streamClaude(
   name: string,
   prompt: string,
   onChunk: (text: string) => void,
-  onUnblock: () => void
+  onUnblock: () => void,
+  onAgentEvent?: (ev: AgentStreamEvent) => void
 ): Promise<void> {
   await mkdir(LOGS_DIR, { recursive: true });
 
@@ -985,6 +993,8 @@ async function streamClaude(
   let buf = "";
   let unblocked = false;
   let textEmitted = false;
+  // Track pending Agent tool calls: tool_use_id → description
+  const pendingAgents = new Map<string, string>();
 
   const maybeUnblock = () => {
     if (!unblocked) {
@@ -1026,6 +1036,13 @@ async function streamClaude(
               onChunk(block.text);
               textEmitted = true;
               hasActivity = true;
+            }
+            // Detect Agent tool spawns
+            if (block.type === "tool_use" && block.name === "Agent" && block.id && onAgentEvent) {
+              const description = String(block.input?.description ?? block.input?.prompt ?? "Running background task...");
+              pendingAgents.set(block.id, description);
+              onAgentEvent({ type: "spawn", id: block.id, description });
+              hasActivity = true;
             } else if (block.type === "tool_use") {
               hasActivity = true;
               if (streamPm && block.name) {
@@ -1038,6 +1055,21 @@ async function streamClaude(
             }
           }
           if (hasActivity) maybeUnblock();
+        } else if (event.type === "user") {
+          // Tool results come back as user messages — match Agent completions
+          type ToolResultBlock = { type: string; tool_use_id?: string; content?: unknown };
+          const msg = event.message as { content?: ToolResultBlock[] } | undefined;
+          const blocks = msg?.content ?? [];
+          for (const block of blocks) {
+            if (block.type === "tool_result" && block.tool_use_id && pendingAgents.has(block.tool_use_id)) {
+              const description = pendingAgents.get(block.tool_use_id)!;
+              pendingAgents.delete(block.tool_use_id);
+              const result = typeof block.content === "string"
+                ? block.content
+                : JSON.stringify(block.content ?? "");
+              if (onAgentEvent) onAgentEvent({ type: "done", id: block.tool_use_id, description, result });
+            }
+          }
         } else if (event.type === "tool_use") {
           // Top-level tool_use event (some stream-json versions) — unblock the UI
           maybeUnblock();
@@ -1070,9 +1102,10 @@ export async function streamUserMessage(
   name: string,
   prompt: string,
   onChunk: (text: string) => void,
-  onUnblock: () => void
+  onUnblock: () => void,
+  onAgentEvent?: (ev: AgentStreamEvent) => void
 ): Promise<void> {
-  return enqueue(() => streamClaude(name, prefixUserMessageWithClock(prompt), onChunk, onUnblock));
+  return enqueue(() => streamClaude(name, prefixUserMessageWithClock(prompt), onChunk, onUnblock, onAgentEvent));
 }
 
 function prefixUserMessageWithClock(prompt: string): string {

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1175,8 +1175,19 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
       if (msg.role === "agent") {
         var agentCls = "chat-msg chat-msg-agent" + (msg.agentStatus === "running" ? " chat-msg-agent-running" : " chat-msg-agent-done");
         if (msgEl.className !== agentCls) msgEl.className = agentCls;
-        var agentText = (msg.text || "") + (msg.agentStatus === "running" ? ' <span class="chat-agent-spinner">…</span>' : "");
-        if (msgEl.innerHTML !== agentText) msgEl.innerHTML = agentText;
+        var agentPlainText = msg.text || "";
+        var existingSpinner = msgEl.querySelector(".chat-agent-spinner");
+        if (msgEl.dataset.agentText !== agentPlainText || msgEl.dataset.agentStatus !== msg.agentStatus) {
+          msgEl.textContent = agentPlainText;
+          msgEl.dataset.agentText = agentPlainText;
+          msgEl.dataset.agentStatus = msg.agentStatus || "";
+          if (msg.agentStatus === "running") {
+            var spinner = document.createElement("span");
+            spinner.className = "chat-agent-spinner";
+            spinner.textContent = "…";
+            msgEl.appendChild(spinner);
+          }
+        }
         return;
       }
 

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1120,7 +1120,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
 
     function saveChatHistory() {
       try {
-        var toSave = chatHistory.filter(function(m) { return !m.streaming; });
+        var toSave = chatHistory.filter(function(m) { return !m.streaming && m.agentStatus !== "running"; });
         localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(toSave));
       } catch (_) {}
     }
@@ -1171,6 +1171,15 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     }
 
     function syncChatMessageEl(msgEl, msg, elapsedMs) {
+      // Agent bubbles: simple centered pill, no role/text structure
+      if (msg.role === "agent") {
+        var agentCls = "chat-msg chat-msg-agent" + (msg.agentStatus === "running" ? " chat-msg-agent-running" : " chat-msg-agent-done");
+        if (msgEl.className !== agentCls) msgEl.className = agentCls;
+        var agentText = (msg.text || "") + (msg.agentStatus === "running" ? ' <span class="chat-agent-spinner">…</span>' : "");
+        if (msgEl.innerHTML !== agentText) msgEl.innerHTML = agentText;
+        return;
+      }
+
       var roleEl = msgEl.querySelector(".chat-msg-role");
       var textEl = msgEl.querySelector(".chat-msg-text");
       if (!roleEl || !textEl) {
@@ -1307,6 +1316,25 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
                 setChatBusy(false);
                 chatHistory[assistantIdx].background = true;
                 renderChatHistory();
+              } else if (ev.type === "agent_spawn") {
+                chatHistory.push({ role: "agent", agentId: ev.id, text: "🤖 Sub-agent started: " + ev.description, agentStatus: "running" });
+                renderChatHistory();
+              } else if (ev.type === "agent_done") {
+                var agentBubble = null;
+                for (var k = chatHistory.length - 1; k >= 0; k--) {
+                  if (chatHistory[k].role === "agent" && chatHistory[k].agentId === ev.id) {
+                    agentBubble = chatHistory[k];
+                    break;
+                  }
+                }
+                if (agentBubble) {
+                  agentBubble.agentStatus = "done";
+                  agentBubble.text = "✅ Sub-agent done: " + ev.description;
+                } else {
+                  chatHistory.push({ role: "agent", agentId: ev.id, text: "✅ Sub-agent done: " + ev.description, agentStatus: "done" });
+                }
+                renderChatHistory();
+                saveChatHistory();
               } else if (ev.type === "done") {
                 chatHistory[assistantIdx].streaming = false;
                 chatHistory[assistantIdx].background = false;

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1313,6 +1313,31 @@ export const pageStyles = String.raw`    :root {
       margin-top: 4px;
       animation: caret 2s step-end infinite;
     }
+    .chat-msg-agent {
+      align-self: center;
+      max-width: 90%;
+      background: rgba(90, 130, 170, 0.08);
+      border: 1px solid rgba(90, 130, 170, 0.25);
+      border-radius: 8px;
+      padding: 6px 12px;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 11px;
+      color: #7aaac8;
+      letter-spacing: 0.02em;
+    }
+    .chat-msg-agent-running {
+      color: #8ac0e8;
+      border-color: rgba(100, 160, 200, 0.4);
+    }
+    .chat-msg-agent-done {
+      color: #5a9a7a;
+      border-color: rgba(90, 154, 122, 0.35);
+      background: rgba(90, 154, 122, 0.06);
+    }
+    .chat-agent-spinner {
+      opacity: 0.6;
+      animation: caret 1.2s step-end infinite;
+    }
 
     @media (max-width: 640px) {
       .stage {

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -196,7 +196,8 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
                 await onChat(
                   message,
                   (chunk) => send({ type: "chunk", text: chunk }),
-                  () => send({ type: "unblock" })
+                  () => send({ type: "unblock" }),
+                  (ev) => send({ type: ev.type === "spawn" ? "agent_spawn" : "agent_done", id: ev.id, description: ev.description, result: ev.result })
                 );
                 send({ type: "done" });
               } catch (err) {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,5 +1,6 @@
 import type { Settings } from "../config";
 import type { Job } from "../jobs";
+export type { AgentStreamEvent } from "../runner";
 
 export interface WebSnapshot {
   pid: number;
@@ -30,6 +31,7 @@ export interface StartWebUiOptions {
   onChat?: (
     message: string,
     onChunk: (text: string) => void,
-    onUnblock: () => void
+    onUnblock: () => void,
+    onAgentEvent: (ev: import("../runner").AgentStreamEvent) => void
   ) => Promise<void>;
 }


### PR DESCRIPTION
Closes #41

Clean port of #41 (chetan-guevara) targeting master's existing `streamClaude()` implementation. All new code layered on top of master's stream-json infrastructure. Attributing original author.

## What this PR does

Adds sub-agent lifecycle event streaming to the web chat UI:

### Server side (`src/runner.ts`)

- `AgentStreamEvent` interface: `{ type: "spawn"|"done", id, description, result? }`
- `streamClaude()` accepts optional `onAgentEvent?: (ev: AgentStreamEvent) => void`
- `pendingAgents` Map tracks `tool_use_id → description` across the NDJSON stream
- Detects `Agent` tool spawns inside `assistant` content blocks → fires `"spawn"` event
- Detects `tool_result` blocks in `user` messages → matches by `tool_use_id` → fires `"done"` event
- `streamUserMessage()` passes `onAgentEvent` through to `streamClaude()`

### Plumbing (`src/ui/types.ts`, `src/ui/server.ts`, `src/commands/start.ts`)

- `types.ts`: re-exports `AgentStreamEvent`; adds `onAgentEvent` as 4th param to `onChat`
- `server.ts`: maps `AgentStreamEvent` to `agent_spawn` / `agent_done` SSE events on the `/api/chat` stream
- `start.ts`: threads `onAgentEvent` from `onChat` → `streamUserMessage()`

### UI (`src/ui/page/script.ts`, `src/ui/page/styles.ts`)

- Handles `agent_spawn` / `agent_done` SSE event types in the chat stream reader
- Agent activity rendered as centered pill bubbles: running (blue, spinner) → done (green, checkmark)
- `saveChatHistory()` filters out `agentStatus: "running"` entries (don't persist mid-flight agents)
- New CSS classes: `.chat-msg-agent`, `.chat-msg-agent-running`, `.chat-msg-agent-done`, `.chat-agent-spinner`

## Difference from original PR #41

Original PR #41 was based on an older master that didn't have `streamClaude()` yet — it added the entire function from scratch. Master now has `streamClaude()` with a working stream-json parser. This port layers the agent-tracking additions on top of master's implementation, preserving:

- `cleanSpawnEnv()` (master's version, not the older `{ CLAUDECODE: _, ...cleanEnv }` destructure)
- Plugin hooks, session rotation, fallback model, watchdog integration
- Correct `createSession()` call for new sessions inside stream-json

The `script.ts` agent rendering uses master's DOM-diffing `syncChatMessageEl()` architecture rather than replacing everything with innerHTML (which was in the original PR because the chat UI didn't exist yet when it was written).

## Validation

- `bun install` ✓
- `bun test` — 95 pass, 0 fail ✓
- `bunx tsc --noEmit` ✓
- `git diff --check origin/master...HEAD` ✓

## Attribution

Original concept and implementation: @chetan-guevara (PR #41)
