### PR TITLE
Bulk cherry-pick #165-#168

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -2,7 +2,7 @@ import { writeFile, unlink, mkdir } from "fs/promises";
 import { extractErrorDetail } from "../messaging";
 import { join } from "path";
 import { fileURLToPath } from "url";
-import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate } from "../runner";
+import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate, isRateLimited, getRateLimitResetAt, wasRateLimitNotified, markRateLimitNotified } from "../runner";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs, snapshotJobFrontmatter } from "../jobs";
@@ -600,6 +600,17 @@ export async function start(args: string[] = []) {
     );
 
     function tick() {
+      if (isRateLimited()) {
+        const resetAt = new Date(getRateLimitResetAt());
+        console.log(`[${ts()}] Heartbeat skipped (rate limited until ${resetAt.toISOString()})`);
+        if (!wasRateLimitNotified()) {
+          markRateLimitNotified();
+          const msg = `Usage limit hit. Pausing until ${resetAt.toUTCString()}. Heartbeats and jobs suspended.`;
+          forwardToTelegram("", { exitCode: 1, stdout: msg, stderr: "" });
+          forwardToDiscord("", { exitCode: 1, stdout: msg, stderr: "" });
+        }
+        return;
+      }
       if (isHeartbeatExcludedNow(currentSettings.heartbeat, currentSettings.timezoneOffsetMinutes)) {
         console.log(`[${ts()}] Heartbeat skipped (excluded window)`);
         nextHeartbeatAt = nextAllowedHeartbeatAt(
@@ -813,6 +824,7 @@ export async function start(args: string[] = []) {
   }
 
   setInterval(() => {
+    if (isRateLimited()) return; // Skip all jobs while rate-limited
     const now = new Date();
     for (const job of currentJobs) {
       // Fire pending retries before checking the cron schedule.

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -824,21 +824,22 @@ export async function start(args: string[] = []) {
   }
 
   setInterval(() => {
-    if (isRateLimited()) return; // Skip all jobs while rate-limited
-    const now = new Date();
-    for (const job of currentJobs) {
-      // Fire pending retries before checking the cron schedule.
-      const retryState = jobRetryState.get(job.name);
-      if (retryState && retryState.retryAt <= Date.now()) {
-        // Push retryAt to sentinel so subsequent cron ticks don't re-fire while in flight.
-        // runJob's .then() handler overwrites this with the real next-retry time (or deletes it).
-        retryState.retryAt = Number.MAX_SAFE_INTEGER;
-        console.log(`[${ts()}] Retrying job: ${job.name} (attempt ${retryState.failCount + 1}/${job.retry})`);
-        runJob(job);
-        continue;
-      }
-      if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
-        runJob(job);
+    if (!isRateLimited()) {
+      const now = new Date();
+      for (const job of currentJobs) {
+        // Fire pending retries before checking the cron schedule.
+        const retryState = jobRetryState.get(job.name);
+        if (retryState && retryState.retryAt <= Date.now()) {
+          // Push retryAt to sentinel so subsequent cron ticks don't re-fire while in flight.
+          // runJob's .then() handler overwrites this with the real next-retry time (or deletes it).
+          retryState.retryAt = Number.MAX_SAFE_INTEGER;
+          console.log(`[${ts()}] Retrying job: ${job.name} (attempt ${retryState.failCount + 1}/${job.retry})`);
+          runJob(job);
+          continue;
+        }
+        if (cronMatches(job.schedule, now, currentSettings.timezoneOffsetMinutes)) {
+          runJob(job);
+        }
       }
     }
     updateState();

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -776,6 +776,14 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     `[${new Date().toLocaleTimeString()}] Telegram ${label}${mediaSuffix}: "${text.slice(0, 60)}${text.length > 60 ? "..." : ""}"`
   );
 
+  // Plugin wizard: local control-plane logic — not subject to rate limiting
+  const wizardCtx = { iface: "telegram" as const, scopeId: String(chatId) };
+  if ((command && isWizardTrigger(command)) || hasActiveWizard(wizardCtx)) {
+    const reply = await handleWizardInput(wizardCtx, text.trim());
+    await sendMessage(config.token, chatId, reply, threadId);
+    return;
+  }
+
   // If rate-limited, reply immediately without calling Claude
   if (isRateLimited()) {
     const resetAt = new Date(getRateLimitResetAt());
@@ -817,14 +825,6 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           }
         }
       }
-    }
-
-    // Plugin wizard: intercept /plugin and /claudeclaw:plugin before Claude routing
-    const wizardCtx = { iface: "telegram" as const, scopeId: String(chatId) };
-    if ((command && isWizardTrigger(command)) || hasActiveWizard(wizardCtx)) {
-      const reply = await handleWizardInput(wizardCtx, text.trim());
-      await sendMessage(config.token, chatId, reply, threadId);
-      return;
     }
 
     // Skill routing: resolve slash commands to SKILL.md prompts

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, isRateLimited, getRateLimitResetAt } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { transcribeAudioToText } from "../whisper";
@@ -741,6 +741,14 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   console.log(
     `[${new Date().toLocaleTimeString()}] Telegram ${label}${mediaSuffix}: "${text.slice(0, 60)}${text.length > 60 ? "..." : ""}"`
   );
+
+  // If rate-limited, reply immediately without calling Claude
+  if (isRateLimited()) {
+    const resetAt = new Date(getRateLimitResetAt());
+    const resetStr = resetAt.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", timeZone: "UTC" });
+    await sendMessage(config.token, chatId, `Usage limit reached. Resets at ${resetStr} UTC. I'll be back after that.`, threadId);
+    return;
+  }
 
   // Keep typing indicator alive while queued/running
   const typingInterval = setInterval(() => sendTyping(config.token, chatId, threadId), 4000);

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -907,6 +907,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       await sendMessage(config.token, chatId, errorMsg, threadId);
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
+      const hadVoiceDirective = /\[voice:\/[^\]\r\n]+\]/i.test(afterReact);
       const { cleanedText: afterVoice, voicePaths } = extractVoiceDirectives(afterReact);
       const { cleanedText, filePaths } = extractSendFileDirectives(afterVoice);
       if (reactionEmoji) {
@@ -933,7 +934,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           await sendMessage(config.token, chatId, `Failed to send file: ${fp.split("/").pop()}`, threadId);
         }
       }
-      if (!cleanedText && filePaths.length === 0 && voicePaths.length === 0) {
+      if (!cleanedText && filePaths.length === 0 && voicePaths.length === 0 && !hadVoiceDirective) {
         await sendMessage(config.token, chatId, "(empty response)", threadId);
       }
     }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -390,6 +390,40 @@ function extractSendFileDirectives(text: string): {
   return { cleanedText, filePaths };
 }
 
+const VOICE_DIRECTIVE_RE = /\[voice:(\/[^\]\r\n]+)\]/gi;
+
+function extractVoiceDirectives(text: string): { cleanedText: string; voicePaths: string[] } {
+  const voicePaths: string[] = [];
+  const cleanedText = text
+    .replace(VOICE_DIRECTIVE_RE, (_match, path) => {
+      const p = String(path).trim();
+      if (p && existsSync(p)) voicePaths.push(p);
+      return "";
+    })
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return { cleanedText, voicePaths };
+}
+
+async function sendVoiceMessage(token: string, chatId: number, voicePath: string, threadId?: number): Promise<void> {
+  const form = new FormData();
+  form.append("chat_id", String(chatId));
+  if (threadId) form.append("message_thread_id", String(threadId));
+
+  const file = Bun.file(voicePath);
+  form.append("voice", file, voicePath.split("/").pop() ?? "voice.ogg");
+
+  const res = await fetch(`${API_BASE}${token}/sendVoice`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Telegram sendVoice: ${res.status} ${res.statusText} — ${body}`);
+  }
+}
+
 async function sendReaction(token: string, chatId: number, messageId: number, emoji: string): Promise<void> {
   await callApi(token, "setMessageReaction", {
     chat_id: chatId,
@@ -873,11 +907,20 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       await sendMessage(config.token, chatId, errorMsg, threadId);
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
-      const { cleanedText, filePaths } = extractSendFileDirectives(afterReact);
+      const { cleanedText: afterVoice, voicePaths } = extractVoiceDirectives(afterReact);
+      const { cleanedText, filePaths } = extractSendFileDirectives(afterVoice);
       if (reactionEmoji) {
         await sendReaction(config.token, chatId, message.message_id, reactionEmoji).catch((err) => {
           console.error(`[Telegram] Failed to send reaction for ${label}: ${err instanceof Error ? err.message : err}`);
         });
+      }
+      for (const vp of voicePaths) {
+        try {
+          await sendVoiceMessage(config.token, chatId, vp, threadId);
+          debugLog(`Voice sent: ${vp}`);
+        } catch (err) {
+          console.error(`[Telegram] Failed to send voice ${vp} for ${label}: ${err instanceof Error ? err.message : err}`);
+        }
       }
       if (cleanedText) {
         await sendMessage(config.token, chatId, cleanedText, threadId);
@@ -890,7 +933,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           await sendMessage(config.token, chatId, `Failed to send file: ${fp.split("/").pop()}`, threadId);
         }
       }
-      if (!cleanedText && filePaths.length === 0) {
+      if (!cleanedText && filePaths.length === 0 && voicePaths.length === 0) {
         await sendMessage(config.token, chatId, "(empty response)", threadId);
       }
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -991,6 +991,8 @@ async function execClaude(
 
     if (threadId) {
       await removeThreadSession(threadId);
+    } else if (usedFallback) {
+      await resetFallbackSession(agentName);
     } else if (agentName) {
       await resetSession(agentName);
     } else {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -991,6 +991,8 @@ async function execClaude(
 
     if (threadId) {
       await removeThreadSession(threadId);
+    } else if (agentName) {
+      await resetSession(agentName);
     } else {
       await backupSession();
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile, realpath } from "fs/promises";
-import { join, resolve, sep } from "path";
+import { join, dirname, resolve, sep } from "path";
+import { execSync } from "child_process";
 import { existsSync } from "fs";
 import {
   getSession,
@@ -39,6 +40,37 @@ const PROJECT_CLAUDE_MD = join(process.cwd(), "CLAUDE.md");
 const LEGACY_PROJECT_CLAUDE_MD = join(process.cwd(), ".claude", "CLAUDE.md");
 const CLAUDECLAW_BLOCK_START = "<!-- claudeclaw:managed:start -->";
 const CLAUDECLAW_BLOCK_END = "<!-- claudeclaw:managed:end -->";
+
+/**
+ * On Windows, `claude` resolves to `claude.cmd`, a batch wrapper that must
+ * be run through cmd.exe (8191-char command-line limit). Resolving the
+ * underlying `claude.exe` lets us call it directly via CreateProcessW
+ * (32767-char limit). Required because --append-system-prompt + prompt
+ * files + CLAUDE.md can easily exceed 8K.
+ */
+function resolveClaudeExecutable(): string {
+  if (process.platform !== "win32") return "claude";
+  try {
+    const out = execSync("where claude", { encoding: "utf8" });
+    const cmdPath = out
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .find((s) => s.toLowerCase().endsWith(".cmd"));
+    if (!cmdPath) return "claude";
+    const exePath = join(
+      dirname(cmdPath),
+      "node_modules",
+      "@anthropic-ai",
+      "claude-code",
+      "bin",
+      "claude.exe"
+    );
+    return existsSync(exePath) ? exePath : "claude";
+  } catch {
+    return "claude";
+  }
+}
+const CLAUDE_EXECUTABLE = resolveClaudeExecutable();
 
 /**
  * Compact configuration.
@@ -635,7 +667,7 @@ export async function runCompact(
   cwd?: string
 ): Promise<boolean> {
   const compactArgs = [
-    "claude", "-p", "/compact",
+    CLAUDE_EXECUTABLE, "-p", "/compact",
     "--output-format", "text",
     "--resume", sessionId,
     ...securityArgs,
@@ -782,7 +814,7 @@ async function execClaude(
   // blocking until all spawned agents finish. --verbose is required for stream-json in
   // print (-p) mode. Session ID is captured from the system/init event; the final result
   // text comes from the result event — no separate output format needed for new vs resumed.
-  const args = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+  const args = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
 
   if (!isNew) {
     args.push("--resume", existing.sessionId);
@@ -829,7 +861,7 @@ async function execClaude(
       `[${new Date().toLocaleTimeString()}] Claude limit reached; retrying with fallback${fallbackConfig.model ? ` (${fallbackConfig.model})` : ""}...`
     );
     const fallbackSession = await getFallbackSession(agentName);
-    const fallbackArgs = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+    const fallbackArgs = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
     if (fallbackSession) {
       fallbackArgs.push("--resume", fallbackSession.sessionId);
     }
@@ -1095,7 +1127,7 @@ async function streamClaude(
   // stream-json gives us events as they happen — text before tool calls,
   // so we can unblock the UI as soon as Claude acknowledges, not after sub-agents finish.
   // --verbose is required for stream-json to produce output in -p (print) mode.
-  const args = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
+  const args = [CLAUDE_EXECUTABLE, "-p", prompt, "--output-format", "stream-json", "--verbose", ...securityArgs];
 
   if (existing) args.push("--resume", existing.sessionId);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -989,10 +989,10 @@ async function execClaude(
       `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name}; recovering with a new session...`
     );
 
-    if (threadId) {
-      await removeThreadSession(threadId);
-    } else if (usedFallback) {
+    if (usedFallback) {
       await resetFallbackSession(agentName);
+    } else if (threadId) {
+      await removeThreadSession(threadId);
     } else if (agentName) {
       await resetSession(agentName);
     } else {
@@ -1038,17 +1038,24 @@ async function execClaude(
   // Gate only on isNew + sessionId present — not on exitCode, so a session that timed
   // out mid-run is still persisted and can be resumed on the next message.
   const parseAsNew = isNew || recoveredFromStale;
-  if (!rateLimitMessage && parseAsNew && exec.sessionId && !usedFallback) {
+  if (!rateLimitMessage && parseAsNew && exec.sessionId) {
     sessionId = exec.sessionId;
-    if (threadId) {
-      await createThreadSession(threadId, sessionId);
-      console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
-    } else {
-      await createSession(sessionId, agentName);
+    if (recoveredFromStale && usedFallback) {
+      await createFallbackSession(sessionId, agentName);
       const label = agentName ? ` (agent ${agentName})` : "";
-      console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}${label}`);
+      console.log(`[${new Date().toLocaleTimeString()}] Fallback session created: ${sessionId}${label}`);
+      startSession(sessionId);
+    } else if (!usedFallback) {
+      if (threadId) {
+        await createThreadSession(threadId, sessionId);
+        console.log(`[${new Date().toLocaleTimeString()}] Thread session created: ${sessionId} (thread ${threadId.slice(0, 8)})`);
+      } else {
+        await createSession(sessionId, agentName);
+        const label = agentName ? ` (agent ${agentName})` : "";
+        console.log(`[${new Date().toLocaleTimeString()}] Session created: ${sessionId}${label}`);
+      }
+      startSession(sessionId);
     }
