### PR TITLE
fix(statusline): reject 0/NaN/non-positive PIDs in alive()

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -60,7 +60,11 @@ function fmt(ms) {
 function alive() {
   try {
     var pid = readFileSync(PID_FILE, "utf-8").trim();
-    process.kill(Number(pid), 0);
+    var parsedPid = Number(pid);
+    if (!Number.isFinite(parsedPid) || !Number.isInteger(parsedPid) || parsedPid <= 0) {
+      return false;
+    }
+    process.kill(parsedPid, 0);
     return true;
   } catch { return false; }
 }


### PR DESCRIPTION
## What

Guard `alive()` against an empty or corrupt pidfile silently reporting the daemon as live.

`process.kill(0, signal)` in Node operates on the *calling process group*, not a specific PID, and always succeeds — so an empty pidfile (daemon crashed mid-write, lifecycle race) returned `true` forever. The statusline showed `● live` permanently and daemon restarts were blocked without a manual `rm daemon.pid`.

## Fix

Validate the parsed PID is a finite, positive integer before calling `process.kill`. Anything else returns `false`.

```js
function alive() {
  try {
    var pid = readFileSync(PID_FILE, "utf-8").trim();
    var parsedPid = Number(pid);
    if (!Number.isFinite(parsedPid) || !Number.isInteger(parsedPid) || parsedPid <= 0) {
      return false;
    }
    process.kill(parsedPid, 0);
    return true;
  } catch { return false; }
}
```

## Test plan

- Empty pidfile → `alive()` returns `false` (was `true`)
- Pidfile contains `"0"` → `false` (was `true`)
- Valid running PID → `true` (unchanged)
- Stale numeric PID → `false` (unchanged)

## Attribution

Originally reported and fixed by [@prashantsolanki3](https://github.com/prashantsolanki3) in #127. Ported to a clean branch off current master. Thank you Prashant.