### PR TITLE
bulk: cherry-pick #173, #183, #184 — per-topic sessions, Discord reply context, Telegram streaming

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.25",
+      "version": "1.0.26",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -55,6 +55,12 @@ interface DiscordAttachment {
   flags?: number;
 }
 
+interface DiscordMessageSnapshot {
+  content: string;
+  attachments: DiscordAttachment[];
+  author?: DiscordUser;
+}
+
 interface DiscordMessage {
   id: string;
   channel_id: string;
@@ -64,6 +70,8 @@ interface DiscordMessage {
   attachments: DiscordAttachment[];
   mentions: DiscordUser[];
   referenced_message?: DiscordMessage | null;
+  message_reference?: { type?: number };
+  message_snapshots?: [{ message: DiscordMessageSnapshot }];
   flags?: number;
   type: number;
 }
@@ -803,6 +811,24 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
       promptParts.push(`Attached text file (${textAttachments[0].filename}):\n${textContent}`);
     } else if (hasText) {
       promptParts.push("The user attached a text file, but downloading it failed. Ask them to resend.");
+    }
+
+    // Include context from replied-to or forwarded messages
+    const isForward = message.message_reference?.type === 1;
+    const snapshot = message.message_snapshots?.[0]?.message;
+    if (isForward && snapshot) {
+      const fwdAuthor = snapshot.author ? snapshot.author.username : "unknown";
+      const fwdAttachments = snapshot.attachments.length > 0
+        ? ` [attachments: ${snapshot.attachments.map((a) => a.filename).join(", ")}]`
+        : "";
+      promptParts.push(`[Forwarded message from ${fwdAuthor}]: ${snapshot.content}${fwdAttachments}`);
+    } else if (message.referenced_message) {
+      const ref = message.referenced_message;
+      const refAuthor = ref.author.username;
+      const refAttachments = ref.attachments.length > 0
+        ? ` [attachments: ${ref.attachments.map((a) => a.filename).join(", ")}]`
+        : "";
+      promptParts.push(`[In reply to ${refAuthor}]: ${ref.content}${refAttachments}`);
     }
 
     const prefixedPrompt = promptParts.join("\n");

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1246,32 +1246,49 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           console.error(`[Telegram] Failed to send voice ${vp} for ${label}: ${err instanceof Error ? err.message : err}`);
         }
       }
+      // Whether the response is directive-only (attachment is the output, text is empty)
+      const isDirectiveOnly = !cleanedText && (buttonRows || filePaths.length > 0 || voicePaths.length > 0 || hadVoiceDirective);
+
       if (buttonRows) {
-        // Route on buttonRows regardless of whether cleanedText is empty
+        // Delete the stream preview before sending the button message — the
+        // preview shows raw streaming text (or the raw [buttons:] directive)
+        // which would otherwise sit above the button message as a duplicate.
+        if (streamMsgId) {
+          await callApi(config.token, "deleteMessage", {
+            chat_id: chatId, message_id: streamMsgId,
+          }).catch(() => {});
+        }
         await sendMessageWithButtons(config.token, chatId, cleanedText, buttonRows, threadId);
       } else if (streamMsgId) {
-        // Edit the streaming message with final formatted HTML.
-        // editStream() already set the message to the correct plain text content,
-        // so if all edits fail (e.g. "message is not modified"), do NOT send a new
-        // message — the user already sees the correct content and a sendMessage
-        // would create a duplicate.
-        const finalText = cleanedText || "(empty response)";
-        const html = markdownToTelegramHtml(normalizeTelegramText(finalText));
-        await callApi(config.token, "editMessageText", {
-          chat_id: chatId, message_id: streamMsgId,
-          text: html.slice(0, 4096), parse_mode: "HTML",
-        }).catch(() => callApi(config.token, "editMessageText", {
-          chat_id: chatId, message_id: streamMsgId,
-          text: finalText.slice(0, 4096),
-        }).catch(() => {
-          // If all edits fail and the stream message has tool output (verbose),
-          // send the final response as a new message. But if there were no tool
-          // lines, the stream message already shows the correct text — "not
-          // modified" just means it's already right, so don't send a duplicate.
-          if (verbose && hadToolLines) {
-            return sendMessage(config.token, chatId, finalText, threadId);
-          }
-        }));
+        if (isDirectiveOnly) {
+          // The attachment (file / voice) IS the response — delete the stream
+          // preview so the user doesn't see "(empty response)" as a stray message.
+          await callApi(config.token, "deleteMessage", {
+            chat_id: chatId, message_id: streamMsgId,
+          }).catch(() => {});
+        } else {
+          // Normal text response: edit stream with final formatted HTML.
+          // editStream() already set the message to the correct plain text, so if
+          // all edits fail ("message is not modified") do NOT send a new message —
+          // the user already sees the correct content and a sendMessage would duplicate.
+          const finalText = cleanedText || "(empty response)";
+          const html = markdownToTelegramHtml(normalizeTelegramText(finalText));
+          await callApi(config.token, "editMessageText", {
+            chat_id: chatId, message_id: streamMsgId,
+            text: html.slice(0, 4096), parse_mode: "HTML",
+          }).catch(() => callApi(config.token, "editMessageText", {
+            chat_id: chatId, message_id: streamMsgId,
+            text: finalText.slice(0, 4096),
+          }).catch(() => {
+            // If all edits fail and the stream message has tool output (verbose),
+            // send the final response as a new message. But if there were no tool
+            // lines, the stream message already shows the correct text — "not
+            // modified" just means it's already right, so don't send a duplicate.
+            if (verbose && hadToolLines) {
+              return sendMessage(config.token, chatId, finalText, threadId);
+            }
+          }));
+        }
       } else if (cleanedText) {
         await sendMessage(config.token, chatId, cleanedText, threadId);
       }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,8 +1,9 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, isRateLimited, getRateLimitResetAt } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { transcribeAudioToText } from "../whisper";
 import { resetSession, resetFallbackSession, peekSession } from "../sessions";
+import { peekThreadSession, removeThreadSession } from "../sessionManager";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -718,6 +719,21 @@ async function handleMyChatMember(update: TelegramMyChatMemberUpdate): Promise<v
   }
 }
 
