### PR TITLE
feat(api): add POST /api/inject endpoint for external message injection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -377,13 +377,13 @@ export async function start(args: string[] = []) {
   let telegramSend: ((chatId: number, text: string) => Promise<void>) | null = null;
   let telegramToken = "";
 
-  async function initTelegram(token: string) {
+  async function initTelegram(token: string, receiveEnabled = true) {
     if (token && token !== telegramToken) {
       const { startPolling, sendMessage } = await import("./telegram");
-      startPolling(debugFlag);
+      if (receiveEnabled) startPolling(debugFlag);
       telegramSend = (chatId, text) => sendMessage(token, chatId, text);
       telegramToken = token;
-      console.log(`[${ts()}] Telegram: enabled`);
+      console.log(`[${ts()}] Telegram: enabled${receiveEnabled ? "" : " (send-only)"}`);
     } else if (!token && telegramToken) {
       telegramSend = null;
       telegramToken = "";
@@ -391,7 +391,7 @@ export async function start(args: string[] = []) {
     }
   }
 
-  await initTelegram(currentSettings.telegram.token);
+  await initTelegram(currentSettings.telegram.token, currentSettings.telegram.receiveEnabled);
   if (!telegramToken) console.log("  Telegram: not configured");
 
   // --- Discord ---
@@ -707,7 +707,7 @@ export async function start(args: string[] = []) {
       currentJobs = newJobs;
 
       // Telegram changes
-      await initTelegram(newSettings.telegram.token);
+      await initTelegram(newSettings.telegram.token, newSettings.telegram.receiveEnabled);
 
       // Discord changes
       await initDiscord(newSettings.discord.token);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -376,6 +376,7 @@ export async function start(args: string[] = []) {
   // --- Telegram ---
   let telegramSend: ((chatId: number, text: string) => Promise<void>) | null = null;
   let telegramToken = "";
+  let telegramReceiveEnabled = true;
 
   async function initTelegram(token: string, receiveEnabled = true) {
     if (token && token !== telegramToken) {
@@ -383,7 +384,18 @@ export async function start(args: string[] = []) {
       if (receiveEnabled) startPolling(debugFlag);
       telegramSend = (chatId, text) => sendMessage(token, chatId, text);
       telegramToken = token;
+      telegramReceiveEnabled = receiveEnabled;
       console.log(`[${ts()}] Telegram: enabled${receiveEnabled ? "" : " (send-only)"}`);
+    } else if (token && token === telegramToken && receiveEnabled !== telegramReceiveEnabled) {
+      const { startPolling, stopPolling } = await import("./telegram");
+      if (receiveEnabled) {
+        startPolling(debugFlag);
+        console.log(`[${ts()}] Telegram: receive enabled`);
+      } else {
+        stopPolling();
+        console.log(`[${ts()}] Telegram: receive disabled (send-only)`);
+      }
+      telegramReceiveEnabled = receiveEnabled;
     } else if (!token && telegramToken) {
       telegramSend = null;
       telegramToken = "";

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -967,8 +967,13 @@ async function registerBotCommands(token: string): Promise<void> {
 
 let running = true;
 let isPolling = false;
+// Monotonically increasing counter. Each startPolling() call captures the
+// value at the time it starts. The poll loop checks it after every await so
+// a stale loop exits cleanly when stopPolling() or a subsequent startPolling()
+// increments the counter, even if a long-poll request is still in flight.
+let pollingGeneration = 0;
 
-async function poll(): Promise<void> {
+async function poll(generation: number): Promise<void> {
   const config = getSettings().telegram;
   let offset = 0;
   try {
@@ -990,13 +995,16 @@ async function poll(): Promise<void> {
   // Register available skills as bot command menu (non-blocking)
   registerBotCommands(config.token).catch(() => {});
 
-  while (running) {
+  while (running && pollingGeneration === generation) {
     try {
       const data = await callApi<{ ok: boolean; result: TelegramUpdate[] }>(
         config.token,
         "getUpdates",
         { offset, timeout: 30, allowed_updates: ["message", "my_chat_member", "callback_query"] }
       );
+
+      // Check generation after the in-flight long-poll request returns.
+      if (pollingGeneration !== generation) break;
 
       if (!data.ok || !data.result.length) continue;
 
@@ -1028,11 +1036,14 @@ async function poll(): Promise<void> {
         }
       }
     } catch (err) {
+      if (pollingGeneration !== generation) break;
       if (!running) break;
       console.error(`[Telegram] Poll error: ${err instanceof Error ? err.message : err}`);
       await Bun.sleep(5000);
     }
   }
+
+  if (pollingGeneration === generation) isPolling = false;
 }
 
 // --- Exports ---
@@ -1049,17 +1060,24 @@ export function startPolling(debug = false): void {
   running = true;
   isPolling = true;
   telegramDebug = debug;
+  const gen = ++pollingGeneration;
   (async () => {
     await ensureProjectClaudeMd();
-    await poll();
+    await poll(gen);
   })().catch((err) => {
-    console.error(`[Telegram] Fatal: ${err}`);
-    isPolling = false;
+    if (pollingGeneration === gen) {
+      console.error(`[Telegram] Fatal: ${err}`);
+      isPolling = false;
+    }
   });
 }
 
-/** Stop polling in-process (called by start.ts when receiveEnabled is toggled off) */
+/** Stop polling in-process (called by start.ts when receiveEnabled is toggled off).
+ *  Increments the generation token so the in-flight long-poll loop exits as soon
+ *  as its current getUpdates call returns, even if running is briefly reset to true
+ *  by a concurrent startPolling() call. */
 export function stopPolling(): void {
+  pollingGeneration++;
   running = false;
   isPolling = false;
 }
@@ -1068,5 +1086,5 @@ export function stopPolling(): void {
 export async function telegram() {
   await loadSettings();
   await ensureProjectClaudeMd();
-  await poll();
+  await poll(++pollingGeneration);
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1046,6 +1046,7 @@ process.on("SIGINT", () => { running = false; });
 /** Start polling in-process (called by start.ts when token is configured) */
 export function startPolling(debug = false): void {
   if (isPolling) return;
+  running = true;
   isPolling = true;
   telegramDebug = debug;
   (async () => {
@@ -1055,6 +1056,12 @@ export function startPolling(debug = false): void {
     console.error(`[Telegram] Fatal: ${err}`);
     isPolling = false;
   });
+}
+
+/** Stop polling in-process (called by start.ts when receiveEnabled is toggled off) */
+export function stopPolling(): void {
+  running = false;
+  isPolling = false;
 }
 
 /** Standalone entry point (bun run src/index.ts telegram) */

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [], listenChats: [] },
+  telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true },
   discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [] },
   slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
@@ -106,6 +106,8 @@ export interface TelegramConfig {
   token: string;
   allowedUserIds: number[];
   listenChats: number[];
+  /** When false, skip Telegram polling (incoming messages). Useful for send-only instances. Default: true */
+  receiveEnabled: boolean;
 }
 
 export interface DiscordConfig {
@@ -148,6 +150,7 @@ export interface Settings {
   security: SecurityConfig;
   web: WebConfig;
   stt: SttConfig;
+  apiToken?: string;
   sessionTimeoutMs: number;
   watchdog: WatchdogSettings;
   plugins: Record<string, PluginEntry>;
@@ -302,6 +305,7 @@ function parseSettings(
       token: process.env.TELEGRAM_TOKEN?.trim() || (typeof raw.telegram?.token === "string" ? raw.telegram.token.trim() : ""),
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
       listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
+      receiveEnabled: raw.telegram?.receiveEnabled !== false,
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),
@@ -352,6 +356,7 @@ function parseSettings(
       maxAgeHours: Number.isFinite(raw.session?.maxAgeHours) ? Number(raw.session.maxAgeHours) : 24,
       summaryPath: typeof raw.session?.summaryPath === "string" ? raw.session.summaryPath.trim() : "",
     },
+    apiToken: typeof raw.apiToken === "string" && raw.apiToken.trim() ? raw.apiToken.trim() : undefined,
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),
   };
 }

--- a/src/ui/auth.ts
+++ b/src/ui/auth.ts
@@ -1,0 +1,8 @@
+import { json } from "./http";
+
+export function checkBearer(req: Request, token: string | undefined): Response | null {
+  if (!token) return json({ ok: false, error: "API token not configured" }, 503);
+  const header = req.headers.get("Authorization");
+  if (header !== `Bearer ${token}`) return json({ ok: false, error: "Unauthorized" }, 401);
+  return null;
+}

--- a/src/ui/http.ts
+++ b/src/ui/http.ts
@@ -1,5 +1,6 @@
-export function json(data: unknown): Response {
+export function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
+    status,
     headers: { "Content-Type": "application/json; charset=utf-8" },
   });
 }

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,11 +1,13 @@
 import { htmlPage } from "./page/html";
 import { clampInt, json } from "./http";
+import { checkBearer } from "./auth";
 import type { StartWebUiOptions, WebServerHandle } from "./types";
 import { buildState, buildTechnicalInfo, sanitizeSettings } from "./services/state";
 import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/settings";
 import { createQuickJob, deleteJob } from "./services/jobs";
 import { readLogs } from "./services/logs";
 import { listSessions, readSessionMessages, listAgents } from "./services/sessions";
+import { runUserMessage } from "../runner";
 
 export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
   const server = Bun.serve({
@@ -175,6 +177,30 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
           return json(await readSessionMessages(sessionId, limit, offset));
         } catch (err) {
           return json({ ok: false, error: String(err) });
+        }
+      }
+
+      if (url.pathname === "/api/inject" && req.method === "POST") {
+        const authErr = checkBearer(req, opts.getSnapshot().settings.apiToken);
+        if (authErr) return authErr;
+        try {
+          const body = await req.json();
+          const message = typeof body.message === "string" ? body.message.trim() : "";
+          if (!message) return json({ ok: false, error: "message is required" }, 400);
+          const result = await runUserMessage("inject", message);
+          const text = result.stdout.trim();
+          const { telegram } = opts.getSnapshot().settings;
+          if (text && telegram.token && telegram.allowedUserIds.length > 0) {
+            const chatId = telegram.allowedUserIds[0];
+            fetch(`https://api.telegram.org/bot${telegram.token}/sendMessage`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ chat_id: chatId, text }),
+            }).catch(() => {});
+          }
+          return json({ ok: true, result: result.stdout, exitCode: result.exitCode });
+        } catch (err) {
+          return json({ ok: false, error: String(err) }, 500);
         }
       }
 

--- a/src/ui/services/state.ts
+++ b/src/ui/services/state.ts
@@ -62,7 +62,28 @@ export async function buildState(snapshot: WebSnapshot) {
   };
 }
 
+function redactSettings(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return raw;
+  const s = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...s };
+  if ("apiToken" in out) out.apiToken = out.apiToken ? "[redacted]" : undefined;
+  if (out.telegram && typeof out.telegram === "object") {
+    const t = out.telegram as Record<string, unknown>;
+    out.telegram = { ...t, token: t.token ? "[redacted]" : "" };
+  }
+  if (out.discord && typeof out.discord === "object") {
+    const d = out.discord as Record<string, unknown>;
+    out.discord = { ...d, token: d.token ? "[redacted]" : "" };
+  }
+  if (out.slack && typeof out.slack === "object") {
+    const sl = out.slack as Record<string, unknown>;
+    out.slack = { ...sl, botToken: sl.botToken ? "[redacted]" : "", appToken: sl.appToken ? "[redacted]" : "" };
+  }
+  return out;
+}
+
 export async function buildTechnicalInfo(snapshot: WebSnapshot) {
+  const rawSettings = await readJsonFile(SETTINGS_FILE);
   return {
     daemon: {
       pid: snapshot.pid,
@@ -70,11 +91,14 @@ export async function buildTechnicalInfo(snapshot: WebSnapshot) {
       uptimeMs: Math.max(0, Date.now() - snapshot.startedAt),
     },
     files: {
-      settingsJson: await readJsonFile(SETTINGS_FILE),
+      settingsJson: redactSettings(rawSettings),
       sessionJson: await readJsonFile(SESSION_FILE),
       stateJson: await readJsonFile(STATE_FILE),
     },
-    snapshot,
+    snapshot: {
+      ...snapshot,
+      settings: redactSettings(snapshot.settings) as WebSnapshot["settings"],
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `POST /api/inject` endpoint for external systems to inject messages into a running claudeclaw daemon via HTTP
- Bearer token authentication: set `apiToken` in `settings.json`; requests must include `Authorization: Bearer <token>`
- Extends `json()` helper to accept an optional HTTP status code (needed for 400/401/500 responses)
- Adds `receiveEnabled` flag to `TelegramConfig` (default `true`); when `false`, the Telegram token is used for send-only (no polling started)
- On a successful inject, optionally forwards Claude's response to the first configured Telegram user

## Configuration

```json
{
  "apiToken": "your-secret-token",
  "telegram": { "receiveEnabled": false }
}
```

## API

```bash
curl -X POST http://127.0.0.1:4632/api/inject \
  -H "Authorization: Bearer your-secret-token" \
  -H "Content-Type: application/json" \
  -d '{"message": "Hello from n8n"}'
```

Response: `{ "ok": true, "result": "...", "exitCode": 0 }`

## Attribution

Ports #19 by @dathtd119 — adapted cleanly onto current master (which has added `/api/sessions`, `/api/agents`, `/api/chat`, and per-context timeouts since #19 was opened).

## Validation

- [x] `bunx tsc --noEmit` passes
- [x] `bun run bump:plugin-version && bun run bump:marketplace-version` run (→ 1.0.21)
- [x] Bearer auth rejects missing token (503), wrong token (401), empty message (400)