-    startSession(sessionId);
   }
 
   const result: RunResult = {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -163,6 +163,37 @@ const RATE_LIMIT_PATTERN = /you(?:'|')ve hit your limit|out of extra usage/i;
 const RATE_LIMIT_RESET_PATTERN = /resets?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*\(?\s*UTC\s*\)?/i;
 const SIGNATURE_ERROR = /Invalid.*signature.*thinking block/i;
 
+// Claude Code prints this when --resume references a session it no longer
+// has on disk (cleared, expired, compacted away, or moved to another machine).
+// When we see it, the cached session ID is dead and the only recovery is to
+// drop --resume and start fresh.
+const STALE_SESSION_PATTERN = /No conversation found with session ID/i;
+
+function isStaleSessionError(stdout: string, stderr: string): boolean {
+  return STALE_SESSION_PATTERN.test(stderr) || STALE_SESSION_PATTERN.test(stdout);
+}
+
+/** Strip --resume <id> from a claude argv list so it runs as a brand-new session. */
+function stripResume(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--resume") {
+      i += 1; // skip the session id that follows
+      continue;
+    }
+    out.push(args[i]!);
+  }
+  return out;
+}
+
+/** Replace the value following --output-format (returns a modified copy). */
+function withOutputFormat(args: string[], format: string): string[] {
+  const out = [...args];
+  const idx = out.indexOf("--output-format");
+  if (idx >= 0 && idx + 1 < out.length) out[idx + 1] = format;
+  return out;
+}
+
 // --- Rate limit state ---
 let rateLimitResetAt: number = 0; // epoch ms; 0 = not rate-limited
 let rateLimitNotified: boolean = false;
