### PR TITLE
feat(telegram): delegate voice transcription to Claude instead of local whisper

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -5,7 +5,6 @@ import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt, listSkills } from "../skills";
 import { mkdir } from "node:fs/promises";
 import { extname, join } from "node:path";
@@ -749,7 +748,6 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     await sendTyping(config.token, chatId, threadId);
     let imagePath: string | null = null;
     let voicePath: string | null = null;
-    let voiceTranscript: string | null = null;
     if (hasImage) {
       try {
         imagePath = await downloadImageFromMessage(config.token, message);
@@ -764,17 +762,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
         console.error(`[Telegram] Failed to download voice for ${label}: ${err instanceof Error ? err.message : err}`);
       }
 
-      if (voicePath) {
-        try {
-          debugLog(`Voice file saved: path=${voicePath}`);
-          voiceTranscript = await transcribeAudioToText(voicePath, {
-            debug: telegramDebug,
-            log: (message) => debugLog(message),
-          });
-        } catch (err) {
-          console.error(`[Telegram] Failed to transcribe voice for ${label}: ${err instanceof Error ? err.message : err}`);
-        }
-      }
+      if (voicePath) debugLog(`Voice file saved: path=${voicePath}`);
     }
 
     // Plugin wizard: intercept /plugin and /claudeclaw:plugin before Claude routing
@@ -826,12 +814,12 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     } else if (hasImage) {
       promptParts.push("The user attached an image, but downloading it failed. Respond and ask them to resend.");
     }
-    if (voiceTranscript) {
-      promptParts.push(`Voice transcript: ${voiceTranscript}`);
-      promptParts.push("The user attached voice audio. Use the transcript as their spoken message.");
+    if (voicePath) {
+      promptParts.push(`Voice file path: ${voicePath}`);
+      promptParts.push("The user sent a voice message. Transcribe it using an available transcription tool, then respond to the transcribed text as their spoken message.");
     } else if (hasVoice) {
       promptParts.push(
-        "The user attached voice audio, but it could not be transcribed. Respond and ask them to resend a clearer clip."
+        "The user attached voice audio, but downloading it failed. Respond and ask them to resend."
       );
     }
     if (documentInfo) {


### PR DESCRIPTION
## Summary

- Removes the whisper dependency for voice transcription in Telegram voice messages
- Instead of transcribing locally, claudeclaw now sends the voice file path directly to Claude and asks it to transcribe
- Reduces setup complexity (no whisper binary needed) and leverages Claude's native audio understanding

## What changed

`src/commands/telegram.ts`:
- Removed `import { transcribeAudioToText } from "../whisper"`
- Removed the transcription block that called whisper
- Voice prompts now pass the file path to Claude with a transcription instruction

## Attribution

Ports #35 by @iammrwrong — adapted onto current master.

## Validation

- [x] `bunx tsc --noEmit` passes
- [x] `bun run bump:plugin-version && bun run bump:marketplace-version` run