### PR TITLE
feat(jobs): persist retry state (failCount, retryAt) in state.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -756,6 +756,9 @@ export async function start(args: string[] = []) {
           name: job.name,
           nextAt: nextCronMatch(job.schedule, now, currentSettings.timezoneOffsetMinutes).getTime(),
           ...(last ? { lastResult: last.result, lastRanAt: last.ranAt } : {}),
+          ...(jobRetryState.get(job.name)
+            ? { failCount: jobRetryState.get(job.name)!.failCount, retryAt: jobRetryState.get(job.name)!.retryAt }
+            : {}),
         };
       }),
       security: currentSettings.security.level,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -752,13 +752,12 @@ export async function start(args: string[] = []) {
         : undefined,
       jobs: currentJobs.map((job) => {
         const last = jobLastResult.get(job.name);
+        const retryState = jobRetryState.get(job.name);
         return {
           name: job.name,
           nextAt: nextCronMatch(job.schedule, now, currentSettings.timezoneOffsetMinutes).getTime(),
           ...(last ? { lastResult: last.result, lastRanAt: last.ranAt } : {}),
-          ...(jobRetryState.get(job.name)
-            ? { failCount: jobRetryState.get(job.name)!.failCount, retryAt: jobRetryState.get(job.name)!.retryAt }
-            : {}),
+          ...(retryState ? { failCount: retryState.failCount, retryAt: retryState.retryAt } : {}),
         };
       }),
       security: currentSettings.security.level,

--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -12,6 +12,10 @@ export interface StateData {
     lastResult?: "ok" | "error" | "skipped";
     /** Unix timestamp (ms) of the most recent completion. Absent until first run. */
     lastRanAt?: number;
+    /** Number of consecutive failures since last success. Present only while retrying. */
+    failCount?: number;
+    /** Unix timestamp (ms) when the next retry fires. Present only while retrying. */
+    retryAt?: number;
   }[];
   security: string;
   telegram: boolean;


### PR DESCRIPTION
Closes #174.

## What

The `retry` / `retry_delay` frontmatter fields and the in-memory retry scheduler (failCount accumulation, retryAt window, one-shot guard) were already wired in `src/commands/start.ts`. The only missing piece was surfacing that state through `state.json` so external tooling (statusline, web UI, dashboards) can observe a job's retry progress without reading daemon logs.

## Changes

**`src/statusline.ts`** — add two optional fields to `StateData.jobs`:
- `failCount?: number` — consecutive failures since last success; present only while a retry is pending
- `retryAt?: number` — Unix timestamp (ms) when the next retry fires; present only while a retry is pending

**`src/commands/start.ts`** — extend `updateState()` to spread these fields into each job's state entry using a local `retryState` variable (avoids triple `Map.get()` call). When no retry is pending the entry is unchanged (backward-compatible).

## Behaviour unchanged

- No `retry` frontmatter → no new fields in state, identical to before
- On success or retry exhaustion, `jobRetryState.delete()` is called → fields disappear from next state write
- `retryAt = MAX_SAFE_INTEGER` sentinel (set while a retry is in-flight) is preserved in state so observers can see the job is actively running

## Validation

- [x] Backward-compatible: jobs without retry config produce identical state.json entries
- [ ] `bunx tsc --noEmit` — not run locally (no Bun environment); please verify on your side