### PR TITLE
telegram: per-topic session isolation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,8 +1,9 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, isRateLimited, getRateLimitResetAt } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { transcribeAudioToText } from "../whisper";
 import { resetSession, resetFallbackSession, peekSession } from "../sessions";
+import { peekThreadSession, removeThreadSession } from "../sessionManager";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -718,6 +719,21 @@ async function handleMyChatMember(update: TelegramMyChatMemberUpdate): Promise<v
   }
 }
 
+function getTelegramSessionKey(
+  chatId: number,
+  threadId: number | undefined,
+  userId: number | undefined,
+  isPrivate: boolean,
+  dmIsolation: "shared" | "perUser",
+): string | undefined {
+  if (isPrivate) {
+    if (dmIsolation === "perUser" && userId !== undefined) return `tg:dm:${userId}`;
+    return undefined;
+  }
+  if (threadId !== undefined) return `tg:${chatId}:${threadId}`;
+  return `tg:${chatId}`;
+}
+
 // --- Message handler ---
 
 async function handleMessage(message: TelegramMessage): Promise<void> {
@@ -732,6 +748,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   const hasImage = Boolean((message.photo && message.photo.length > 0) || isImageDocument(message.document));
   const hasVoice = Boolean(message.voice || message.audio || isAudioDocument(message.document));
   const hasDocument = Boolean(message.document && isDocumentAttachment(message.document));
+  const sessionKey = getTelegramSessionKey(chatId, threadId, userId, isPrivate, config.dmIsolation);
 
   if (!isPrivate && !isGroup) return;
 
@@ -773,21 +790,29 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   }
 
   if (command === "/reset") {
-    await resetSession();
-    await resetFallbackSession();
-    await sendMessage(config.token, chatId, "Global session reset. Next message starts fresh.", threadId);
+    if (sessionKey) {
+      await removeThreadSession(sessionKey);
+      await resetFallbackSession(undefined, sessionKey);
+      await sendMessage(config.token, chatId, "Session reset. Next message starts fresh.", threadId);
+    } else {
+      await resetSession();
+      await resetFallbackSession();
+      await sendMessage(config.token, chatId, "Global session reset. Next message starts fresh.", threadId);
+    }
     return;
   }
 
   if (command === "/compact") {
     await sendMessage(config.token, chatId, "⏳ Compacting session...", threadId);
-    const result = await compactCurrentSession();
+    const result = sessionKey
+      ? await compactCurrentThreadSession(sessionKey)
+      : await compactCurrentSession();
     await sendMessage(config.token, chatId, result.message, threadId);
     return;
   }
 
   if (command === "/status") {
-    const session = await peekSession();
+    const session = sessionKey ? await peekThreadSession(sessionKey) : await peekSession();
     const settings = getSettings();
     if (!session) {
       await sendMessage(config.token, chatId, "📊 No active session.", threadId);
@@ -808,7 +833,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   }
 
   if (command === "/context") {
-    const session = await peekSession();
+    const session = sessionKey ? await peekThreadSession(sessionKey) : await peekSession();
     if (!session) {
       await sendMessage(config.token, chatId, "No active session.", threadId);
       return;
@@ -1012,7 +1037,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       );
     }
     const prefixedPrompt = promptParts.join("\n");
-    const result = await runUserMessage("telegram", prefixedPrompt);
+    const result = await runUserMessage("telegram", prefixedPrompt, sessionKey);
 
     if (result.exitCode !== 0) {
       const isTimedOut = result.exitCode === 124;

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,7 +78,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true },
+  telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true, dmIsolation: "shared" },
   discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [] },
   slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
@@ -111,6 +111,12 @@ export interface TelegramConfig {
   listenChats: number[];
   /** When false, skip Telegram polling (incoming messages). Useful for send-only instances. Default: true */
   receiveEnabled: boolean;
+  /**
+   * Controls session isolation for Telegram DMs.
+   * - "shared": all DMs share the global session (matches Discord DM behaviour). Default.
+   * - "perUser": each DM user gets their own isolated session.
+   */
+  dmIsolation: "shared" | "perUser";
 }
 
 export interface DiscordConfig {
@@ -327,6 +333,7 @@ function parseSettings(
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
       listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
       receiveEnabled: raw.telegram?.receiveEnabled !== false,
+      dmIsolation: raw.telegram?.dmIsolation === "perUser" ? "perUser" : "shared",
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),


### PR DESCRIPTION
## Summary

- Adds `getTelegramSessionKey()` helper that maps each Telegram context to an isolated session key: `tg:<chatId>:<threadId>` for supergroup topics, `tg:<chatId>` for general group chat, `tg:dm:<userId>` for per-user DMs (opt-in), or `undefined` to fall through to the global session
- Adds `telegram.dmIsolation: "shared" | "perUser"` config setting (default `"shared"` to match existing Discord DM behavior)
- Scopes `/reset`, `/compact`, `/status`, and `/context` to the per-topic session when a key is present

## Motivation

Without this, all Telegram group topics share a single global session. A conversation in one topic bleeds context into unrelated topics, and `/reset` nukes every topic at once. This matches the isolation pattern Discord already uses for guild channels.

## Test plan

- [ ] Supergroup: send messages in two different topics — confirm each maintains its own context
- [ ] `/reset` in one topic does not affect another topic's session
- [ ] `/status` and `/context` show the correct per-topic session
- [ ] `/compact` runs on the correct thread session
- [ ] DMs with `dmIsolation: "shared"` (default) still use the global session
- [ ] DMs with `dmIsolation: "perUser"` isolate per user ID
- [ ] Plain group chat (no threads) uses `tg:<chatId>` key correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)