### PR TITLE
feat: track concurrent session count in active-runs file

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile, realpath } from "fs/promises";
 import { join, dirname, resolve, sep } from "path";
 import { execSync } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, writeFileSync, mkdirSync } from "fs";
 import {
   getSession,
   createSession,
@@ -31,6 +31,7 @@ import { recordResult, abortReason, clearSession, startSession } from "./watchdo
 import { getPluginManager, type EventContext } from "./plugins";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
+const ACTIVE_RUNS_FILE = join(process.cwd(), ".claude/claudeclaw/active-runs");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
 const PROMPTS_DIR = join(import.meta.dir, "..", "prompts");
 const HEARTBEAT_PROMPT_FILE = join(PROMPTS_DIR, "heartbeat", "HEARTBEAT.md");
@@ -248,6 +249,18 @@ let globalQueue: Promise<unknown> = Promise.resolve();
 // Per-thread queues — each thread runs independently in parallel
 const threadQueues = new Map<string, Promise<unknown>>();
 
+// Counter of concurrently-running main-queue sessions (per-thread queues run in parallel)
+let mainRunCount = 0;
+
+/** Current number of concurrently-running main-queue sessions. */
+export function getMainRunCount(): number {
+  return mainRunCount;
+}
+
+function persistRunCount(): void {
+  try { writeFileSync(ACTIVE_RUNS_FILE, String(mainRunCount)); } catch {}
+}
+
 function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {
   if (threadId) {
     const current = threadQueues.get(threadId) ?? Promise.resolve();
@@ -275,10 +288,6 @@ export function killActive(): boolean {
   mainActiveProcs.clear();
   return true;
 }
-
-// Counter rather than boolean: per-thread queues run in parallel so
-// multiple main runs can be in-flight simultaneously.
-let mainRunCount = 0;
 
 /** True while any main-queue agent is processing a task (excludes fork). */
 export function isMainBusy(): boolean {
@@ -989,6 +998,7 @@ async function execClaude(
   onToolEvent?: (line: string) => void
 ): Promise<RunResult> {
   mainRunCount++;
+  persistRunCount();
   try {
   await mkdir(LOGS_DIR, { recursive: true });
 
@@ -1380,6 +1390,7 @@ async function execClaude(
   return result;
   } finally {
     mainRunCount--;
+    persistRunCount();
   }
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -258,7 +258,10 @@ export function getMainRunCount(): number {
 }
 
 function persistRunCount(): void {
-  try { writeFileSync(ACTIVE_RUNS_FILE, String(mainRunCount)); } catch {}
+  try {
+    mkdirSync(dirname(ACTIVE_RUNS_FILE), { recursive: true });
+    writeFileSync(ACTIVE_RUNS_FILE, String(mainRunCount));
+  } catch {}
 }
 
 function enqueue<T>(fn: () => Promise<T>, threadId?: string): Promise<T> {


### PR DESCRIPTION
## Problem

Agents restarting their own host process risk interrupting other concurrently-running sessions (e.g. a long task in a thread). There was no way for an agent to check whether other sessions were active before deciding to restart.

## Solution

Writes the number of currently-running main-queue sessions to `.claude/claudeclaw/active-runs` (a plain integer file) on every session start and finish, using `writeFileSync` so writes are synchronous and always reflect the true in-memory count.

Agents can read this file before triggering a restart:

```bash
count=$(cat .claude/claudeclaw/active-runs 2>/dev/null || echo 0)
if [ "$count" -gt 1 ]; then
  # Post waiting notification via direct API call (NOT response text —
  # the session ends with a restart so buffered output is lost)
  curl -s -X POST "https://discord.com/api/v10/channels/$CHANNEL_ID/messages" \
    -H "Authorization: Bot $DISCORD_TOKEN" \
    -H "Content-Type: application/json" \
    -d "{\"content\": \"Waiting for $((count - 1)) other session(s) to finish...\"}"

  while [ "$(cat .claude/claudeclaw/active-runs 2>/dev/null || echo 0)" -gt 1 ]; do
    sleep 5
  done
fi
```

**Known limitation:** the check happens at LLM execution time (~30–60s after message receipt). Sessions shorter than that window may finish before the agent reads the file. This approach is intended for long-running tasks (minutes), not quick ones.

## Changes

- `src/runner.ts` — `mainRunCount` counter, `persistRunCount()` (sync write), `getMainRunCount()` export; increment/decrement wraps `execClaude` in try/finally

## Notes

The waiting notification must be sent via a direct transport API call (Bash tool `curl`), not as response text. ClaudeClaw delivers the session response only after the session completes — but this session ends with a restart, so buffered text is lost. See `RESTART_RESUME_SPEC.md` (PR #191) for the full wait-for-idle pattern.