### PR TITLE
feat(discord): isolated sessions per guild channel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -166,6 +166,18 @@ describe("sessions — agent-scoped paths", () => {
     // Verify path uses getAgentsDir() (project root) not HEARTBEAT_DIR (.claude/...)
     expect(src).toContain('join(getAgentsDir(), agentName, "session.json")');
   });
+
+  test("fallback sessions can be scoped by thread id", async () => {
+    const sessionsSrc = await Bun.file(join(import.meta.dir, "../sessions.ts")).text();
+    const runnerSrc = await Bun.file(join(import.meta.dir, "../runner.ts")).text();
+    const discordSrc = await Bun.file(join(import.meta.dir, "../commands/discord.ts")).text();
+
+    expect(sessionsSrc).toContain('join(HEARTBEAT_DIR, "fallback-sessions", `${encodeURIComponent(threadId)}.json`)');
+    expect(sessionsSrc).toContain("getFallbackSession(\n  agentName?: string,\n  threadId?: string");
+    expect(runnerSrc).toContain("getFallbackSession(agentName, threadId)");
+    expect(runnerSrc).toContain("createFallbackSession(exec.sessionId, agentName, threadId)");
+    expect(discordSrc).toContain("resetFallbackSession(undefined, interaction.channel_id!)");
+  });
 });
 
 // ─── Unit: protection-bug validation (the core motivation) ───────────────

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -699,6 +699,16 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     const prefixedPrompt = promptParts.join("\n");
     // Guild channels (including threads) each get their own isolated session; DMs use the global session
     const sessionKey = isGuild ? channelId : undefined;
+    if (sessionKey) {
+      const existing = await peekThreadSession(sessionKey);
+      const globalSession = await peekSession();
+      if (!existing && globalSession) {
+        console.warn(
+          `[Discord] Channel ${channelId} now using isolated session. ` +
+            `Global session history is no longer accessible here.`,
+        );
+      }
+    }
     const result = await runUserMessage("discord", prefixedPrompt, sessionKey, threadInfo?.agentName);
 
     if (result.exitCode !== 0) {

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -742,10 +742,15 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
     }
 
     if (interaction.data.name === "reset") {
-      await resetSession();
-      await resetFallbackSession();
+      const isGuildCmd = !!interaction.guild_id && !!interaction.channel_id;
+      if (isGuildCmd) {
+        await removeThreadSession(interaction.channel_id!);
+      } else {
+        await resetSession();
+        await resetFallbackSession();
+      }
       await respondToInteraction(interaction, {
-        content: "Global session reset. Next message starts fresh.",
+        content: isGuildCmd ? "Channel session reset. Next message starts fresh." : "Global session reset. Next message starts fresh.",
       });
       return;
     }
@@ -754,8 +759,9 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
       await respondToInteraction(interaction, { content: "⏳ Compacting session..." });
       const compactChannelId = interaction.channel_id;
       const compactThreadInfo = compactChannelId ? knownThreads.get(compactChannelId) : undefined;
