### PR TITLE
fix(runner): bypass claude.cmd on Windows to avoid 8K command-line limit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile, realpath } from "fs/promises";
-import { join, resolve, sep } from "path";
+import { join, dirname, resolve, sep } from "path";
+import { execSync } from "child_process";
 import { existsSync } from "fs";
 import {
   getSession,
@@ -39,6 +40,37 @@ const PROJECT_CLAUDE_MD = join(process.cwd(), "CLAUDE.md");
 const LEGACY_PROJECT_CLAUDE_MD = join(process.cwd(), ".claude", "CLAUDE.md");
 const CLAUDECLAW_BLOCK_START = "<!-- claudeclaw:managed:start -->";
 const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
+
+/**
+ * On Windows, `claude` resolves to `claude.cmd`, a batch wrapper that must
+ * be run through cmd.exe (8191-char command-line limit). Resolving the
+ * underlying `claude.exe` lets us call it directly via CreateProcessW
+ * (32767-char limit). Required because --append-system-prompt + prompt
+ * files + CLAUDE.md can easily exceed 8K.
+ */
+function resolveClaudeExecutable(): string {
+  if (process.platform !== "win32") return "claude";
+  try {
+    const out = execSync("where claude", { encoding: "utf8" });
+    const cmdPath = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find((s) => s.toLowerCase().endsWith(".cmd"));
+    if (!cmdPath) return "claude";
+    const exePath = join(
+      dirname(cmdPath),
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "bin",
+      "claude.exe"
+    );
+    return existsSync(exePath) ? exePath : "claude";
+  } catch {
+    return "claude";
+  }
+}
+const CLAUDE_EXECUTABLE = resolveClaudeExecutable();
 
 /**
  * Compact configuration.
@@ -635,7 +667,7 @@ export async function runCompact(
   cwd?: string
 ): Promise<boolean> {
   const compactArgs = [
-    "claude", "-p", "/compact",
+    CLAUDE_EXECUTABLE, "-p", "/compact",
     "--output-format", "text",
     "--resume", sessionId,
     ...securityArgs,
@@ -782,7 +814,7 @@ async function execClaude(
   // blocking until all spawned agents finish. --verbose is required for stream-json in
   // print (-p) mode. Session ID is captured from the system/init event; the final result
   // text comes from the result event — no separate output format needed for new vs resumed.
-  const args = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+  const args = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
 
   if (!isNew) {
     args.push("--resume", existing.sessionId);
@@ -829,7 +861,7 @@ async function execClaude(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
     const fallbackSession = await getFallbackSession(agentName);
-    const fallbackArgs = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+    const fallbackArgs = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
     if (fallbackSession) {
       fallbackArgs.push("--resume", fallbackSession.sessionId);
     }
@@ -1095,7 +1127,7 @@ async function streamClaude(
   // stream-json gives us events as they happen — text before tool calls,
   // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
   // --verbose is required for stream-json to produce output in -p (print) mode.
-  const args = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+  const args = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
 
   if (existing) args.push("--resume", existing.sessionId);
 


### PR DESCRIPTION
## Summary

On Windows, `npm install` creates `claude.cmd` — a batch wrapper that `cmd.exe` must execute. The `cmd.exe` command-line limit is 8191 characters. A typical ClaudeClaw spawn already exceeds this with `--append-system-prompt` carrying CLAUDE.md + prompt files. Every spawn returned exit 1 with `The command line is too long.` — nothing reached Claude.

**Fix:** resolve `claude.exe` directly (inside `@anthropic-ai/claude-code/bin/`). Calling it via `CreateProcessW` raises the limit to 32767 chars.

```
Before: claude → claude.cmd → cmd.exe (8191 char limit) → exit 1
After:  claude → claude.exe  (CreateProcessW, 32767 char limit) → exit 0
```

**Zero behavior change on non-Windows** — `resolveClaudeExecutable()` returns `"claude"` immediately on macOS/Linux. Falls back to `"claude"` on Windows if the `.exe` can't be located.

## Files changed

`src/runner.ts` — adds `resolveClaudeExecutable()` + `CLAUDE_EXECUTABLE` constant; replaces the 4 `"claude"` spawn literals in `runCompact`, `execClaude` (primary + fallback), and `streamClaude`.

## Validation

- [ ] `bunx tsc --noEmit` — passes
- [ ] Non-Windows: no behavior change
- [ ] Windows: bootstrap produces exit 0 with a real session ID
- [ ] Fallback: `where claude` fails → graceful fallback to `"claude"`

## Plugin version bumps

```
bun run bump:plugin-version   # ✓ → 1.0.24
bun run bump:marketplace-version  # ✓ → 1.0.24
```

Ported from: PR #99 by @DerfEflow