### PR TITLE
feat(telegram): configurable Whisper model via settings

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,10 @@ export interface TelegramConfig {
    * - "perUser": each DM user gets their own isolated session.
    */
   dmIsolation: "shared" | "perUser";
+  /** Local whisper.cpp model for voice transcription. Default: "base.en".
+   *  Supported values: tiny, base, small, medium, large-v3, large-v3-turbo (with or without .en suffix).
+   *  Ignored when stt.baseUrl is configured. */
+  whisperModel?: string;
 }
 
 export interface DiscordConfig {
@@ -334,6 +338,9 @@ function parseSettings(
       listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
       receiveEnabled: raw.telegram?.receiveEnabled !== false,
       dmIsolation: raw.telegram?.dmIsolation === "perUser" ? "perUser" : "shared",
+      ...(typeof raw.telegram?.whisperModel === "string" && raw.telegram.whisperModel.trim()
+        ? { whisperModel: raw.telegram.whisperModel.trim() }
+        : {}),
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -5,7 +5,7 @@ import { basename, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getSettings } from "./config";
 
-const WHISPER_MODEL = "base.en";
+const DEFAULT_WHISPER_MODEL = "base.en";
 const WHISPER_ROOT = join(process.cwd(), ".claude", "claudeclaw", "whisper");
 const BIN_DIR = join(WHISPER_ROOT, "bin");
 const LIB_DIR = join(WHISPER_ROOT, "lib");
@@ -14,7 +14,18 @@ const TMP_FOLDER = join(WHISPER_ROOT, "tmp");
 const OGG_MJS_CONVERTER = fileURLToPath(new URL("./ogg.mjs", import.meta.url));
 const PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
-const MODEL_URL = `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${WHISPER_MODEL}.bin`;
+function getWhisperModel(): string {
+  try {
+    const m = getSettings().telegram.whisperModel?.trim();
+    return m || DEFAULT_WHISPER_MODEL;
+  } catch {
+    return DEFAULT_WHISPER_MODEL;
+  }
+}
+
+function getModelUrl(model: string): string {
+  return `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${model}.bin`;
+}
 
 interface BinarySource {
   url: string;
@@ -60,7 +71,7 @@ function getWhisperBinaryPath(): string {
 }
 
 function getModelPath(): string {
-  return join(MODEL_FOLDER, `ggml-${WHISPER_MODEL}.bin`);
+  return join(MODEL_FOLDER, `ggml-${getWhisperModel()}.bin`);
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -221,18 +232,19 @@ async function downloadAndExtractBinary(): Promise<void> {
 }
 
 async function downloadModel(): Promise<void> {
+  const model = getWhisperModel();
   const modelPath = getModelPath();
   if (await fileExists(modelPath)) return;
 
   await mkdir(MODEL_FOLDER, { recursive: true });
-  console.log(`whisper: downloading model ${WHISPER_MODEL}...`);
-  await downloadFile(MODEL_URL, modelPath);
+  console.log(`whisper: downloading model ${model}...`);
+  await downloadFile(getModelUrl(model), modelPath);
   console.log("whisper: model ready");
 }
 
 async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
   const startedAt = Date.now();
-  console.log(`whisper warmup: start root=${WHISPER_ROOT} model=${WHISPER_MODEL}`);
+  console.log(`whisper warmup: start root=${WHISPER_ROOT} model=${getWhisperModel()}`);
   await mkdir(WHISPER_ROOT, { recursive: true });
   await mkdir(TMP_FOLDER, { recursive: true });
 


### PR DESCRIPTION
Closes #176

## What

Adds `telegram.whisperModel` to `settings.json`, letting users choose which local whisper.cpp model to use for voice transcription without manually swapping files.

```json
{
  "telegram": {
    "whisperModel": "large-v3"
  }
}
```

Supported values: `tiny`, `base`, `small`, `medium`, `large-v3`, `large-v3-turbo` (with or without `.en` suffix). Default: `"base.en"` (backwards-compatible, no behaviour change for existing users).

The setting is ignored when `stt.baseUrl` is configured (API mode takes precedence).

## Changes

**`src/config.ts`**
- Added `whisperModel?: string` to `TelegramConfig` interface with JSDoc
- Added `whisperModel` parsing in `parseSettings()` (strict type check + trim)

**`src/whisper.ts`**
- `WHISPER_MODEL` constant → `DEFAULT_WHISPER_MODEL` fallback
- New `getWhisperModel()` helper reads from `getSettings().telegram.whisperModel` with fallback to `"base.en"` (also catches the edge case where settings aren't loaded yet, e.g. in the standalone warmup script)
- New `getModelUrl(model)` function replaces the module-level `MODEL_URL` constant
- `getModelPath()`, `downloadModel()`, and `prepareWhisperAssets()` all use `getWhisperModel()` dynamically

## Behaviour

- No settings.json change required — existing installs keep `base.en` automatically
- Model is resolved at call time, so a daemon restart picks up any change
- The `warmupWhisperAssets()` singleton still works correctly (warms up whichever model is configured at startup)