### PR TITLE
feat(discord): forward message support with coalescing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.29",
+      "version": "1.0.33",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.32",
+      "version": "1.0.28",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.32",
+  "version": "1.0.28",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.29",
+  "version": "1.0.33",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -568,6 +568,10 @@ async function respondToInteraction(
 
 // --- Message handler ---
 
+// Pending forwards: when Discord delivers a forward with empty content, hold it briefly
+// so a follow-up text comment from the same user can absorb it as context.
+const pendingForwards = new Map<string, { snapshot: DiscordMessageSnapshot; timer: ReturnType<typeof setTimeout> }>();
+
 async function handleMessageCreate(token: string, message: DiscordMessage): Promise<void> {
   const config = getSettings().discord;
 
@@ -627,6 +631,33 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
 
   const hasForwardedContent = !!message.message_snapshots?.[0]?.message?.content;
   if (!content.trim() && !hasImage && !hasVoice && !hasText && !hasForwardedContent) return;
+
+  const forwardKey = `${channelId}:${userId}`;
+  const isForwardOnly = message.message_reference?.type === 1 && !content.trim() && !hasImage && !hasVoice && !hasText;
+
+  if (isForwardOnly && hasForwardedContent) {
+    // Pure forward with no accompanying text — hold it and wait for a follow-up comment
+    const existing = pendingForwards.get(forwardKey);
+    if (existing) clearTimeout(existing.timer);
+    const snapshot = message.message_snapshots![0].message;
+    const timer = setTimeout(() => {
+      pendingForwards.delete(forwardKey);
+      handleMessageCreate(token, message).catch((err) =>
+        console.error(`[Discord] Deferred forward error: ${err instanceof Error ? err.message : err}`)
+      );
+    }, 1500);
+    pendingForwards.set(forwardKey, { snapshot, timer });
+    return;
+  }
+
+  // If a pending forward exists for this user+channel, absorb it into this message as context
+  let coalescedSnapshot: DiscordMessageSnapshot | undefined;
+  const pending = pendingForwards.get(forwardKey);
+  if (pending && !isForwardOnly) {
+    clearTimeout(pending.timer);
+    pendingForwards.delete(forwardKey);
+    coalescedSnapshot = pending.snapshot;
+  }
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;
@@ -817,8 +848,8 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
 
     // Include context from replied-to or forwarded messages
     const isForward = message.message_reference?.type === 1;
-    const snapshot = message.message_snapshots?.[0]?.message;
-    if (isForward && snapshot) {
+    const snapshot = coalescedSnapshot ?? message.message_snapshots?.[0]?.message;
+    if ((isForward || coalescedSnapshot) && snapshot) {
       const fwdAuthor = snapshot.author ? snapshot.author.username : "unknown";
       const fwdAttachments = snapshot.attachments.length > 0
         ? ` [attachments: ${snapshot.attachments.map((a) => a.filename).join(", ")}]`

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -625,7 +625,8 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   const hasVoice = voiceAttachments.length > 0;
   const hasText = textAttachments.length > 0;
 
-  if (!content.trim() && !hasImage && !hasVoice && !hasText) return;
+  const hasForwardedContent = !!message.message_snapshots?.[0]?.message?.content;
+  if (!content.trim() && !hasImage && !hasVoice && !hasText && !hasForwardedContent) return;
 
   // Strip bot mention from content for cleaner prompt
   let cleanContent = content;

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -572,7 +572,7 @@ async function respondToInteraction(
 // so a follow-up text comment from the same user can absorb it as context.
 const pendingForwards = new Map<string, { snapshot: DiscordMessageSnapshot; timer: ReturnType<typeof setTimeout> }>();
 
-async function handleMessageCreate(token: string, message: DiscordMessage): Promise<void> {
+async function handleMessageCreate(token: string, message: DiscordMessage, skipCoalesce = false): Promise<void> {
   const config = getSettings().discord;
 
   // Ignore bot messages
@@ -635,14 +635,14 @@ async function handleMessageCreate(token: string, message: DiscordMessage): Prom
   const forwardKey = `${channelId}:${userId}`;
   const isForwardOnly = message.message_reference?.type === 1 && !content.trim() && !hasImage && !hasVoice && !hasText;
 
-  if (isForwardOnly && hasForwardedContent) {
+  if (!skipCoalesce && isForwardOnly && hasForwardedContent) {
     // Pure forward with no accompanying text — hold it and wait for a follow-up comment
     const existing = pendingForwards.get(forwardKey);
     if (existing) clearTimeout(existing.timer);
     const snapshot = message.message_snapshots![0].message;
     const timer = setTimeout(() => {
       pendingForwards.delete(forwardKey);
-      handleMessageCreate(token, message).catch((err) =>
+      handleMessageCreate(token, message, true).catch((err) =>
         console.error(`[Discord] Deferred forward error: ${err instanceof Error ? err.message : err}`)
       );
     }, 1500);


### PR DESCRIPTION
## Summary

- Discord forwarded messages arrive with an empty `content` field — the text lives in `message_snapshots[0].message.content`. The early-exit guard was silently dropping them before the detection code ran. Fixed by adding a `hasForwardedContent` check.
- Discord delivers a forward + accompanying text comment as two separate MESSAGE_CREATE events, causing the bot to respond twice. Fixed with a 1.5s coalescing window: a pure forward is held in memory; if a text message from the same user+channel arrives within the window, the forward snapshot is absorbed as context into that message and the two are processed as one prompt.

## Test plan

- [ ] Forward a message with a text comment — one response that includes the forwarded content
- [ ] Forward a message with no comment — responds after ~1.5s with the forwarded content
- [ ] Normal messages (text, images, voice) unaffected
- [ ] Empty messages with no content/attachments/forward still filtered out