### PR TITLE
feat(telegram): explicit model selection commands

### DIFF
--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -368,6 +368,12 @@ async function sendDocumentToChat(
 // Chat IDs with verbose tool display enabled
 const verboseChats = new Set<number>();
 
+// Model overrides per chat ID
+const chatModels = new Map<number, string>();
+const MODEL_HAIKU = "claude-haiku-4-5-20251001";
+const MODEL_SONNET = "claude-sonnet-4-6";
+const MODEL_OPUS = "claude-opus-4-7";
+
 /**
  * Build a streaming callback using editMessageText.
  * On first chunk: send a placeholder message to get message_id.
@@ -1027,6 +1033,45 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     return;
   }
 
+  if (command === "/model") {
+    const currentModel = chatModels.get(chatId);
+    const settings = getSettings();
+    const defaultModel = settings.model || "default";
+    if (!currentModel) {
+      await sendMessage(config.token, chatId, `📊 Current model: **${defaultModel}** (default)\n\nAvailable:\n• /modelhaiku - Fastest, least capable\n• /modelsonnet - Balanced (default)\n• /modelopus - Most capable, slower\n• /modeldefault - Use config default`, threadId);
+    } else {
+      const modelName = currentModel === MODEL_HAIKU ? "Haiku" : currentModel === MODEL_SONNET ? "Sonnet" : currentModel === MODEL_OPUS ? "Opus" : currentModel;
+      await sendMessage(config.token, chatId, `📊 Current model: **${modelName}**\n\nAvailable:\n• /modelhaiku - Fastest, least capable\n• /modelsonnet - Balanced\n• /modelopus - Most capable, slower\n• /modeldefault - Use config default (${defaultModel})`, threadId);
+    }
+    return;
+  }
+
+  if (command === "/modelhaiku") {
+    chatModels.set(chatId, MODEL_HAIKU);
+    await sendMessage(config.token, chatId, "⚡ Switched to Haiku - fastest responses, less capable.", threadId);
+    return;
+  }
+
+  if (command === "/modelsonnet") {
+    chatModels.set(chatId, MODEL_SONNET);
+    await sendMessage(config.token, chatId, "⚖️ Switched to Sonnet - balanced speed and capability.", threadId);
+    return;
+  }
+
+  if (command === "/modelopus") {
+    chatModels.set(chatId, MODEL_OPUS);
+    await sendMessage(config.token, chatId, "🧠 Switched to Opus - most capable, slower responses.", threadId);
+    return;
+  }
+
+  if (command === "/modeldefault") {
+    chatModels.delete(chatId);
+    const settings = getSettings();
+    const defaultModel = settings.model || "default";
+    await sendMessage(config.token, chatId, `🔄 Reset to default model: ${defaultModel}`, threadId);
+    return;
+  }
+
   if (command === "/fork") {
     const forkPrompt = text.replace(/^\/fork\s*/i, "").trim();
     if (!forkPrompt) {
@@ -1247,6 +1292,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     const prefixedPrompt = promptParts.join("\n");
     const busy = isMainBusy();
     const verbose = verboseChats.has(chatId);
+    const modelOverride = chatModels.get(chatId);
     let result;
     let streamMsgId: number | null = null;
     let hadToolLines = false;
@@ -1255,7 +1301,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       return;
     } else {
       const stream = makeStreamCallback(config.token, chatId, threadId, { verbose });
-      result = await runUserMessage("telegram", prefixedPrompt, sessionKey, undefined, stream.onChunk, stream.onToolEvent);
+      result = await runUserMessage("telegram", prefixedPrompt, sessionKey, undefined, stream.onChunk, stream.onToolEvent, modelOverride);
       const streamResult = await stream.waitForStreamMsg();
       streamMsgId = streamResult.msgId;
       hadToolLines = streamResult.hadToolLines;
@@ -1483,15 +1529,24 @@ async function registerBotCommands(token: string): Promise<void> {
   try {
     const skills = await listSkills();
     const commands = [
-      { command: "start", description: "Show welcome message" },
-      { command: "reset", description: "Reset session and start fresh" },
-      { command: "compact", description: "Compact session to reduce context size" },
-      { command: "status", description: "Show current session status" },
-      { command: "context", description: "Show context window usage" },
-      { command: "kill", description: "Kill the currently running agent" },
-      { command: "verbose", description: "Toggle tool call display in responses" },
-      { command: "fork", description: "Run a parallel lightweight agent without blocking" },
-      { command: "mode", description: "Get or set Claude permission mode" },
+      // Session management
+      { command: "start", description: "👋 Welcome message" },
+      { command: "status", description: "📊 Session info and stats" },
+      { command: "context", description: "📐 Context window usage" },
+      { command: "reset", description: "🔄 Start fresh session" },
+      { command: "compact", description: "🗜️ Reduce context size" },
+      // Model selection
+      { command: "model", description: "📊 Show current model and options" },
+      { command: "modelhaiku", description: "⚡ Switch to Haiku (fastest)" },
+      { command: "modelsonnet", description: "⚖️ Switch to Sonnet (balanced)" },
+      { command: "modelopus", description: "🧠 Switch to Opus (most capable)" },
+      { command: "modeldefault", description: "🔄 Reset to config default model" },
+      // Mode toggles
+      { command: "mode", description: "🔐 Get or set Claude permission mode" },
+      { command: "verbose", description: "🔧 Toggle tool call display" },
+      // Control
+      { command: "fork", description: "🍴 Run parallel task" },
+      { command: "kill", description: "⛔ Stop current agent" },
     ];
     for (const skill of skills) {
       // Telegram commands: 1-32 chars, lowercase a-z, 0-9, underscores only
@@ -1514,7 +1569,7 @@ async function registerBotCommands(token: string): Promise<void> {
     } catch (regErr) {
       // Skill-generated commands may violate Telegram constraints; retry with built-in commands only
       console.warn(`[Telegram] Full command registration failed, retrying with built-in commands only: ${regErr instanceof Error ? regErr.message : regErr}`);
-      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context", "kill", "verbose", "fork", "mode"].includes(c.command));
+      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context", "kill", "verbose", "fork", "mode", "model", "modelhaiku", "modelsonnet", "modelopus", "modeldefault"].includes(c.command));
       await callApi(token, "setMyCommands", { commands: builtinOnly });
       console.log(`  Commands registered (built-in only): ${builtinOnly.length}`);
     }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1669,9 +1669,10 @@ export async function runUserMessage(
   threadId?: string,
   agentName?: string,
   onChunk?: (text: string) => void,
-  onToolEvent?: (line: string) => void
+  onToolEvent?: (line: string) => void,
+  modelOverride?: string
 ): Promise<RunResult> {
-  return run(name, prefixUserMessageWithClock(prompt), threadId, undefined, undefined, agentName, undefined, onChunk, onToolEvent);
+  return run(name, prefixUserMessageWithClock(prompt), threadId, modelOverride, undefined, agentName, undefined, onChunk, onToolEvent);
 }
 
 // Path where Claude Code stores session JSONL transcripts for this project


### PR DESCRIPTION
## Summary

Replaces the `/fast` toggle with explicit per-chat model selection commands, giving users clear control over which Claude model handles their messages.

**New commands:**
- `/model` — Show current model and available options
- `/modelhaiku` — Switch to Haiku (fastest, least capable)
- `/modelsonnet` — Switch to Sonnet (balanced, default)
- `/modelopus` — Switch to Opus (most capable, slower)
- `/modeldefault` — Reset to the model configured in settings

**Implementation:**
- Tracks model overrides per chat ID using `Map<number, string>`
- Passes the override to `runUserMessage()` as a new optional `modelOverride` parameter (threads through to `run()`)
- Removes the old `/fast` toggle (replaced by `/modelhaiku` + `/modeldefault`)
- Reorganises the command menu with emoji prefixes and logical groupings (session management / model selection / mode toggles / control)

**Why this change?**
The `/fast` toggle was ambiguous — users couldn't tell whether fast mode was on or off, and it only offered two states (default vs Haiku). Explicit model commands make the current model visible and support all three Claude model tiers.

## Validation

- [x] I ran the relevant checks locally
- [x] I updated any docs or setup guidance affected by this change

## Plugin Versioning

Plugin version bumped (`.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`) as this change ships new Telegram commands under `src/`.