### PR TITLE
fix(discord): handle forwarded messages with empty content

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -624,7 +624,8 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   const hasVoice = voiceAttachments.length > 0;
   const hasText = textAttachments.length > 0;
 
-  if (!content.trim() && !hasImage && !hasVoice && !hasText) return;
+  const hasForwardedContent = !!message.message_snapshots?.[0]?.message?.content;
+  if (!content.trim() && !hasImage && !hasVoice && !hasText && !hasForwardedContent) return;
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;


### PR DESCRIPTION
## Summary

- Discord forwarded messages have an empty `content` field — the text is in `message_snapshots[0].message.content`
- The early-exit guard (`if (!content.trim() && !hasImage && !hasVoice && !hasText) return`) was silently dropping forwarded messages before the detection code ever ran
- Added `hasForwardedContent` check to the guard so forwarded messages pass through and get injected as `[Forwarded message from <author>]: <text>` context in the prompt

## Test plan

- [ ] Send a forwarded message to a channel the bot is listening on
- [ ] Verify the bot receives it and the forwarded content appears in the prompt as `[Forwarded message from <author>]: ...`
- [ ] Verify normal messages (text, images, voice) still work as expected
- [ ] Verify empty messages with no content/images/voice are still filtered out