### PR TITLE
fix(runner): auto-recover from stale --resume session IDs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -959,6 +959,8 @@ async function execClaude(
 
     if (threadId) {
       await removeThreadSession(threadId);
+    } else if (agentName) {
+      await resetSession(agentName);
     } else {
       await backupSession();
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -959,6 +959,8 @@ async function execClaude(
 
     if (threadId) {
       await removeThreadSession(threadId);
+    } else if (usedFallback) {
+      await resetFallbackSession(agentName);
     } else if (agentName) {
       await resetSession(agentName);
     } else {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -957,10 +957,10 @@ async function execClaude(
       `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name}; recovering with a new session...`
     );
 
-    if (threadId) {
-      await removeThreadSession(threadId);
-    } else if (usedFallback) {
+    if (usedFallback) {
       await resetFallbackSession(agentName);
+    } else if (threadId) {
+      await removeThreadSession(threadId);
     } else if (agentName) {
       await resetSession(agentName);
     } else {
@@ -1006,17 +1006,24 @@ async function execClaude(
   // Gate only on isNew + sessionId present — not on exitCode, so a session that timed
   // out mid-run is still persisted and can be resumed on the next message.
   const parseAsNew = isNew || recoveredFromStale;
-  if (!rateLimitMessage && parseAsNew && exec.sessionId && !usedFallback) {
+  if (!rateLimitMessage && parseAsNew && exec.sessionId) {
     sessionId = exec.sessionId;
-    if (threadId) {
-      await createThreadSession(threadId, sessionId);
-      console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
-    } else {
-      await createSession(sessionId, agentName);
+    if (recoveredFromStale && usedFallback) {
+      await createFallbackSession(sessionId, agentName);
       const label = agentName ? ` (agent ${agentName})` : "";
-      console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}${label}`);
+      console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${sessionId}${label}`);
+      startSession(sessionId);
+    } else if (!usedFallback) {
+      if (threadId) {
+        await createThreadSession(threadId, sessionId);
+        console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
+      } else {
+        await createSession(sessionId, agentName);
+        const label = agentName ? ` (agent ${agentName})` : "";
+        console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}${label}`);
+      }
+      startSession(sessionId);
     }
-    startSession(sessionId);
   }
 
   const result: RunResult = {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -131,6 +131,37 @@ const RATE_LIMIT_PATTERN = /you(?:'|')ve hit your limit|out of extra usage/i;
 const RATE_LIMIT_RESET_PATTERN = /resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\(?\s*UTC\s*\)?/i;
 const SIGNATURE_ERROR = /Invalid.*signature.*thinking block/i;
 
+// Claude Code prints this when --resume references a session it no longer
+// has on disk (cleared, expired, compacted away, or moved to another machine).
+// When we see it, the cached session ID is dead and the only recovery is to
+// drop --resume and start fresh.
+const STALE_SESSION_PATTERN = /No conversation found with session ID/i;
+
+function isStaleSessionError(stdout: string, stderr: string): boolean {
+  return STALE_SESSION_PATTERN.test(stderr) || STALE_SESSION_PATTERN.test(stdout);
+}
+
+/** Strip --resume <id> from a claude argv list so it runs as a brand-new session. */
+function stripResume(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--resume") {
+      i += 1; // skip the session id that follows
+      continue;
+    }
+    out.push(args[i]!);
+  }
+  return out;
+}
+
+/** Replace the value following --output-format (returns a modified copy). */
+function withOutputFormat(args: string[], format: string): string[] {
+  const out = [...args];
+  const idx = out.indexOf("--output-format");
+  if (idx >= 0 && idx + 1 < out.length) out[idx + 1] = format;
+  return out;
+}
+
 // --- Rate limit state ---
 let rateLimitResetAt: number = 0; // epoch ms; 0 = not rate-limited
 let rateLimitNotified: boolean = false;
@@ -909,6 +940,47 @@ async function execClaude(
     }
   }
 
+  let recoveredFromStale = false;
+
+  // --- Stale session recovery ---
+  // Claude Code returns "No conversation found with session ID: <id>" when
+  // --resume points at a session it no longer has (cleared, expired, etc.).
+  // Back up the dead ID, drop --resume, and retry as a new session so the
+  // user isn't permanently stuck.
+  if (
+    !isNew &&
+    exitCode !== 0 &&
+    existing &&
+    isStaleSessionError(rawStdout, stderr)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name}; recovering with a new session...`
+    );
+
+    if (threadId) {
+      await removeThreadSession(threadId);
+    } else {
+      await backupSession();
+    }
+
+    const retryArgs = withOutputFormat(stripResume(args), "stream-json");
+    const retryConfig = usedFallback ? fallbackConfig : primaryConfig;
+    exec = await runClaudeStream(
+      retryArgs,
+      retryConfig.model,
+      retryConfig.api,
+      baseEnv,
+      timeoutMs,
+      spawnCwd
+    );
+
+    rawStdout = exec.rawStdout;
+    stderr = exec.stderr;
+    exitCode = exec.exitCode;
+    stdout = rawStdout;
+    recoveredFromStale = true;
+  }
+
   const rateLimitMessage = extractRateLimitMessage(rawStdout, stderr);
 
   if (rateLimitMessage) {
@@ -929,7 +1001,8 @@ async function execClaude(
   // Capture session ID from stream events and persist for new sessions.
   // Gate only on isNew + sessionId present — not on exitCode, so a session that timed
   // out mid-run is still persisted and can be resumed on the next message.
-  if (!rateLimitMessage && isNew && exec.sessionId && !usedFallback) {
+  const parseAsNew = isNew || recoveredFromStale;
+  if (!rateLimitMessage && parseAsNew && exec.sessionId && !usedFallback) {
     sessionId = exec.sessionId;
     if (threadId) {
       await createThreadSession(threadId, sessionId);
@@ -995,7 +1068,7 @@ async function execClaude(
   }
 
   // --- Auto-compact on timeout (exit 124) ---
-  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {
+  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing && !recoveredFromStale) {
     emitCompactEvent({ type: "auto-compact-start" });
     const compactOk = await runCompact(
       existing.sessionId,
@@ -1034,7 +1107,7 @@ async function execClaude(
   }
 
   // --- Turn tracking & compact warning ---
-  if (exitCode === 0 && !isNew) {
+  if (exitCode === 0 && !isNew && !recoveredFromStale) {
     const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn(agentName);
     const turnLabel = threadId ? ` (thread ${threadId.slice(0, 8)})` : agentName ? ` (agent ${agentName})` : "";
     console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${turnLabel}`);
@@ -1131,6 +1204,10 @@ async function streamClaude(
     stderr: "pipe",
     env: childEnv,
   });
+
+  // Collect stderr in the background so it doesn't back-pressure the process.
+  // We need it after proc.exited for stale session detection.
+  const stderrPromise = new Response(proc.stderr).text();
 
   const reader = proc.stdout.getReader();
   const decoder = new TextDecoder();
@@ -1232,6 +1309,23 @@ async function streamClaude(
   }
 
   await proc.exited;
+  const stderrText = await stderrPromise;
+
+  // --- Stale session recovery (stream path) ---
+  if (
+    existing &&
+    !textEmitted &&
+    (proc.exitCode ?? 0) !== 0 &&
+    isStaleSessionError("", stderrText)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name} (stream); recovering with a new session...`
+    );
+    await backupSession();
+    await streamClaude(name, prompt, onChunk, onUnblock, onAgentEvent);
+    return;
+  }
+
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
 


### PR DESCRIPTION
## Summary

When Claude Code no longer has a session on disk (cleared, expired, compacted away, or synced to another machine), every `--resume` call fails with:

```
Error (exit 1): No conversation found with session ID: <id>
```

The daemon would loop forever returning that error — the only recovery was to hand-delete `session.json`. Telegram and Discord users saw a permanent error with no way out.

**Fix:** both `execClaude` and `streamClaude` now detect the error, back up the dead session ID, and retry as a fresh session — all within one turn.

### Changes

- `STALE_SESSION_PATTERN` + `isStaleSessionError()` — detects the error in stdout/stderr
- `stripResume()` — removes `--resume <id>` from argv before retry
- `withOutputFormat()` — forces `stream-json` on retry to capture the new session ID
- `execClaude` recovery: removes thread session or backs up global, retries once, persists new session ID
- `streamClaude` recovery: collects stderr in parallel (avoids backpressure), detects stale after exit, backs up and recurses once
- Auto-compact-on-timeout and turn-count increment gated with `!recoveredFromStale`

### Repro

```bash
echo '{"sessionId":"deadbeef-dead-dead-dead-deaddeaddead","createdAt":"...","lastUsedAt":"...","turnCount":5}' \
  > .claude/claudeclaw/session.json
# Any Telegram message → "Error (exit 1): No conversation found..."
# Every subsequent message → same error
```

After this fix: logs `Stale session deadbeef for <name>; recovering...`, then returns a normal reply.

## Validation

- [ ] `bunx tsc --noEmit` — passes
- [ ] Injected stale ID → single recovery log line + successful reply
- [ ] Normal path unchanged (no stale session → no extra code executed)
- [ ] Thread session: `removeThreadSession` used instead of `backupSession`

## Plugin version bumps

```
bun run bump:plugin-version   # ✓ → 1.0.24
bun run bump:marketplace-version  # ✓ → 1.0.24
```

Ported from: PR #110 by @lunklin