-      const result = compactChannelId && compactThreadInfo
-        ? await compactCurrentThreadSession(compactChannelId, compactThreadInfo.agentName)
+      const isGuildCmd = !!interaction.guild_id && !!compactChannelId;
+      const result = isGuildCmd
+        ? await compactCurrentThreadSession(compactChannelId!, compactThreadInfo?.agentName)
         : await compactCurrentSession();
       await fetch(
         `${DISCORD_API}/webhooks/${applicationId}/${interaction.token}/messages/@original`,
@@ -769,7 +775,10 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
     }
 
     if (interaction.data.name === "status") {
-      const session = await peekSession();
+      const isGuildCmd = !!interaction.guild_id && !!interaction.channel_id;
+      const session = isGuildCmd
+        ? await peekThreadSession(interaction.channel_id!)
+        : await peekSession();
       const settings = getSettings();
       if (!session) {
         await respondToInteraction(interaction, { content: "📊 No active session." });
@@ -800,7 +809,10 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
     }
 
     if (interaction.data.name === "context") {
-      const session = await peekSession();
+      const isGuildCmd = !!interaction.guild_id && !!interaction.channel_id;
+      const session = isGuildCmd
+        ? await peekThreadSession(interaction.channel_id!)
+        : await peekSession();
       if (!session) {
         await respondToInteraction(interaction, { content: "No active session." });
         return;

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -755,6 +755,7 @@ async function handleInteractionCreate(token: string, interaction: DiscordIntera
       const isGuildCmd = !!interaction.guild_id && !!interaction.channel_id;
       if (isGuildCmd) {
         await removeThreadSession(interaction.channel_id!);
+        await resetFallbackSession(undefined, interaction.channel_id!);
       } else {
         await resetSession();
         await resetFallbackSession();

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -665,7 +665,9 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     }
 
     // Build prompt (same pattern as Telegram)
-    const promptParts = [`[Discord from ${label}]`];
+    const channelName = config.channelNames?.[channelId] ?? channelId;
+    const channelTag = isGuild ? `[Discord Channel: ${channelName}]` : `[Discord DM]`;
+    const promptParts = [channelTag, `[Discord from ${label}]`];
     if (skillContext) {
       const args = cleanContent.trim().slice(command!.length).trim();
       promptParts.push(`<command-name>${command}</command-name>`);
@@ -695,9 +697,9 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
     }
 
     const prefixedPrompt = promptParts.join("\n");
-    // Use thread-specific session if message is in a known thread
-    const threadId = knownThreads.has(channelId) ? channelId : undefined;
-    const result = await runUserMessage("discord", prefixedPrompt, threadId, threadInfo?.agentName);
+    // Guild channels (including threads) each get their own isolated session; DMs use the global session
+    const sessionKey = isGuild ? channelId : undefined;
+    const result = await runUserMessage("discord", prefixedPrompt, sessionKey, threadInfo?.agentName);
 
     if (result.exitCode !== 0) {
       await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,6 +116,7 @@ export interface DiscordConfig {
   allowedUserIds: string[]; // Discord snowflake IDs exceed Number.MAX_SAFE_INTEGER
   listenChannels: string[]; // Channel IDs where bot responds to all messages (no mention needed)
   listenGuilds: string[]; // Guild IDs where bot responds to all messages in any channel/thread
+  channelNames?: Record<string, string>; // channelId -> friendly name for system prompt context
 }
 
 export interface SlackConfig {
@@ -337,6 +338,11 @@ function parseSettings(
       listenGuilds: Array.isArray(raw.discord?.listenGuilds)
         ? raw.discord.listenGuilds.map(String)
         : [],
+      channelNames: raw.discord?.channelNames && typeof raw.discord.channelNames === "object"
+        ? Object.fromEntries(
+            Object.entries(raw.discord.channelNames as Record<string, unknown>).map(([k, v]) => [String(k), String(v)]),
+          )
+        : undefined,
     },
     slack: {
       botToken: process.env.SLACK_BOT_TOKEN?.trim() || (typeof raw.slack?.botToken === "string" ? raw.slack.botToken.trim() : ""),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -891,7 +891,7 @@ async function execClaude(
     console.warn(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
-    const fallbackSession = await getFallbackSession(agentName);
+    const fallbackSession = await getFallbackSession(agentName, threadId);
     const fallbackArgs = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
     if (fallbackSession) {
       fallbackArgs.push("--resume", fallbackSession.sessionId);
@@ -905,8 +905,8 @@ async function execClaude(
 
     // If the fallback resumed a corrupted session, reset it and retry fresh.
     if (!fallbackRateLimit && fallbackSession && exec.exitCode !== 0 && SIGNATURE_ERROR.test(exec.rawStdout + exec.stderr)) {
-      await resetFallbackSession(agentName);
-      const flabel = agentName ? ` (agent ${agentName})` : "";
+      await resetFallbackSession(agentName, threadId);
+      const flabel = threadId ? ` (thread ${threadId.slice(0, 8)})` : agentName ? ` (agent ${agentName})` : "";
       console.warn(
         `[${new Date().toLocaleTimeString()}] Detected corrupted fallback session (thinking block signature mismatch). Reset${flabel}, retrying fallback fresh...`
       );
@@ -914,16 +914,16 @@ async function execClaude(
       exec = await runClaudeStream(freshFallbackArgs, fallbackConfig.model, fallbackConfig.api, baseEnv, timeoutMs, spawnCwd);
       fallbackRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
       if (!fallbackRateLimit && exec.sessionId) {
-        await createFallbackSession(exec.sessionId, agentName);
+        await createFallbackSession(exec.sessionId, agentName, threadId);
         console.log(`[${new Date().toLocaleTimeString()}] Fallback session recovered: ${exec.sessionId}${flabel}`);
       }
     } else if (!fallbackRateLimit) {
       if (!fallbackSession && exec.sessionId) {
-        await createFallbackSession(exec.sessionId, agentName);
-        const label = agentName ? ` (agent ${agentName})` : "";
+        await createFallbackSession(exec.sessionId, agentName, threadId);
+        const label = threadId ? ` (thread ${threadId.slice(0, 8)})` : agentName ? ` (agent ${agentName})` : "";
         console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${exec.sessionId}${label}`);
       } else if (fallbackSession) {
-        await incrementFallbackTurn(agentName);
+        await incrementFallbackTurn(agentName, threadId);
       }
     }
   }
@@ -990,7 +990,7 @@ async function execClaude(
     );
 
     if (usedFallback) {
-      await resetFallbackSession(agentName);
+      await resetFallbackSession(agentName, threadId);
     } else if (threadId) {
       await removeThreadSession(threadId);
     } else if (agentName) {
@@ -1041,8 +1041,8 @@ async function execClaude(
   if (!rateLimitMessage && parseAsNew && exec.sessionId) {
     sessionId = exec.sessionId;
     if (recoveredFromStale && usedFallback) {
-      await createFallbackSession(sessionId, agentName);
-      const label = agentName ? ` (agent ${agentName})` : "";
+      await createFallbackSession(sessionId, agentName, threadId);
+      const label = threadId ? ` (thread ${threadId.slice(0, 8)})` : agentName ? ` (agent ${agentName})` : "";
       console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${sessionId}${label}`);
       startSession(sessionId);
     } else if (!usedFallback) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { unlink, readdir, rename } from "fs/promises";
+import { dirname, join } from "path";
+import { unlink, readdir, rename, mkdir } from "fs/promises";
 import { getAgentsDir } from "./config";
 
 const HEARTBEAT_DIR = join(process.cwd(), ".claude", "claudeclaw");
@@ -118,58 +118,62 @@ export async function resetSession(agentName?: string): Promise<void> {
 
 const FALLBACK_SESSION_FILE = join(HEARTBEAT_DIR, "session_fallback.json");
 
-function fallbackSessionPathFor(agentName?: string): string {
+function fallbackSessionPathFor(agentName?: string, threadId?: string): string {
+  if (threadId) return join(HEARTBEAT_DIR, "fallback-sessions", `${encodeURIComponent(threadId)}.json`);
   if (agentName) return join(getAgentsDir(), agentName, "session_fallback.json");
   return FALLBACK_SESSION_FILE;
 }
 
-async function loadFallbackSession(agentName?: string): Promise<GlobalSession | null> {
+async function loadFallbackSession(agentName?: string, threadId?: string): Promise<GlobalSession | null> {
   try {
-    return await Bun.file(fallbackSessionPathFor(agentName)).json();
+    return await Bun.file(fallbackSessionPathFor(agentName, threadId)).json();
   } catch {
     return null;
   }
 }
 
-async function saveFallbackSession(session: GlobalSession, agentName?: string): Promise<void> {
-  await Bun.write(fallbackSessionPathFor(agentName), JSON.stringify(session, null, 2) + "\n");
+async function saveFallbackSession(session: GlobalSession, agentName?: string, threadId?: string): Promise<void> {
+  const path = fallbackSessionPathFor(agentName, threadId);
+  await mkdir(dirname(path), { recursive: true });
+  await Bun.write(path, JSON.stringify(session, null, 2) + "\n");
 }
 
 export async function getFallbackSession(
-  agentName?: string
+  agentName?: string,
+  threadId?: string
 ): Promise<{ sessionId: string; turnCount: number } | null> {
-  const existing = await loadFallbackSession(agentName);
+  const existing = await loadFallbackSession(agentName, threadId);
   if (existing) {
     if (typeof existing.turnCount !== "number") existing.turnCount = 0;
     existing.lastUsedAt = new Date().toISOString();
-    await saveFallbackSession(existing, agentName);
+    await saveFallbackSession(existing, agentName, threadId);
     return { sessionId: existing.sessionId, turnCount: existing.turnCount };
   }
   return null;
 }
 
-export async function createFallbackSession(sessionId: string, agentName?: string): Promise<void> {
+export async function createFallbackSession(sessionId: string, agentName?: string, threadId?: string): Promise<void> {
   await saveFallbackSession({
     sessionId,
     createdAt: new Date().toISOString(),
     lastUsedAt: new Date().toISOString(),
     turnCount: 0,
     compactWarned: false,
-  }, agentName);
+  }, agentName, threadId);
 }
 
-export async function incrementFallbackTurn(agentName?: string): Promise<number> {
-  const existing = await loadFallbackSession(agentName);
+export async function incrementFallbackTurn(agentName?: string, threadId?: string): Promise<number> {
+  const existing = await loadFallbackSession(agentName, threadId);
   if (!existing) return 0;
   if (typeof existing.turnCount !== "number") existing.turnCount = 0;
   existing.turnCount += 1;
-  await saveFallbackSession(existing, agentName);
+  await saveFallbackSession(existing, agentName, threadId);
   return existing.turnCount;
 }
 
-export async function resetFallbackSession(agentName?: string): Promise<void> {
+export async function resetFallbackSession(agentName?: string, threadId?: string): Promise<void> {
   try {
-    await unlink(fallbackSessionPathFor(agentName));
+    await unlink(fallbackSessionPathFor(agentName, threadId));
   } catch {
     // already gone
   }


### PR DESCRIPTION
## Summary
- Each guild channel (and thread) now gets its own isolated session keyed by `channelId`; DMs continue to share the global session.
- Adds optional `discord.channelNames` config (channelId → friendly name) to surface a human-readable channel label in the prompt prefix (`[Discord Channel: <name>]` for guild messages, `[Discord DM]` for DMs).

## Test plan
- [ ] Send a message in two different guild channels and verify each gets its own session context.
- [ ] Send a message in a thread and verify it stays isolated under the thread's channelId.
- [ ] Send a DM and verify it still uses the global session.
- [ ] Configure `discord.channelNames` and confirm the friendly name appears in the prompt prefix; absent config falls back to channelId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)