@@ -941,6 +972,47 @@ async function execClaude(
     }
   }
 
+  let recoveredFromStale = false;
+
+  // --- Stale session recovery ---
+  // Claude Code returns "No conversation found with session ID: <id>" when
+  // --resume points at a session it no longer has (cleared, expired, etc.).
+  // Back up the dead ID, drop --resume, and retry as a new session so the
+  // user isn't permanently stuck.
+  if (
+    !isNew &&
+    exitCode !== 0 &&
+    existing &&
+    isStaleSessionError(rawStdout, stderr)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name}; recovering with a new session...`
+    );
+
+    if (threadId) {
+      await removeThreadSession(threadId);
+    } else {
+      await backupSession();
+    }
+
+    const retryArgs = withOutputFormat(stripResume(args), "stream-json");
+    const retryConfig = usedFallback ? fallbackConfig : primaryConfig;
+    exec = await runClaudeStream(
+      retryArgs,
+      retryConfig.model,
+      retryConfig.api,
+      baseEnv,
+      timeoutMs,
+      spawnCwd
+    );
+
+    rawStdout = exec.rawStdout;
+    stderr = exec.stderr;
+    exitCode = exec.exitCode;
+    stdout = rawStdout;
+    recoveredFromStale = true;
+  }
+
   const rateLimitMessage = extractRateLimitMessage(rawStdout, stderr);
 
   if (rateLimitMessage) {
@@ -961,7 +1033,8 @@ async function execClaude(
   // Capture session ID from stream events and persist for new sessions.
   // Gate only on isNew + sessionId present — not on exitCode, so a session that timed
   // out mid-run is still persisted and can be resumed on the next message.
-  if (!rateLimitMessage && isNew && exec.sessionId && !usedFallback) {
+  const parseAsNew = isNew || recoveredFromStale;
+  if (!rateLimitMessage && parseAsNew && exec.sessionId && !usedFallback) {
     sessionId = exec.sessionId;
     if (threadId) {
       await createThreadSession(threadId, sessionId);
@@ -1027,7 +1100,7 @@ async function execClaude(
   }
 
   // --- Auto-compact on timeout (exit 124) ---
-  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing) {
+  if (COMPACT_TIMEOUT_ENABLED && exitCode === 124 && !isNew && existing && !recoveredFromStale) {
     emitCompactEvent({ type: "auto-compact-start" });
     const compactOk = await runCompact(
       existing.sessionId,
@@ -1066,7 +1139,7 @@ async function execClaude(
   }
 
   // --- Turn tracking & compact warning ---
-  if (exitCode === 0 && !isNew) {
+  if (exitCode === 0 && !isNew && !recoveredFromStale) {
     const turnCount = threadId ? await incrementThreadTurn(threadId) : await incrementTurn(agentName);
     const turnLabel = threadId ? ` (thread ${threadId.slice(0, 8)})` : agentName ? ` (agent ${agentName})` : "";
     console.log(`[${new Date().toLocaleTimeString()}] Turn count: ${turnCount}${turnLabel}`);
@@ -1163,6 +1236,10 @@ async function streamClaude(
     stderr: "pipe",
     env: childEnv,
   });
+
+  // Collect stderr in the background so it doesn't back-pressure the process.
+  // We need it after proc.exited for stale session detection.
+  const stderrPromise = new Response(proc.stderr).text();
 
   const reader = proc.stdout.getReader();
   const decoder = new TextDecoder();
@@ -1264,6 +1341,23 @@ async function streamClaude(
   }
 
   await proc.exited;
+  const stderrText = await stderrPromise;
+
+  // --- Stale session recovery (stream path) ---
+  if (
+    existing &&
+    !textEmitted &&
+    (proc.exitCode ?? 0) !== 0 &&
+    isStaleSessionError("", stderrText)
+  ) {
+    console.warn(
+      `[${new Date().toLocaleTimeString()}] Stale session ${existing.sessionId.slice(0, 8)} for ${name} (stream); recovering with a new session...`
+    );
+    await backupSession();
+    await streamClaude(name, prompt, onChunk, onUnblock, onAgentEvent);
+    return;
+  }
+
   // Ensure unblock fires even if something unexpected happened
   maybeUnblock();
 


### PR DESCRIPTION
## Summary
- Cherry-picks the rate-limit daemon/message handling from #165.
- Cherry-picks Telegram voice directive support from #166.
- Cherry-picks the Windows claude.exe runner resolution from #167.
- Cherry-picks stale --resume session recovery from #168.

## Attribution
- #165 by @TerrysPOV, based on the original idea in #33 by @dmitryanchikov.
- #166 by @TerrysPOV, based on the original idea in #34 by @dmitryanchikov.
- #167 by @TerrysPOV, based on the original fix in #99 by @DerfEflow.
- #168 by @TerrysPOV, based on the original fix in #110 by @lunklin.

## Overlap handling
#165 and #168 both carried stale-session recovery changes. This branch uses #168 as the source of truth for stale-session recovery and only takes the rate-limit-specific commits from #165, so the duplicated recovery work is represented once while retaining the #168 attribution in the commit history.

The #166 plugin version bump was already covered by the #165 cherry-pick, so the duplicate no-op commit was skipped.

## Verification
- git diff --check origin/master..HEAD
- bun install
- bun test
- bunx tsc --noEmit --pretty false