### PR TITLE
feat(discord): include reply and forwarded message context in prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -55,6 +55,12 @@ interface DiscordAttachment {
   flags?: number;
 }
 
+interface DiscordMessageSnapshot {
+  content: string;
+  attachments: DiscordAttachment[];
+  author?: DiscordUser;
+}
+
 interface DiscordMessage {
   id: string;
   channel_id: string;
@@ -64,6 +70,8 @@ interface DiscordMessage {
   attachments: DiscordAttachment[];
   mentions: DiscordUser[];
   referenced_message?: DiscordMessage | null;
+  message_reference?: { type?: number };
+  message_snapshots?: [{ message: DiscordMessageSnapshot }];
   flags?: number;
   type: number;
 }
@@ -803,6 +811,24 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       promptParts.push(`Attached text file (${textAttachments[0].filename}):\n${textContent}`);
     } else if (hasText) {
       promptParts.push("The user attached a text file, but downloading it failed. Ask them to resend.");
+    }
+
+    // Include context from replied-to or forwarded messages
+    const isForward = message.message_reference?.type === 1;
+    const snapshot = message.message_snapshots?.[0]?.message;
+    if (isForward && snapshot) {
+      const fwdAuthor = snapshot.author ? snapshot.author.username : "unknown";
+      const fwdAttachments = snapshot.attachments.length > 0
+        ? ` [attachments: ${snapshot.attachments.map((a) => a.filename).join(", ")}]`
+        : "";
+      promptParts.push(`[Forwarded message from ${fwdAuthor}]: ${snapshot.content}${fwdAttachments}`);
+    } else if (message.referenced_message) {
+      const ref = message.referenced_message;
+      const refAuthor = ref.author.username;
+      const refAttachments = ref.attachments.length > 0
+        ? ` [attachments: ${ref.attachments.map((a) => a.filename).join(", ")}]`
+        : "";
+      promptParts.push(`[In reply to ${refAuthor}]: ${ref.content}${refAttachments}`);
     }
 
     const prefixedPrompt = promptParts.join("\n");


### PR DESCRIPTION
## Summary

- Injects replied-to message content into the Claude prompt as `[In reply to <user>]: <text>`
- Injects forwarded message snapshot content as `[Forwarded message from <user>]: <text>`
- Attachments on referenced/forwarded messages are noted by filename but not downloaded
- Adds `DiscordMessageSnapshot` interface and extends `DiscordMessage` with `message_reference` and `message_snapshots` fields

## Test plan

- [ ] Reply to a message in a Discord guild channel — verify the bot's response reflects the replied-to content
- [ ] Forward a message into a channel where the bot is listening — verify the forwarded content appears in the bot's context
- [ ] Send a plain message (no reply, no forward) — verify no regression
- [ ] Reply to a message that has attachments — verify attachment filenames are noted in the prompt

Closes BCD-89