### PR TITLE
feat: proactive session resume after self-restart

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/RESTART_RESUME_SPEC.md
+++ b/RESTART_RESUME_SPEC.md
@@ -13,7 +13,7 @@ This kills the systemd service — which is the process running the CC session t
 - The Bash tool receives exit code 144 (process killed mid-execution)
 - The CC session is terminated before it can send a reply
 - The agent cannot confirm success to the user
-- If the session had a pending Discord/Slack/Telegram reply queued, it is lost
+- If the session had a pending Discord/Telegram reply queued, it is lost
 - If the session is resumed later (e.g. user sends another message), CC resumes the old context and may re-run the restart command, causing a second unnecessary restart
 
 This is a fundamental gap: agents that manage their own lifecycle have no clean way to restart and report back.
@@ -52,7 +52,7 @@ ClaudeClaw provides a file-based mechanism for agents to schedule a **session co
 
 2. Agent fires the detached restart and ends the session cleanly.
 
-3. On the next startup, after the transport gateway reports ready (Discord READY event, Slack `hello` + `auth.test`, Telegram polling start), ClaudeClaw atomically renames the file (preventing double-fire on crash) and calls `runUserMessage` with the stored session key and wake-up prompt.
+3. On the next startup, after the transport gateway reports ready (Discord READY event, Telegram polling start), ClaudeClaw reads the file to check the transport, then atomically renames it (preventing double-fire on crash) and calls `runUserMessage` with the stored session key and wake-up prompt.
 
 4. The resumed Claude session runs as a normal turn — it has all its original context, can run tools, read logs, check process state — and its output is delivered to the stored channel and thread.
 
@@ -60,9 +60,9 @@ ClaudeClaw provides a file-based mechanism for agents to schedule a **session co
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `transport` | `"discord" \| "telegram" \| "slack"` | Which transport delivers the reply |
-| `channelId` | string | Discord channel snowflake, Telegram chat ID, or Slack channel ID |
-| `threadId` | string? | Discord thread ID or Slack `thread_ts` |
+| `transport` | `"discord" \| "telegram"` | Which transport delivers the reply |
+| `channelId` | string | Discord channel snowflake or Telegram chat ID |
+| `threadId` | string? | Discord thread ID |
 | `sessionKey` | string? | Key in `sessions.json` for the session to resume; omit to resume the global session |
 | `agentName` | string? | Agent working-directory name if the session is agent-scoped |
 | `wakeUpPrompt` | string | Injected as the next user turn; should describe the context and what to verify |
@@ -77,17 +77,13 @@ The hook fires once per process lifetime, immediately after the gateway reports 
 runPendingResume(token).catch(/* log */);
 ```
 
-**Slack** — in `startSlack`, after `auth.test` succeeds and before `connectSocket`:
-```typescript
-runPendingResumeSlack().catch(/* log */);
-```
-
 **Telegram** — in `startPolling`, before the poll loop starts:
 ```typescript