+function getTelegramSessionKey(
+  chatId: number,
+  threadId: number | undefined,
+  userId: number | undefined,
+  isPrivate: boolean,
+  dmIsolation: "shared" | "perUser",
+): string | undefined {
+  if (isPrivate) {
+    if (dmIsolation === "perUser" && userId !== undefined) return `tg:dm:${userId}`;
+    return undefined;
+  }
+  if (threadId !== undefined) return `tg:${chatId}:${threadId}`;
+  return `tg:${chatId}`;
+}
+
 // --- Message handler ---
 
 async function handleMessage(message: TelegramMessage): Promise<void> {
@@ -732,6 +748,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   const hasImage = Boolean((message.photo && message.photo.length > 0) || isImageDocument(message.document));
   const hasVoice = Boolean(message.voice || message.audio || isAudioDocument(message.document));
   const hasDocument = Boolean(message.document && isDocumentAttachment(message.document));
+  const sessionKey = getTelegramSessionKey(chatId, threadId, userId, isPrivate, config.dmIsolation);
 
   if (!isPrivate && !isGroup) return;
 
@@ -773,21 +790,29 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   }
 
   if (command === "/reset") {
-    await resetSession();
-    await resetFallbackSession();
-    await sendMessage(config.token, chatId, "Global session reset. Next message starts fresh.", threadId);
+    if (sessionKey) {
+      await removeThreadSession(sessionKey);
+      await resetFallbackSession(undefined, sessionKey);
+      await sendMessage(config.token, chatId, "Session reset. Next message starts fresh.", threadId);
+    } else {
+      await resetSession();
+      await resetFallbackSession();
+      await sendMessage(config.token, chatId, "Global session reset. Next message starts fresh.", threadId);
+    }
     return;
   }
 
   if (command === "/compact") {
     await sendMessage(config.token, chatId, "⏳ Compacting session...", threadId);
-    const result = await compactCurrentSession();
+    const result = sessionKey
+      ? await compactCurrentThreadSession(sessionKey)
+      : await compactCurrentSession();
     await sendMessage(config.token, chatId, result.message, threadId);
     return;
   }
 
   if (command === "/status") {
-    const session = await peekSession();
+    const session = sessionKey ? await peekThreadSession(sessionKey) : await peekSession();
     const settings = getSettings();
     if (!session) {
       await sendMessage(config.token, chatId, "📊 No active session.", threadId);
@@ -808,7 +833,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
   }
 
   if (command === "/context") {
-    const session = await peekSession();
+    const session = sessionKey ? await peekThreadSession(sessionKey) : await peekSession();
     if (!session) {
       await sendMessage(config.token, chatId, "No active session.", threadId);
       return;
@@ -1012,7 +1037,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       );
     }
     const prefixedPrompt = promptParts.join("\n");
-    const result = await runUserMessage("telegram", prefixedPrompt);
+    const result = await runUserMessage("telegram", prefixedPrompt, sessionKey);
 
     if (result.exitCode !== 0) {
       const isTimedOut = result.exitCode === 124;

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, runFork, killActive, isMainBusy, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { getSettings, loadSettings } from "../config";
 import { transcribeAudioToText } from "../whisper";
@@ -362,6 +362,128 @@ async function sendDocumentToChat(
     const body = await res.text();
     throw new Error(`Telegram sendDocument failed: ${res.status} ${body}`);
   }
+}
+
+// Chat IDs with verbose tool display enabled
+const verboseChats = new Set<number>();
+
+/**
+ * Build a streaming callback using editMessageText.
+ * On first chunk: send a placeholder message to get message_id.
+ * On subsequent chunks (throttled): edit that message with accumulated plain text.
+ * In verbose mode, tool call/result lines appear above the text response.
+ */
+function makeStreamCallback(
+  token: string,
+  chatId: number,
+  threadId: number | undefined,
+  options: { intervalMs?: number; verbose?: boolean } = {}
+): { onChunk: (text: string) => void; onToolEvent: (line: string) => void; waitForStreamMsg: () => Promise<{ msgId: number | null; hadToolLines: boolean }> } {
+  const { intervalMs = 500, verbose = false } = options;
+  let textAcc = "";
+  const toolLines: string[] = [];
+  let lastSentAt = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let streamMsgId: number | null = null;
+  let initPromise: Promise<void> | null = null;
+  let finalized = false;
+
+  const getDisplay = () => {
+    const MAX_TOOL_LINES = 8;
+    const MAX_TEXT_LINES = 15;
+    let toolPart: string;
+    if (toolLines.length > MAX_TOOL_LINES) {
+      const shown = toolLines.slice(-MAX_TOOL_LINES);
+      toolPart = `[...${toolLines.length - MAX_TOOL_LINES} earlier]\n` + shown.join("\n");
+    } else {
+      toolPart = toolLines.join("\n");
+    }
+    let textPart = textAcc;
+    const textLines = textPart.split("\n");
+    if (textLines.length > MAX_TEXT_LINES) {
+      textPart = `[...]\n` + textLines.slice(-MAX_TEXT_LINES).join("\n");
+    }
+    return toolPart + (textPart ? (toolPart ? "\n\n" : "") + textPart : "");
+  };
+
+  const editStream = () => {
+    if (!streamMsgId || finalized) return;
+    let display: string;
+    if (verbose) {
+      display = getDisplay();
+    } else {
+      // Keep last N lines of text for streaming preview
+      const lines = textAcc.split("\n");
+      display = lines.length > 30 ? `[...]\n${lines.slice(-30).join("\n")}` : textAcc;
+    }
+    if (!display) return;
+    callApi(token, "editMessageText", {
+      chat_id: chatId,
+      message_id: streamMsgId,
+      text: display.slice(0, 4096),
+    }).catch(() => {});
+  };
+
+  const flush = async () => {
+    const display = verbose ? getDisplay() : textAcc;
+    if (!display) return;
+    lastSentAt = Date.now();
+
+    if (!streamMsgId && !initPromise) {
+      initPromise = (async () => {
+        try {
+          const res = await callApi<{ ok: boolean; result: { message_id: number } }>(
+            token, "sendMessage", {
+              chat_id: chatId,
+              text: "⏳",
+              ...(threadId ? { message_thread_id: threadId } : {}),
+            }
+          );
+          if (res.ok) {
+            streamMsgId = res.result.message_id;
+            editStream();
+          }
+        } catch {}
+      })();
+      await initPromise;
+    } else {
+      if (initPromise) await initPromise;
+      editStream();
+    }
+  };
+
+  const onChunk = (text: string) => {
+    textAcc += text;
+    const now = Date.now();
+    if (now - lastSentAt >= intervalMs) {
+      if (timer) { clearTimeout(timer); timer = null; }
+      flush();
+    } else if (!timer) {
+      timer = setTimeout(() => { timer = null; flush(); }, intervalMs - (now - lastSentAt));
+    }
+  };
+
+  const onToolEvent = (line: string) => {
+    if (!verbose) return;
+    toolLines.push(line);
+    // Use same throttle logic as onChunk to avoid spamming the API
+    const now = Date.now();
+    if (now - lastSentAt >= intervalMs) {
+      if (timer) { clearTimeout(timer); timer = null; }
+      flush();
+    } else if (!timer) {
+      timer = setTimeout(() => { timer = null; flush(); }, intervalMs - (now - lastSentAt));
+    }
+  };
+
+  const waitForStreamMsg = async (): Promise<{ msgId: number | null; hadToolLines: boolean }> => {
+    if (timer) { clearTimeout(timer); timer = null; }
+    if (initPromise) await initPromise;
+    finalized = true;
+    return { msgId: streamMsgId, hadToolLines: toolLines.length > 0 };
+  };
+
+  return { onChunk, onToolEvent, waitForStreamMsg };
 }
 
 function extractReactionDirective(text: string): { cleanedText: string; reactionEmoji: string | null } {
@@ -887,6 +1009,47 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     return;
   }
 
+  if (command === "/kill") {
+    const killed = killActive();
+    await sendMessage(config.token, chatId, killed ? "Killed active agent." : "No active agent running.", threadId);
+    return;
+  }
+
+  if (command === "/verbose") {
+    if (verboseChats.has(chatId)) {
+      verboseChats.delete(chatId);
+      await sendMessage(config.token, chatId, "Verbose mode off.", threadId);
+    } else {
+      verboseChats.add(chatId);
+      await sendMessage(config.token, chatId, "Verbose mode on — tool calls will be shown.", threadId);
+    }
+    return;
+  }
+
+  if (command === "/fork") {
+    const forkPrompt = text.replace(/^\/fork\s*/i, "").trim();
+    if (!forkPrompt) {
+      await sendMessage(config.token, chatId, "Usage: /fork <prompt>", threadId);
+      return;
+    }
+    const typingInterval = setInterval(() => sendTyping(config.token, chatId, threadId), 4000);
+    try {
+      await sendTyping(config.token, chatId, threadId);
+      const senderLabel = message.from?.username ?? String(userId ?? "unknown");
+      const result = await runFork(`[Telegram from ${senderLabel}]\nMessage: ${forkPrompt}`);
+      if (result.exitCode !== 0) {
+        await sendMessage(config.token, chatId, `Fork error (exit ${result.exitCode}): ${result.stderr || "Unknown error"}`, threadId);
+      } else {
+        await sendMessage(config.token, chatId, result.stdout || "(empty response)", threadId);
+      }
+    } catch (err) {
+      await sendMessage(config.token, chatId, `Fork error: ${err instanceof Error ? err.message : String(err)}`, threadId);
+    } finally {
+      clearInterval(typingInterval);
+    }
+    return;
+  }
+
   // Secretary: detect reply to a bot alert message → treat as custom reply
   const replyToMsgId = message.reply_to_message?.message_id;
   if (replyToMsgId && text && botId && message.reply_to_message?.from?.id === botId) {
@@ -969,7 +1132,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
     // Skill routing: resolve slash commands to SKILL.md prompts
     let skillContext: string | null = null;
-    if (command && command !== "/start" && command !== "/reset" && command !== "/compact" && command !== "/status" && command !== "/context") {
+    if (command && command !== "/start" && command !== "/reset" && command !== "/compact" && command !== "/status" && command !== "/context" && command !== "/kill" && command !== "/verbose" && command !== "/fork") {
       try {
         skillContext = await resolveSkillPrompt(command);
         if (skillContext) {
@@ -1037,14 +1200,33 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       );
     }
     const prefixedPrompt = promptParts.join("\n");
-    const result = await runUserMessage("telegram", prefixedPrompt, sessionKey);
+    const busy = isMainBusy();
+    const verbose = verboseChats.has(chatId);
+    let result;
+    let streamMsgId: number | null = null;
+    let hadToolLines = false;
+    if (busy) {
+      result = await runFork(prefixedPrompt);
+    } else {
+      const stream = makeStreamCallback(config.token, chatId, threadId, { verbose });
+      result = await runUserMessage("telegram", prefixedPrompt, sessionKey, undefined, stream.onChunk, stream.onToolEvent);
+      const streamResult = await stream.waitForStreamMsg();
+      streamMsgId = streamResult.msgId;
+      hadToolLines = streamResult.hadToolLines;
+    }
 
     if (result.exitCode !== 0) {
       const isTimedOut = result.exitCode === 124;
       const errorMsg = isTimedOut
         ? `⏱ Request timed out — the subprocess took too long and was killed. Try again or split into smaller steps.`
         : `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`;
-      await sendMessage(config.token, chatId, errorMsg, threadId);
+      if (streamMsgId) {
+        await callApi(config.token, "editMessageText", {
+          chat_id: chatId, message_id: streamMsgId, text: errorMsg,
+        }).catch(() => sendMessage(config.token, chatId, errorMsg, threadId));
+      } else {
+        await sendMessage(config.token, chatId, errorMsg, threadId);
+      }
     } else {
       const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
       const hadVoiceDirective = /\[voice:\/[^\]\r\n]+\]/i.test(afterReact);
@@ -1067,6 +1249,29 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       if (buttonRows) {
         // Route on buttonRows regardless of whether cleanedText is empty
         await sendMessageWithButtons(config.token, chatId, cleanedText, buttonRows, threadId);
+      } else if (streamMsgId) {
+        // Edit the streaming message with final formatted HTML.
+        // editStream() already set the message to the correct plain text content,
+        // so if all edits fail (e.g. "message is not modified"), do NOT send a new
+        // message — the user already sees the correct content and a sendMessage
+        // would create a duplicate.
+        const finalText = cleanedText || "(empty response)";
+        const html = markdownToTelegramHtml(normalizeTelegramText(finalText));
+        await callApi(config.token, "editMessageText", {
+          chat_id: chatId, message_id: streamMsgId,
+          text: html.slice(0, 4096), parse_mode: "HTML",
+        }).catch(() => callApi(config.token, "editMessageText", {
+          chat_id: chatId, message_id: streamMsgId,
+          text: finalText.slice(0, 4096),
+        }).catch(() => {
+          // If all edits fail and the stream message has tool output (verbose),
+          // send the final response as a new message. But if there were no tool
+          // lines, the stream message already shows the correct text — "not
+          // modified" just means it's already right, so don't send a duplicate.
+          if (verbose && hadToolLines) {
+            return sendMessage(config.token, chatId, finalText, threadId);
+          }
+        }));
       } else if (cleanedText) {
         await sendMessage(config.token, chatId, cleanedText, threadId);
       }
@@ -1078,7 +1283,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           await sendMessage(config.token, chatId, `Failed to send file: ${fp.split("/").pop()}`, threadId);
         }
       }
-      if (!cleanedText && !buttonRows && filePaths.length === 0 && voicePaths.length === 0 && !hadVoiceDirective) {
+      if (!cleanedText && !buttonRows && filePaths.length === 0 && voicePaths.length === 0 && !hadVoiceDirective && !streamMsgId) {
         await sendMessage(config.token, chatId, "(empty response)", threadId);
       }
     }
@@ -1220,6 +1425,9 @@ async function registerBotCommands(token: string): Promise<void> {
       { command: "compact", description: "Compact session to reduce context size" },
       { command: "status", description: "Show current session status" },
       { command: "context", description: "Show context window usage" },
+      { command: "kill", description: "Kill the currently running agent" },
+      { command: "verbose", description: "Toggle tool call display in responses" },
+      { command: "fork", description: "Run a parallel lightweight agent without blocking" },
     ];
     for (const skill of skills) {
       // Telegram commands: 1-32 chars, lowercase a-z, 0-9, underscores only
@@ -1242,7 +1450,7 @@ async function registerBotCommands(token: string): Promise<void> {
     } catch (regErr) {
       // Skill-generated commands may violate Telegram constraints; retry with built-in commands only
       console.warn(`[Telegram] Full command registration failed, retrying with built-in commands only: ${regErr instanceof Error ? regErr.message : regErr}`);
-      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context"].includes(c.command));
+      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context", "kill", "verbose", "fork"].includes(c.command));
       await callApi(token, "setMyCommands", { commands: builtinOnly });
       console.log(`  Commands registered (built-in only): ${builtinOnly.length}`);
     }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1206,7 +1206,8 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     let streamMsgId: number | null = null;
     let hadToolLines = false;
     if (busy) {
-      result = await runFork(prefixedPrompt);
+      await sendMessage(config.token, chatId, "Claude is busy — try again in a moment, or use /fork for a quick parallel task.", threadId);
+      return;
     } else {
       const stream = makeStreamCallback(config.token, chatId, threadId, { verbose });
       result = await runUserMessage("telegram", prefixedPrompt, sessionKey, undefined, stream.onChunk, stream.onToolEvent);

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,7 +78,7 @@ const DEFAULT_SETTINGS: Settings = {
     excludeWindows: [],
     forwardToTelegram: true,
   },
-  telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true },
+  telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true, dmIsolation: "shared" },
   discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [] },
   slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
@@ -111,6 +111,12 @@ export interface TelegramConfig {
   listenChats: number[];
   /** When false, skip Telegram polling (incoming messages). Useful for send-only instances. Default: true */
   receiveEnabled: boolean;
+  /**
+   * Controls session isolation for Telegram DMs.
+   * - "shared": all DMs share the global session (matches Discord DM behaviour). Default.
+   * - "perUser": each DM user gets their own isolated session.
+   */
+  dmIsolation: "shared" | "perUser";
 }
 
 export interface DiscordConfig {
@@ -327,6 +333,7 @@ function parseSettings(
       allowedUserIds: raw.telegram?.allowedUserIds ?? [],
       listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
       receiveEnabled: raw.telegram?.receiveEnabled !== false,
+      dmIsolation: raw.telegram?.dmIsolation === "perUser" ? "perUser" : "shared",
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1665,11 +1665,16 @@ const FORK_SYSTEM_PROMPT = [
 
 const FORK_MODEL = "claude-haiku-4-5-20251001";
 
+// Forks are lightweight watchers — hard-kill after 2 minutes.
+const FORK_TIMEOUT_MS = 120_000;
+
 /**
  * Run a fork agent — parallel, outside the main serial queue, no main session.
  *
  * Spawns directly rather than through runClaudeOnce so the fork proc is never
  * added to mainActiveProcs — /kill must only target main-queue runs, not forks.
+ * Uses the same collectStream + timeout pattern as the main runner so forks
+ * cannot hang indefinitely or grow memory unbounded.
  */
 export async function runFork(prompt: string): Promise<RunResult> {
   const { api } = getSettings();
@@ -1689,21 +1694,43 @@ export async function runFork(prompt: string): Promise<RunResult> {
     env: buildChildEnv(baseEnv, FORK_MODEL, api),
   });
 
-  const [rawStdout, rawStderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  await proc.exited;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      try { proc.kill(); } catch {}
+      reject(new Error(`Fork timed out after ${FORK_TIMEOUT_MS / 1000}s`));
+    }, FORK_TIMEOUT_MS);
+  });
+
+  let rawStdout: string;
+  let rawStderr: string;
+  let exitCode: number;
+
+  try {
+    [rawStdout, rawStderr] = await Promise.race([
+      Promise.all([
+        collectStream(proc.stdout as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
+        collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
+      ]),
+      timeoutPromise,
+    ]) as [string, string];
+    if (timeoutId) clearTimeout(timeoutId);
+    await proc.exited;
+    exitCode = proc.exitCode ?? 1;
+  } catch (err) {
+    if (timeoutId) clearTimeout(timeoutId);
+    return { stdout: "", stderr: String(err), exitCode: 1 };
+  }
 
   let stdout = rawStdout;
-  if ((proc.exitCode ?? 1) === 0) {
+  if (exitCode === 0) {
     try {
       const json = JSON.parse(rawStdout);
       stdout = json.result ?? rawStdout;
     } catch {}
   }
 
-  return { stdout, stderr: rawStderr, exitCode: proc.exitCode ?? 1 };
+  return { stdout, stderr: rawStderr, exitCode };
 }
 
 /**

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1677,13 +1677,14 @@ const FORK_TIMEOUT_MS = 120_000;
  * cannot hang indefinitely or grow memory unbounded.
  */
 export async function runFork(prompt: string): Promise<RunResult> {
-  const { api } = getSettings();
+  const { api, security } = getSettings();
   const baseEnv = cleanSpawnEnv();
+  const securityArgs = buildSecurityArgs(security);
 
   const args = [
     CLAUDE_EXECUTABLE, "-p", prompt,
     "--output-format", "json",
-    "--dangerously-skip-permissions",
+    ...securityArgs,
     "--model", FORK_MODEL,
     "--append-system-prompt", FORK_SYSTEM_PROMPT,
   ];

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -260,6 +260,25 @@ function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
   return task;
 }
 
+// Active process tracking — allows kill from outside
+let activeProc: ReturnType<typeof Bun.spawn> | null = null;
+
+/** Kill the currently running claude subprocess. Returns true if something was killed. */
+export function killActive(): boolean {
+  if (!activeProc) return false;
+  try { activeProc.kill(); } catch {}
+  activeProc = null;
+  return true;
+}
+
+// Tracks whether the main serial queue is currently executing
+let mainRunning = false;
+
+/** True while the main agent is processing a task (excludes fork). */
+export function isMainBusy(): boolean {
+  return mainRunning;
+}
+
 function extractRateLimitMessage(stdout: string, stderr: string): string | null {
   const candidates = [stdout, stderr];
   for (const text of candidates) {
@@ -386,6 +405,7 @@ async function runClaudeOnce(
     ...(cwd ? { cwd } : {}),
   });
 
+  activeProc = proc;
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
@@ -402,6 +422,7 @@ async function runClaudeOnce(
 
     if (timeoutId) clearTimeout(timeoutId);
     await proc.exited;
+    if (activeProc === proc) activeProc = null;
 
     return {
       rawStdout,
@@ -410,6 +431,7 @@ async function runClaudeOnce(
     };
   } catch (err) {
     if (timeoutId) clearTimeout(timeoutId);
+    if (activeProc === proc) activeProc = null;
     // Kill the hung process
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
@@ -437,7 +459,9 @@ async function runClaudeStream(
   api: string,
   baseEnv: Record<string, string>,
   timeoutMs: number = DEFAULT_SESSION_TIMEOUT_MS,
-  cwd?: string
+  cwd?: string,
+  onChunk?: (text: string) => void,
+  onToolEvent?: (line: string) => void
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number; sessionId?: string }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();
@@ -450,9 +474,15 @@ async function runClaudeStream(
     ...(cwd ? { cwd } : {}),
   });
 
+  activeProc = proc;
   let sessionId: string | undefined;
   let resultText = "";
   let stderr = "";
+
+  // Streaming state for onChunk/onToolEvent callbacks
+  let streamDelivered = "";
+  let streamLastMsgId = "";
+  const streamPendingToolCalls = new Map<string, string>();
 
   const readStdout = async () => {
     const reader = proc.stdout.getReader();
@@ -475,6 +505,41 @@ async function runClaudeStream(
           if (event.type === "result" && typeof event.result === "string") {
             resultText = event.result;
           }
+          // Emit streaming callbacks if provided
+          if ((onChunk || onToolEvent) && event.type === "assistant" && (event.message as any)?.content) {
+            const msg = event.message as any;
+            const msgId: string = msg.id ?? "";
+            if (msgId !== streamLastMsgId) {
+              if (onChunk && streamDelivered) onChunk("\n");
+              streamDelivered = "";
+              streamLastMsgId = msgId;
+            }
+            let full = "";
+            for (const block of msg.content) {
+              if (block.type === "text" && typeof block.text === "string") {
+                full += block.text;
+              } else if (block.type === "tool_use" && onToolEvent) {
+                streamPendingToolCalls.set(block.id, block.name);
+                onToolEvent(`● ${formatToolCallSummary(block.name, block.input ?? {})}`);
+              }
+            }
+            if (onChunk && full.length > streamDelivered.length) {
+              onChunk(full.slice(streamDelivered.length));
+              streamDelivered = full;
+            }
+          }
+          if (onToolEvent && event.type === "user") {
+            for (const block of (event.message as any)?.content ?? []) {
+              if (block.type === "tool_result") {
+                const toolName = streamPendingToolCalls.get(block.tool_use_id) ?? "?";
+                streamPendingToolCalls.delete(block.tool_use_id);
+                const text = extractToolResultText(block.content);
+                const firstLine = text.split("\n")[0].slice(0, 80);
+                const summary = block.is_error ? `Error: ${firstLine}` : (firstLine || "done");
+                onToolEvent(`  ⎿  [${toolName}] ${summary}`);
+              }
+            }
+          }
         } catch {}
       }
     }
@@ -496,15 +561,152 @@ async function runClaudeStream(
     ]);
     if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
     await proc.exited;
+    if (activeProc === proc) activeProc = null;
     return { rawStdout: resultText, stderr: stderr.trim(), exitCode: proc.exitCode ?? 1, sessionId };
   } catch (err) {
     if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
+    if (activeProc === proc) activeProc = null;
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[${new Date().toLocaleTimeString()}] ${message}`);
     return { rawStdout: "", stderr: message, exitCode: 124, sessionId };
   }
+}
+
+function formatToolCallSummary(name: string, input: Record<string, unknown>): string {
+  const s = (v: unknown, max = 50) => String(v ?? "").slice(0, max);
+  switch (name) {
+    case "Write":
+    case "Edit":
+    case "Read":    return `${name}(${s(input.file_path)})`;
+    case "Bash":    return `Bash(${s(input.command, 60)})`;
+    case "Grep":    return `Grep(${s(input.pattern)} in ${s(input.path ?? ".")})`;
+    case "Glob":    return `Glob(${s(input.pattern)})`;
+    case "WebSearch": return `WebSearch(${s(input.query)})`;
+    case "WebFetch":  return `WebFetch(${s(input.url, 60)})`;
+    default:        return `${name}(...)`;
+  }
+}
+
+function extractToolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return (content as Array<{ type?: string; text?: string }>)
+      .filter(b => b.type === "text")
+      .map(b => b.text ?? "")
+      .join("");
+  }
+  return String(content ?? "");
+}
+
+/**
+ * Run claude with --output-format stream-json, emitting text chunks via onChunk
+ * and tool call/result lines via onToolEvent as they arrive.
+ * Session ID and final result come from the result event.
+ * Unlike runClaudeStream, this function is for real-time delivery to external surfaces
+ * (e.g. Telegram streaming) and does NOT use a timeout — callers must handle that.
+ */
+async function runClaudeStreaming(
+  baseArgs: string[],
+  model: string,
+  api: string,
+  baseEnv: Record<string, string>,
+  onChunk?: (text: string) => void,
+  onToolEvent?: (line: string) => void
+): Promise<{ result: string; stderr: string; exitCode: number; sessionId?: string; isRateLimit: boolean }> {
+  const args = [...baseArgs];
+  const normalizedModel = model.trim().toLowerCase();
+  if (model.trim() && normalizedModel !== "glm") args.push("--model", model.trim());
+
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: buildChildEnv(baseEnv, model, api),
+  });
+
+  activeProc = proc;
+  const stderrPromise = new Response(proc.stderr).text();
+
+  let finalResult = "";
+  let sessionId: string | undefined;
+  let isRateLimit = false;
+  let delivered = ""; // text already sent to onChunk for the current message
+  let lastMsgId = ""; // reset delivered tracking when a new assistant message starts
+  const pendingToolCalls = new Map<string, string>(); // tool_use_id → tool name
+
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+
+    let nl: number;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+
+      try {
+        const event = JSON.parse(line);
+
+        if (event.type === "assistant" && event.message?.content) {
+          const msgId: string = event.message.id ?? "";
+          if (msgId !== lastMsgId) {
+            // Insert newline separator between assistant messages so text
+            // from successive turns doesn't merge onto one line.
+            if (onChunk && delivered) onChunk("\n");
+            delivered = "";
+            lastMsgId = msgId;
+          }
+          let full = "";
+          for (const block of event.message.content) {
+            if (block.type === "text" && typeof block.text === "string") {
+              full += block.text;
+            } else if (block.type === "tool_use" && onToolEvent) {
+              pendingToolCalls.set(block.id, block.name);
+              onToolEvent(`● ${formatToolCallSummary(block.name, block.input ?? {})}`);
+            }
+          }
+          if (onChunk && full.length > delivered.length) {
+            onChunk(full.slice(delivered.length));
+            delivered = full;
+          }
+        }
+
+        if (event.type === "user" && onToolEvent) {
+          for (const block of event.message?.content ?? []) {
+            if (block.type === "tool_result") {
+              const name = pendingToolCalls.get(block.tool_use_id) ?? "?";
+              pendingToolCalls.delete(block.tool_use_id);
+              const text = extractToolResultText(block.content);
+              const firstLine = text.split("\n")[0].slice(0, 80);
+              const summary = block.is_error ? `Error: ${firstLine}` : (firstLine || "done");
+              onToolEvent(`  ⎿  [${name}] ${summary}`);
+            }
+          }
+        }
+
+        if (event.type === "result") {
+          sessionId = event.session_id;
+          finalResult = typeof event.result === "string" ? event.result : finalResult;
+          isRateLimit = RATE_LIMIT_PATTERN.test(finalResult);
+        }
+      } catch {}
+    }
+  }
+
+  await proc.exited;
+  if (activeProc === proc) activeProc = null;
+
+  const stderr = await stderrPromise;
+  // Also check stderr for rate limit signals
+  if (!isRateLimit) isRateLimit = RATE_LIMIT_PATTERN.test(stderr);
+
+  return { result: finalResult, stderr, exitCode: proc.exitCode ?? 1, sessionId, isRateLimit };
 }
 
 const PROJECT_DIR = process.cwd();
@@ -776,8 +978,12 @@ async function execClaude(
   modelOverride?: string,
   timeoutMsOverride?: number,
   agentName?: string,
-  timeoutCategory?: string
+  timeoutCategory?: string,
+  onChunk?: (text: string) => void,
+  onToolEvent?: (line: string) => void
 ): Promise<RunResult> {
+  mainRunning = true;
+  try {
   await mkdir(LOGS_DIR, { recursive: true });
 
   // Rotate the global session if thresholds are exceeded (thread/agent sessions are not rotated).
@@ -883,7 +1089,7 @@ async function execClaude(
   const baseEnv = cleanSpawnEnv();
   const spawnCwd = agentName ? await ensureAgentDir(agentName) : undefined;
 
-  let exec = await runClaudeStream(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs, spawnCwd);
+  let exec = await runClaudeStream(args, primaryConfig.model, primaryConfig.api, baseEnv, timeoutMs, spawnCwd, onChunk, onToolEvent);
   const primaryRateLimit = extractRateLimitMessage(exec.rawStdout, exec.stderr);
   let usedFallback = false;
 
@@ -1166,6 +1372,9 @@ async function execClaude(
   }
 
   return result;
+  } finally {
+    mainRunning = false;
+  }
 }
 
 export async function run(
@@ -1175,9 +1384,11 @@ export async function run(
   modelOverride?: string,
   timeoutMs?: number,
   agentName?: string,
-  timeoutCategory?: string
+  timeoutCategory?: string,
+  onChunk?: (text: string) => void,
+  onToolEvent?: (line: string) => void
 ): Promise<RunResult> {
-  return enqueue(() => execClaude(name, prompt, threadId, modelOverride, timeoutMs, agentName, timeoutCategory), threadId);
+  return enqueue(() => execClaude(name, prompt, threadId, modelOverride, timeoutMs, agentName, timeoutCategory, onChunk, onToolEvent), threadId);
 }
 
 async function streamClaude(
@@ -1402,8 +1613,77 @@ function prefixUserMessageWithClock(prompt: string): string {
   }
 }
 
-export async function runUserMessage(name: string, prompt: string, threadId?: string, agentName?: string): Promise<RunResult> {
-  return run(name, prefixUserMessageWithClock(prompt), threadId, undefined, undefined, agentName);
+export async function runUserMessage(
+  name: string,
+  prompt: string,
+  threadId?: string,
+  agentName?: string,
+  onChunk?: (text: string) => void,
+  onToolEvent?: (line: string) => void
+): Promise<RunResult> {
+  return run(name, prefixUserMessageWithClock(prompt), threadId, undefined, undefined, agentName, undefined, onChunk, onToolEvent);
+}
+
+// Path where Claude Code stores session JSONL transcripts for this project
+const CLAUDE_SESSIONS_DIR = join(
+  process.env.HOME ?? "/root",
+  ".claude",
+  "projects",
+  PROJECT_DIR.replace(/\//g, "-")
+);
+
+const FORK_SYSTEM_PROMPT = [
+  "You are a FORK AGENT — a fast, lightweight watcher running in parallel with the main agent.",
+  "",
+  "SPEED IS YOUR PRIORITY. Be brief. Answer in 1-3 sentences. No preamble, no padding.",
+  "Do NOT over-analyze. Do NOT think through edge cases. Just answer and stop.",
+  "",
+  "Your job: answer quick questions and peek at the main agent's progress via its session transcript.",
+  "",
+  "DENY immediately (one sentence explanation) any request that would take more than ~30 seconds:",
+  "• Compiling / building anything (kernels, projects, binaries)",
+  "• Downloads or network fetches",
+  "• Fuzzing, long analysis, heavy computations",
+  "• Anything that would block you and prevent monitoring/killing the main agent",
+  "",
+  "ALLOW:",
+  "• Reading files (especially JSONL transcripts to report main agent progress)",
+  "• Short factual answers",
+  "• Reporting on what the main agent is currently doing",
+  "",
+  `Main session info lives at: /project/.claude/claudeclaw/session.json`,
+  `Session JSONL transcripts dir: ${CLAUDE_SESSIONS_DIR}`,
+  "To peek at main agent progress: read session.json for the session ID, then read the .jsonl file in the transcripts dir.",
+  "Each JSONL line is a turn. The last few lines show what the main agent is currently doing.",
+].join("\n");
+
+const FORK_MODEL = "claude-haiku-4-5-20251001";
+
+/** Run a fork agent — parallel, does NOT touch the main serial queue or main session. */
+export async function runFork(prompt: string): Promise<RunResult> {
+  const { api } = getSettings();
+
+  const args = [
+    CLAUDE_EXECUTABLE, "-p", prompt,
+    "--output-format", "json",
+    "--dangerously-skip-permissions",
+    "--model", FORK_MODEL,
+    "--append-system-prompt", FORK_SYSTEM_PROMPT,
+  ];
+
+  const baseEnv = cleanSpawnEnv();
+
+  const exec = await runClaudeOnce(args, FORK_MODEL, api, baseEnv);
+
+  let stdout = exec.rawStdout;
+  if (exec.exitCode === 0) {
+    try {
+      const json = JSON.parse(exec.rawStdout);
+      stdout = json.result ?? exec.rawStdout;
+    } catch {}
+  }
+
+  return { stdout, stderr: exec.stderr, exitCode: exec.exitCode };
 }
 
 /**

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -260,23 +260,29 @@ function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
   return task;
 }
 
-// Active process tracking — allows kill from outside
-let activeProc: ReturnType<typeof Bun.spawn> | null = null;
+// Track active main-queue subprocesses so /kill targets them exclusively.
+// Using a Set because per-thread queues run in parallel — multiple main
+// runs can be in-flight at the same time. Fork procs are excluded: they run
+// outside the main queue and must not be killed by /kill.
+const mainActiveProcs = new Set<ReturnType<typeof Bun.spawn>>();
 
-/** Kill the currently running claude subprocess. Returns true if something was killed. */
+/** Kill all running main-queue claude subprocesses. Returns true if anything was killed. */
 export function killActive(): boolean {
-  if (!activeProc) return false;
-  try { activeProc.kill(); } catch {}
-  activeProc = null;
+  if (mainActiveProcs.size === 0) return false;
+  for (const proc of mainActiveProcs) {
+    try { proc.kill(); } catch {}
+  }
+  mainActiveProcs.clear();
   return true;
 }
 
-// Tracks whether the main serial queue is currently executing
-let mainRunning = false;
+// Counter rather than boolean: per-thread queues run in parallel so
+// multiple main runs can be in-flight simultaneously.
+let mainRunCount = 0;
 
-/** True while the main agent is processing a task (excludes fork). */
+/** True while any main-queue agent is processing a task (excludes fork). */
 export function isMainBusy(): boolean {
-  return mainRunning;
+  return mainRunCount > 0;
 }
 
 function extractRateLimitMessage(stdout: string, stderr: string): string | null {
@@ -405,7 +411,7 @@ async function runClaudeOnce(
     ...(cwd ? { cwd } : {}),
   });
 
-  activeProc = proc;
+  mainActiveProcs.add(proc);
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => reject(new Error(`Claude session timed out after ${timeoutMs / 1000}s`)), timeoutMs);
@@ -422,7 +428,7 @@ async function runClaudeOnce(
 
     if (timeoutId) clearTimeout(timeoutId);
     await proc.exited;
-    if (activeProc === proc) activeProc = null;
+    mainActiveProcs.delete(proc);
 
     return {
       rawStdout,
@@ -431,7 +437,7 @@ async function runClaudeOnce(
     };
   } catch (err) {
     if (timeoutId) clearTimeout(timeoutId);
-    if (activeProc === proc) activeProc = null;
+    mainActiveProcs.delete(proc);
     // Kill the hung process
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
@@ -474,7 +480,7 @@ async function runClaudeStream(
     ...(cwd ? { cwd } : {}),
   });
 
-  activeProc = proc;
+  mainActiveProcs.add(proc);
   let sessionId: string | undefined;
   let resultText = "";
   let stderr = "";
@@ -561,11 +567,11 @@ async function runClaudeStream(
     ]);
     if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
     await proc.exited;
-    if (activeProc === proc) activeProc = null;
+    mainActiveProcs.delete(proc);
     return { rawStdout: resultText, stderr: stderr.trim(), exitCode: proc.exitCode ?? 1, sessionId };
   } catch (err) {
     if (streamJsonTimeoutId) clearTimeout(streamJsonTimeoutId);
-    if (activeProc === proc) activeProc = null;
+    mainActiveProcs.delete(proc);
     try { proc.kill("SIGTERM"); } catch {}
     setTimeout(() => { try { proc.kill("SIGKILL"); } catch {} }, 5000);
     const message = err instanceof Error ? err.message : String(err);
@@ -625,7 +631,7 @@ async function runClaudeStreaming(
     env: buildChildEnv(baseEnv, model, api),
   });
 
-  activeProc = proc;
+  mainActiveProcs.add(proc);
   const stderrPromise = new Response(proc.stderr).text();
 
   let finalResult = "";
@@ -700,7 +706,7 @@ async function runClaudeStreaming(
   }
 
   await proc.exited;
-  if (activeProc === proc) activeProc = null;
+  mainActiveProcs.delete(proc);
 
   const stderr = await stderrPromise;
   // Also check stderr for rate limit signals
@@ -982,7 +988,7 @@ async function execClaude(
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void
 ): Promise<RunResult> {
-  mainRunning = true;
+  mainRunCount++;
   try {
   await mkdir(LOGS_DIR, { recursive: true });
 
@@ -1373,7 +1379,7 @@ async function execClaude(
 
   return result;
   } finally {
-    mainRunning = false;
+    mainRunCount--;
   }
 }
 
@@ -1659,9 +1665,15 @@ const FORK_SYSTEM_PROMPT = [
 
 const FORK_MODEL = "claude-haiku-4-5-20251001";
 
-/** Run a fork agent — parallel, does NOT touch the main serial queue or main session. */
+/**
+ * Run a fork agent — parallel, outside the main serial queue, no main session.
+ *
+ * Spawns directly rather than through runClaudeOnce so the fork proc is never
+ * added to mainActiveProcs — /kill must only target main-queue runs, not forks.
+ */
 export async function runFork(prompt: string): Promise<RunResult> {
   const { api } = getSettings();
+  const baseEnv = cleanSpawnEnv();
 
   const args = [
     CLAUDE_EXECUTABLE, "-p", prompt,
@@ -1671,19 +1683,27 @@ export async function runFork(prompt: string): Promise<RunResult> {
     "--append-system-prompt", FORK_SYSTEM_PROMPT,
   ];
 
-  const baseEnv = cleanSpawnEnv();
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: buildChildEnv(baseEnv, FORK_MODEL, api),
+  });
 
-  const exec = await runClaudeOnce(args, FORK_MODEL, api, baseEnv);
+  const [rawStdout, rawStderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
 
-  let stdout = exec.rawStdout;
-  if (exec.exitCode === 0) {
+  let stdout = rawStdout;
+  if ((proc.exitCode ?? 1) === 0) {
     try {
-      const json = JSON.parse(exec.rawStdout);
-      stdout = json.result ?? exec.rawStdout;
+      const json = JSON.parse(rawStdout);
+      stdout = json.result ?? rawStdout;
     } catch {}
   }
 
-  return { stdout, stderr: exec.stderr, exitCode: exec.exitCode };
+  return { stdout, stderr: rawStderr, exitCode: proc.exitCode ?? 1 };
 }
 
 /**


### PR DESCRIPTION
Bulk cherry-pick of three contributor PRs. Each commit preserves the original author's identity.

## Included PRs

**#173 — telegram: per-topic session isolation** (author: @ybuzko)
- Adds `dmIsolation` config flag to route DMs to their own session
- Per-topic `threadId` keying so group threads maintain separate Claude contexts
- Commits: `62e5d31`, `61243c3`

**#183 — feat(discord): include reply and forwarded message context in prompt** (author: @BCDel89)
- Enriches Discord prompts with the content of replied-to and forwarded messages
- Commit: `a3cf80b`

**#184 — feat(telegram): live streaming, /verbose, /fork, /kill** (author: @TerrysPOV)
- Streams Claude output token-by-token via `editMessageText`
- `/verbose` toggle to show/hide tool use events
- `/fork` spawns a parallel Haiku sub-agent for quick side tasks
- `/kill` terminates the active process
- Commits: `1b3cbe7`, `d3e2625`, `f1261c8`

## Conflict resolution

PRs #173 and #184 both modify `telegram.ts`. The per-topic `sessionKey` from #173 was wired into #184's streaming `runUserMessage` call so both features coexist:
```ts
result = await runUserMessage("telegram", prefixedPrompt, sessionKey, undefined, stream.onChunk, stream.onToolEvent);
```

## Attribution

Original PRs are being closed and authors credited here. Thanks to @ybuzko, @BCDel89, and all who reviewed #184 for iterating to this state.

## Validation

- `bunx tsc --noEmit` — pass
- `bun test` — pass
- Manual: Telegram streaming, /fork, /kill, per-topic session isolation, Discord reply context