-await runPendingResumeTelegram();
+await runPendingResumeTelegram().catch(/* log */);
 ```
+The resume is wrapped so that a failure does not prevent polling from starting.
 
-The file is renamed atomically before parsing. If the wake-up throws, the file is already gone, so a subsequent crash-restart does not re-fire (prefer a lost message over a duplicate restart confirmation).
+The file is parsed first to check the transport, then renamed atomically before executing the wake-up. If the wake-up throws, the file is already gone, so a subsequent crash-restart does not re-fire (prefer a lost message over a duplicate restart confirmation).
 
 A module-level `consumed` guard in `pending-resume.ts` ensures the file is only loaded once even if multiple transports are initialised in the same process.
 
@@ -157,7 +153,7 @@ The file is written on a best-effort basis (`active-runs` is absent during the f
 ## Scope
 
 - ClaudeClaw only (not CC core)
-- Works for Discord, Telegram, and Slack transports
+- Works for Discord and Telegram transports (Slack support is out of scope for this PR)
 - No change to CC session format or JSONL
 - No new permissions required beyond what the agent already has
 

--- a/RESTART_RESUME_SPEC.md
+++ b/RESTART_RESUME_SPEC.md
@@ -1,0 +1,168 @@
+# Spec: Restart-and-Resume
+
+## Problem
+
+When a ClaudeClaw agent needs to restart its own host process (e.g. to pick up a new config, apply a service file change, or deploy updated code), it issues a command like:
+
+```bash
+sudo systemctl restart my-service
+```
+
+This kills the systemd service — which is the process running the CC session that issued the command. The result:
+
+- The Bash tool receives exit code 144 (process killed mid-execution)
+- The CC session is terminated before it can send a reply
+- The agent cannot confirm success to the user
+- If the session had a pending Discord/Slack/Telegram reply queued, it is lost
+- If the session is resumed later (e.g. user sends another message), CC resumes the old context and may re-run the restart command, causing a second unnecessary restart
+
+This is a fundamental gap: agents that manage their own lifecycle have no clean way to restart and report back.
+
+## Current workaround
+
+Agents can fire a detached restart:
+
+```bash
+nohup bash -c 'sleep 2 && sudo systemctl restart my-service' &
+```
+
+This lets the session exit cleanly before the kill arrives. But the agent still cannot send a post-restart confirmation — the session is gone and there is no mechanism for the new instance to know what to report.
+
+A static message queue could patch over this, but it has a fundamental flaw: any message written *before* the restart was composed before the restart happened. It cannot check whether the service came up cleanly, whether the config was applied correctly, or whether any side effects succeeded. A pre-written "restarted successfully" that fires unconditionally is worse than no message: it lies when things go wrong.
+
+## Proposed Solution: Pending Session Resume
+
+ClaudeClaw provides a file-based mechanism for agents to schedule a **session continuation** after the next startup. Rather than queuing a static reply, the agent schedules itself to be woken up with a prompt, and the resumed Claude session runs normally — with full tool access, original context, and the ability to observe post-restart state before composing a reply.
+
+### Flow
+
+1. Before triggering the restart, the agent writes `pending-resume.json` to a well-known location:
+
+```json
+// .claude/claudeclaw/pending-resume.json
+{
+  "transport": "discord",
+  "channelId": "1234567890",
+  "threadId": "9876543210",
+  "sessionKey": "1234567890",
+  "wakeUpPrompt": "The service was just restarted. Verify it came up cleanly (check systemctl status, recent logs), then report back to the user on the outcome.",
+  "expires": 1746100000000
+}
+```
+
+2. Agent fires the detached restart and ends the session cleanly.
+
+3. On the next startup, after the transport gateway reports ready (Discord READY event, Slack `hello` + `auth.test`, Telegram polling start), ClaudeClaw atomically renames the file (preventing double-fire on crash) and calls `runUserMessage` with the stored session key and wake-up prompt.
+
+4. The resumed Claude session runs as a normal turn — it has all its original context, can run tools, read logs, check process state — and its output is delivered to the stored channel and thread.
+
+### File schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transport` | `"discord" \| "telegram" \| "slack"` | Which transport delivers the reply |
+| `channelId` | string | Discord channel snowflake, Telegram chat ID, or Slack channel ID |
+| `threadId` | string? | Discord thread ID or Slack `thread_ts` |
+| `sessionKey` | string? | Key in `sessions.json` for the session to resume; omit to resume the global session |
+| `agentName` | string? | Agent working-directory name if the session is agent-scoped |
+| `wakeUpPrompt` | string | Injected as the next user turn; should describe the context and what to verify |
+| `expires` | number? | Unix milliseconds; files past this timestamp are silently discarded |
+
+### Startup hook location
+
+The hook fires once per process lifetime, immediately after the gateway reports ready — before any incoming user messages are processed:
+
+**Discord** — in the `READY` case of the gateway message handler:
+```typescript
+runPendingResume(token).catch(/* log */);
+```
+
+**Slack** — in `startSlack`, after `auth.test` succeeds and before `connectSocket`:
+```typescript
+runPendingResumeSlack().catch(/* log */);
+```
+
+**Telegram** — in `startPolling`, before the poll loop starts:
+```typescript
+await runPendingResumeTelegram();
+```
+
+The file is renamed atomically before parsing. If the wake-up throws, the file is already gone, so a subsequent crash-restart does not re-fire (prefer a lost message over a duplicate restart confirmation).
+
+A module-level `consumed` guard in `pending-resume.ts` ensures the file is only loaded once even if multiple transports are initialised in the same process.
+
+### Implementation
+
+- **`src/pending-resume.ts`** — defines `PendingResume` interface and `loadPendingResume()` function
+- **`src/commands/discord.ts`** — calls `runPendingResume()` in READY handler
+- **`src/commands/telegram.ts`** — calls `runPendingResumeTelegram()` in `startPolling`
+
+## Why session continuation, not a static message queue
+
+The critical distinction: the agent isn't pre-writing a reply, it's pre-scheduling a **verification step**.
+
+A static queue requires the agent to write the confirmation before the restart — at a point when it cannot know whether the restart will succeed. The resumed Claude session, by contrast, runs after the restart, in the new process, and can:
+
+- Check `systemctl status`
+- Read recent logs
+- Verify config was applied
+- Run any other diagnostic tool
+
+The confirmation the user sees is composed after the restart, by a Claude instance that can actually observe the post-restart state. A static "restarted successfully" that fires unconditionally is worse than no message: it misinforms when things go wrong.
+
+ClaudeClaw already has all the session resume infrastructure needed for this (the `--resume` flag, `sessions.json`, `sessionManager`). The only gap was a startup hook that fires proactively, without waiting for the next user message. This patch fills that gap.
+
+## Wait-for-idle before restart
+
+If other sessions are running concurrently (e.g. a long-running thread task), an agent that restarts immediately will interrupt them mid-run.
+
+ClaudeClaw writes the current active session count to `.claude/claudeclaw/active-runs` (a plain integer file) whenever a session starts or finishes. Agents can read this to decide whether to wait before restarting.
+
+**Recommended pattern:**
+
+```bash
+# Count active sessions. My own session is included, so "idle" means count == 1.
+count=$(cat .claude/claudeclaw/active-runs 2>/dev/null || echo 1)
+if [ "$count" -gt 1 ]; then
+  # Post the waiting notification directly via the transport API — NOT as response text.
+  # The CC session ends with a restart, so anything in the response stream is lost.
+  # A direct API call goes out immediately, before the poll loop starts.
+  curl -s -X POST "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" \
+    -H "Authorization: Bot $DISCORD_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"content\": \"Waiting for $((count - 1)) other session(s) to finish before restarting...\"}"
+
+  while [ "$(cat .claude/claudeclaw/active-runs 2>/dev/null || echo 1)" -gt 1 ]; do
+    sleep 5
+  done
+fi
+
+# Write pending-resume.json, then trigger detached restart
+cat > .claude/claudeclaw/pending-resume.json <<'EOF'
+{ ... }
+EOF
+nohup bash -c 'sleep 2 && sudo systemctl restart my-service' &
+```
+
+**Why direct API call:** the "waiting" message must be sent via a Bash tool `curl` call (or equivalent), not as part of the agent's response text. ClaudeClaw only delivers the response to the user after the CC session completes — but this session ends with a restart, so buffered response text is lost. A direct API call goes out immediately and independently.
+
+**Force override:** if the user explicitly asks for an immediate restart regardless of active sessions, skip the wait loop entirely. Always tell the user which sessions will be interrupted before proceeding.
+
+The file is written synchronously on every session start/finish, so the value is always consistent with the in-memory counter.
+
+**Known limitation:** the check happens at LLM execution time, not message-receipt time. If a concurrent session starts and completes in under ~60 seconds (the typical CC startup + LLM first-response latency), it may finish before the agent reads the file. The wait-for-idle pattern is intended for long-running tasks (minutes), not quick ones.
+
+The file is written on a best-effort basis (`active-runs` is absent during the first session before any run completes). Treat a missing file as count = 0 (no active sessions other than your own).
+
+## Scope
+
+- ClaudeClaw only (not CC core)
+- Works for Discord, Telegram, and Slack transports
+- No change to CC session format or JSONL
+- No new permissions required beyond what the agent already has
+
+## Out of scope
+
+- Multi-message queues (single pending resume is sufficient)
+- Resuming a partially-completed tool sequence mid-execution
+- Cross-restart state serialisation beyond what the session already carries

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1178,10 +1178,10 @@ function sendResume(token: string): void {
 const FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 
 async function runPendingResume(token: string): Promise<void> {
-  const resume = await loadPendingResume();
-  if (!resume || resume.transport !== "discord") return;
+  const resume = await loadPendingResume("discord");
+  if (!resume) return;
   console.log(`[Discord] Running pending resume for channel ${resume.channelId}`);
-  const result = await runUserMessage("discord", resume.wakeUpPrompt, resume.sessionKey);
+  const result = await runUserMessage("discord", resume.wakeUpPrompt, resume.sessionKey, resume.agentName);
   if (result.exitCode !== 0) {
     console.error(`[Discord] Pending resume failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
     return;

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,5 +1,6 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { extractErrorDetail } from "../messaging";
+import { loadPendingResume } from "../pending-resume";
 import { getSettings, loadSettings, DEFAULT_IMAGE_OUTPUT_ROOT } from "../config";
 import { resetSession, resetFallbackSession, peekSession } from "../sessions";
 import { listThreadSessions, removeThreadSession, peekThreadSession } from "../sessionManager";
@@ -1176,6 +1177,23 @@ function sendResume(token: string): void {
 // Non-recoverable close codes that should not trigger reconnection
 const FATAL_CLOSE_CODES = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
 
+async function runPendingResume(token: string): Promise<void> {
+  const resume = await loadPendingResume();
+  if (!resume || resume.transport !== "discord") return;
+  console.log(`[Discord] Running pending resume for channel ${resume.channelId}`);
+  const result = await runUserMessage("discord", resume.wakeUpPrompt, resume.sessionKey);
+  if (result.exitCode !== 0) {
+    console.error(`[Discord] Pending resume failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
+    return;
+  }
+  const output = result.stdout?.trim();
+  if (output) {
+    // Discord threads are channels — post to thread ID when present, else channel
+    const targetChannel = resume.threadId ?? resume.channelId;
+    await sendMessage(token, targetChannel, output);
+  }
+}
+
 function handleDispatch(token: string, eventName: string, data: any): void {
   debugLog(`Dispatch: ${eventName}`);
 
@@ -1191,6 +1209,9 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       console.log(`[Discord] Ready as ${data.user.username} (${data.user.id})`);
       registerSlashCommands(token).catch((err) =>
         console.error(`[Discord] Failed to register slash commands: ${err}`),
+      );
+      runPendingResume(token).catch((err) =>
+        console.error(`[Discord] Pending resume failed: ${err instanceof Error ? err.message : err}`),
       );
       break;
 

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,5 +1,6 @@
 import { ensureProjectClaudeMd, run, runUserMessage, runFork, killActive, isMainBusy, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt } from "../runner";
 import { extractErrorDetail } from "../messaging";
+import { loadPendingResume } from "../pending-resume";
 import { getSettings, loadSettings } from "../config";
 import { transcribeAudioToText } from "../whisper";
 import { resetSession, resetFallbackSession, peekSession } from "../sessions";
@@ -1568,6 +1569,28 @@ export { sendMessage };
 process.on("SIGTERM", () => { running = false; });
 process.on("SIGINT", () => { running = false; });
 
+async function runPendingResumeTelegram(): Promise<void> {
+  const config = getSettings().telegram;
+  const resume = await loadPendingResume();
+  if (!resume || resume.transport !== "telegram") return;
+  const chatId = parseInt(resume.channelId, 10);
+  if (!Number.isFinite(chatId)) {
+    console.warn(`[Telegram] Pending resume: invalid chatId "${resume.channelId}"`);
+    return;
+  }
+  console.log(`[Telegram] Running pending resume for chat ${chatId}`);
+  const result = await runUserMessage("telegram", resume.wakeUpPrompt, resume.sessionKey);
+  if (result.exitCode !== 0) {
+    console.error(`[Telegram] Pending resume failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
+    return;
+  }
+  const output = result.stdout?.trim();
+  if (output) {
+    const threadId = resume.threadId ? parseInt(resume.threadId, 10) : undefined;
+    await sendMessage(config.token, chatId, output, Number.isFinite(threadId) ? threadId : undefined);
+  }
+}
+
 /** Start polling in-process (called by start.ts when token is configured) */
 export function startPolling(debug = false): void {
   if (isPolling) return;
@@ -1577,6 +1600,7 @@ export function startPolling(debug = false): void {
   const gen = ++pollingGeneration;
   (async () => {
     await ensureProjectClaudeMd();
+    await runPendingResumeTelegram();
     await poll(gen);
   })().catch((err) => {
     if (pollingGeneration === gen) {

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1600,7 +1600,9 @@ export function startPolling(debug = false): void {
   const gen = ++pollingGeneration;
   (async () => {
     await ensureProjectClaudeMd();
-    await runPendingResumeTelegram();
+    await runPendingResumeTelegram().catch((err) =>
+      console.error(`[Telegram] Pending resume failed: ${err instanceof Error ? err.message : err}`)
+    );
     await poll(gen);
   })().catch((err) => {
     if (pollingGeneration === gen) {

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1571,15 +1571,15 @@ process.on("SIGINT", () => { running = false; });
 
 async function runPendingResumeTelegram(): Promise<void> {
   const config = getSettings().telegram;
-  const resume = await loadPendingResume();
-  if (!resume || resume.transport !== "telegram") return;
+  const resume = await loadPendingResume("telegram");
+  if (!resume) return;
   const chatId = parseInt(resume.channelId, 10);
   if (!Number.isFinite(chatId)) {
     console.warn(`[Telegram] Pending resume: invalid chatId "${resume.channelId}"`);
     return;
   }
   console.log(`[Telegram] Running pending resume for chat ${chatId}`);
-  const result = await runUserMessage("telegram", resume.wakeUpPrompt, resume.sessionKey);
+  const result = await runUserMessage("telegram", resume.wakeUpPrompt, resume.sessionKey, resume.agentName);
   if (result.exitCode !== 0) {
     console.error(`[Telegram] Pending resume failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
     return;

--- a/src/pending-resume.ts
+++ b/src/pending-resume.ts
@@ -10,10 +10,10 @@ let consumed = false;
 
 export interface PendingResume {
   /** Which transport should deliver the wake-up reply. */
-  transport: "discord" | "telegram" | "slack";
-  /** Destination channel ID (Discord snowflake, Telegram chat ID as string, Slack channel ID). */
+  transport: "discord" | "telegram";
+  /** Destination channel ID (Discord snowflake, Telegram chat ID as string). */
   channelId: string;
-  /** Optional thread context — Discord thread ID or Slack thread_ts. */
+  /** Optional thread context — Discord thread ID. */
   threadId?: string;
   /**
    * sessions.json key for the session to resume (e.g. Discord channel/thread snowflake).
@@ -35,30 +35,36 @@ export interface PendingResume {
 }
 
 /**
- * Atomically consume pending-resume.json and return its contents, or null if absent/expired.
+ * Atomically consume pending-resume.json for the given transport and return its contents,
+ * or null if absent/expired/wrong-transport.
+ *
+ * The transport check happens before the file is renamed so that the wrong-transport caller
+ * does not silently destroy a file intended for a different transport handler.
  *
  * The file is renamed before the wake-up runs.  If the wake-up throws, the file is already
  * gone so a subsequent restart does not fire a second time (prefer lost message over duplicate).
  */
-export async function loadPendingResume(): Promise<PendingResume | null> {
+export async function loadPendingResume(expectedTransport: string): Promise<PendingResume | null> {
   if (consumed) return null;
-  consumed = true;
 
   if (!existsSync(PENDING_RESUME_PATH)) return null;
 
-  // Rename atomically before parsing — prevents double-fire even on crash
+  // Peek at the file to check transport before consuming it
+  let resume: PendingResume;
   try {
-    await rename(PENDING_RESUME_PATH, PENDING_RESUME_CONSUMED);
-  } catch {
+    resume = await Bun.file(PENDING_RESUME_PATH).json() as PendingResume;
+  } catch (err) {
+    console.warn(`[pending-resume] Parse failed: ${err instanceof Error ? err.message : err}`);
     return null;
   }
 
-  let resume: PendingResume;
+  if (resume.transport !== expectedTransport) return null;
+
+  // Transport matches — mark consumed and atomically rename before executing
+  consumed = true;
   try {
-    resume = await Bun.file(PENDING_RESUME_CONSUMED).json() as PendingResume;
-  } catch (err) {
-    console.warn(`[pending-resume] Parse failed: ${err instanceof Error ? err.message : err}`);
-    await unlink(PENDING_RESUME_CONSUMED).catch(() => {});
+    await rename(PENDING_RESUME_PATH, PENDING_RESUME_CONSUMED);
+  } catch {
     return null;
   }
 

--- a/src/pending-resume.ts
+++ b/src/pending-resume.ts
@@ -1,0 +1,78 @@
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { unlink, rename } from "node:fs/promises";
+
+const PENDING_RESUME_PATH = join(process.cwd(), ".claude", "claudeclaw", "pending-resume.json");
+// Consumed path: renamed before running so a crash mid-wake-up doesn't re-fire on next start
+const PENDING_RESUME_CONSUMED = PENDING_RESUME_PATH + ".consumed";
+
+let consumed = false;
+
+export interface PendingResume {
+  /** Which transport should deliver the wake-up reply. */
+  transport: "discord" | "telegram" | "slack";
+  /** Destination channel ID (Discord snowflake, Telegram chat ID as string, Slack channel ID). */
+  channelId: string;
+  /** Optional thread context — Discord thread ID or Slack thread_ts. */
+  threadId?: string;
+  /**
+   * sessions.json key for the session to resume (e.g. Discord channel/thread snowflake).
+   * Omit to resume the global session.
+   */
+  sessionKey?: string;
+  /** Agent working-directory name, if the session is agent-scoped. */
+  agentName?: string;
+  /**
+   * The prompt injected into the resumed session.  Should explain that a restart just occurred
+   * and instruct the agent to verify the outcome and reply to the user.
+   */
+  wakeUpPrompt: string;
+  /**
+   * Expiry as Unix milliseconds.  Files older than this are silently discarded to avoid
+   * stale confirmations firing hours later after an unexpected crash.
+   */
+  expires?: number;
+}
+
+/**
+ * Atomically consume pending-resume.json and return its contents, or null if absent/expired.
+ *
+ * The file is renamed before the wake-up runs.  If the wake-up throws, the file is already
+ * gone so a subsequent restart does not fire a second time (prefer lost message over duplicate).
+ */
+export async function loadPendingResume(): Promise<PendingResume | null> {
+  if (consumed) return null;
+  consumed = true;
+
+  if (!existsSync(PENDING_RESUME_PATH)) return null;
+
+  // Rename atomically before parsing — prevents double-fire even on crash
+  try {
+    await rename(PENDING_RESUME_PATH, PENDING_RESUME_CONSUMED);
+  } catch {
+    return null;
+  }
+
+  let resume: PendingResume;
+  try {
+    resume = await Bun.file(PENDING_RESUME_CONSUMED).json() as PendingResume;
+  } catch (err) {
+    console.warn(`[pending-resume] Parse failed: ${err instanceof Error ? err.message : err}`);
+    await unlink(PENDING_RESUME_CONSUMED).catch(() => {});
+    return null;
+  }
+
+  await unlink(PENDING_RESUME_CONSUMED).catch(() => {});
+
+  if (resume.expires && Date.now() > resume.expires) {
+    console.log("[pending-resume] Expired, discarding.");
+    return null;
+  }
+
+  if (!resume.wakeUpPrompt || !resume.transport || !resume.channelId) {
+    console.warn("[pending-resume] Missing required fields (transport, channelId, wakeUpPrompt), discarding.");
+    return null;
+  }
+
+  return resume;
+}


### PR DESCRIPTION
## Problem

Agents that manage their own lifecycle — applying config changes, deploying updated code, reloading service files — restart their host process with something like:

```bash
nohup bash -c 'sleep 2 && sudo systemctl restart my-service' &
```

The session exits cleanly, but there's no way for the new instance to know what to report back. The user gets silence, or at best a pre-written canned message that was composed *before* the restart and can't reflect what actually happened.

A static message queue patches over this, but has a fundamental flaw: "Restarted successfully" written before the restart fires unconditionally whether the restart succeeded or not — worse than no message when things go wrong.

## Solution

`pending-resume.json`: before triggering a restart, the agent writes a file containing a transport, channel ID, session key, and wake-up prompt. On the next startup, after the gateway reports ready, ClaudeClaw resumes the stored session and injects the wake-up prompt as the next user turn.

The resumed Claude session runs normally — full tool access, original context, ability to check `systemctl status`, read logs, verify config. Its output is delivered to the stored channel and thread.

The distinction matters: the agent isn't pre-writing a reply, it's pre-scheduling a **verification step**. The confirmation the user sees is composed after the restart, by a Claude instance that can actually observe the post-restart state.

ClaudeClaw already has all the session resume infrastructure needed (`--resume`, `sessions.json`, `sessionManager`). The only missing piece was a startup hook that fires proactively without waiting for the next user message.

## Usage

Write `.claude/claudeclaw/pending-resume.json` before triggering the restart:

```json
{
  "transport": "discord",
  "channelId": "1234567890",
  "sessionKey": "optional-thread-session-key",
  "wakeUpPrompt": "The service was just restarted. Check systemctl status and recent logs, then report back.",
  "expires": 1746100000000
}
```

The file is renamed atomically before parsing (prevents double-fire on crash). A module-level `consumed` guard ensures it fires at most once per process lifetime.

## Changes

- `src/pending-resume.ts` — new: `PendingResume` interface and `loadPendingResume()` (atomic rename, expiry check, field validation)
- `src/commands/discord.ts` — `runPendingResume()` called in `READY` handler
- `src/commands/telegram.ts` — `runPendingResumeTelegram()` called in `startPolling`
- `RESTART_RESUME_SPEC.md` — spec describing the design and rationale