### PR TITLE
Bulk: cherry-pick job retry state, Whisper model config, and Telegram mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -756,6 +756,9 @@ export async function start(args: string[] = []) {
           name: job.name,
           nextAt: nextCronMatch(job.schedule, now, currentSettings.timezoneOffsetMinutes).getTime(),
           ...(last ? { lastResult: last.result, lastRanAt: last.ranAt } : {}),
+          ...(jobRetryState.get(job.name)
+            ? { failCount: jobRetryState.get(job.name)!.failCount, retryAt: jobRetryState.get(job.name)!.retryAt }
+            : {}),
         };
       }),
       security: currentSettings.security.level,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -752,13 +752,12 @@ export async function start(args: string[] = []) {
         : undefined,
       jobs: currentJobs.map((job) => {
         const last = jobLastResult.get(job.name);
+        const retryState = jobRetryState.get(job.name);
         return {
           name: job.name,
           nextAt: nextCronMatch(job.schedule, now, currentSettings.timezoneOffsetMinutes).getTime(),
           ...(last ? { lastResult: last.result, lastRanAt: last.ranAt } : {}),
-          ...(jobRetryState.get(job.name)
-            ? { failCount: jobRetryState.get(job.name)!.failCount, retryAt: jobRetryState.get(job.name)!.retryAt }
-            : {}),
+          ...(retryState ? { failCount: retryState.failCount, retryAt: retryState.retryAt } : {}),
         };
       }),
       security: currentSettings.security.level,

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, runFork, killActive, isMainBusy, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, runFork, killActive, isMainBusy, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt, getPermissionMode, setPermissionMode, type PermissionMode } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { loadPendingResume } from "../pending-resume";
 import { getSettings, loadSettings } from "../config";
@@ -1051,6 +1051,50 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     return;
   }
 
+  if (command === "/mode") {
+    const arg = text.trim().slice("/mode".length).trim().toLowerCase();
+    const modeMap: Record<string, PermissionMode> = {
+      plan: "plan",
+      edit: "acceptEdits",
+      unrestricted: "bypassPermissions",
+    };
+    const modeLabels: Record<PermissionMode, string> = {
+      plan: "plan",
+      acceptEdits: "edit",
+      bypassPermissions: "unrestricted",
+    };
+
+    if (!arg) {
+      const current = getPermissionMode();
+      await sendMessage(
+        config.token,
+        chatId,
+        [
+          `Current mode: **${modeLabels[current]}**`,
+          "",
+          "Available modes:",
+          "- /mode plan - read-only planning",
+          "- /mode edit - auto-accept file edits",
+          "- /mode unrestricted - full permissions, no prompts",
+        ].join("\n"),
+        threadId
+      );
+      return;
+    }
+
+    const mode = modeMap[arg];
+    if (!mode) {
+      const safeArg = arg.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      await sendMessage(config.token, chatId, `Unknown mode: \`${safeArg}\`\n\nValid modes: plan, edit, unrestricted`, threadId);
+      return;
+    }
+
+    setPermissionMode(mode);
+    console.log(`[Telegram] Permission mode changed to ${modeLabels[mode]} by user ${userId ?? "unknown"}`);
+    await sendMessage(config.token, chatId, `Mode set to **${modeLabels[mode]}**. Takes effect on the next message.`, threadId);
+    return;
+  }
+
   // Secretary: detect reply to a bot alert message → treat as custom reply
   const replyToMsgId = message.reply_to_message?.message_id;
   if (replyToMsgId && text && botId && message.reply_to_message?.from?.id === botId) {
@@ -1133,7 +1177,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
     // Skill routing: resolve slash commands to SKILL.md prompts
     let skillContext: string | null = null;
-    if (command && command !== "/start" && command !== "/reset" && command !== "/compact" && command !== "/status" && command !== "/context" && command !== "/kill" && command !== "/verbose" && command !== "/fork") {
+    if (command && command !== "/start" && command !== "/reset" && command !== "/compact" && command !== "/status" && command !== "/context" && command !== "/kill" && command !== "/verbose" && command !== "/fork" && command !== "/mode") {
       try {
         skillContext = await resolveSkillPrompt(command);
         if (skillContext) {
@@ -1447,6 +1491,7 @@ async function registerBotCommands(token: string): Promise<void> {
       { command: "kill", description: "Kill the currently running agent" },
       { command: "verbose", description: "Toggle tool call display in responses" },
       { command: "fork", description: "Run a parallel lightweight agent without blocking" },
+      { command: "mode", description: "Get or set Claude permission mode" },
     ];
     for (const skill of skills) {
       // Telegram commands: 1-32 chars, lowercase a-z, 0-9, underscores only
@@ -1469,7 +1514,7 @@ async function registerBotCommands(token: string): Promise<void> {
     } catch (regErr) {
       // Skill-generated commands may violate Telegram constraints; retry with built-in commands only
       console.warn(`[Telegram] Full command registration failed, retrying with built-in commands only: ${regErr instanceof Error ? regErr.message : regErr}`);
-      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context", "kill", "verbose", "fork"].includes(c.command));
+      const builtinOnly = commands.filter((c) => ["start", "reset", "compact", "status", "context", "kill", "verbose", "fork", "mode"].includes(c.command));
       await callApi(token, "setMyCommands", { commands: builtinOnly });
       console.log(`  Commands registered (built-in only): ${builtinOnly.length}`);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,10 @@ export interface TelegramConfig {
    * - "perUser": each DM user gets their own isolated session.
    */
   dmIsolation: "shared" | "perUser";
+  /** Local whisper.cpp model for voice transcription. Default: "base.en".
+   *  Supported values: tiny, base, small, medium, large-v3, large-v3-turbo (with or without .en suffix).
+   *  Ignored when stt.baseUrl is configured. */
+  whisperModel?: string;
 }
 
 export interface DiscordConfig {
@@ -334,6 +338,9 @@ function parseSettings(
       listenChats: Array.isArray(raw.telegram?.listenChats) ? raw.telegram.listenChats.map(Number) : [],
       receiveEnabled: raw.telegram?.receiveEnabled !== false,
       dmIsolation: raw.telegram?.dmIsolation === "perUser" ? "perUser" : "shared",
+      ...(typeof raw.telegram?.whisperModel === "string" && raw.telegram.whisperModel.trim()
+        ? { whisperModel: raw.telegram.whisperModel.trim() }
+        : {}),
     },
     discord: {
       token: process.env.DISCORD_TOKEN?.trim() || (typeof raw.discord?.token === "string" ? raw.discord.token.trim() : ""),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile, realpath } from "fs/promises";
 import { join, dirname, resolve, sep } from "path";
 import { execSync } from "child_process";
-import { existsSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, writeFileSync, mkdirSync, readFileSync } from "fs";
 import {
   getSession,
   createSession,
@@ -32,6 +32,7 @@ import { getPluginManager, type EventContext } from "./plugins";
 
 const LOGS_DIR = join(process.cwd(), ".claude/claudeclaw/logs");
 const ACTIVE_RUNS_FILE = join(process.cwd(), ".claude/claudeclaw/active-runs");
+const PERMISSION_MODE_FILE = join(process.cwd(), ".claude/claudeclaw/permission-mode.json");
 // Resolve prompts relative to the claudeclaw installation, not the project dir
 const PROMPTS_DIR = join(import.meta.dir, "..", "prompts");
 const HEARTBEAT_PROMPT_FILE = join(PROMPTS_DIR, "heartbeat", "HEARTBEAT.md");
@@ -838,8 +839,37 @@ export async function ensureProjectClaudeMd(): Promise<void> {
   }
 }
 
+export type PermissionMode = "plan" | "acceptEdits" | "bypassPermissions";
+
+let cachedPermissionMode: PermissionMode | null = null;
+
+export function getPermissionMode(): PermissionMode {
+  if (cachedPermissionMode) return cachedPermissionMode;
+  try {
+    const raw = JSON.parse(readFileSync(PERMISSION_MODE_FILE, "utf8")) as { mode?: unknown };
+    if (raw.mode === "plan" || raw.mode === "acceptEdits" || raw.mode === "bypassPermissions") {
+      cachedPermissionMode = raw.mode;
+      return raw.mode;
+    }
+  } catch {}
+  return "bypassPermissions";
+}
+
+export function setPermissionMode(mode: PermissionMode): void {
+  cachedPermissionMode = mode;
+  try {
+    mkdirSync(dirname(PERMISSION_MODE_FILE), { recursive: true });
+    writeFileSync(PERMISSION_MODE_FILE, `${JSON.stringify({ mode }, null, 2)}\n`);
+  } catch (err) {
+    console.error("[runner] Failed to persist permission mode:", err);
+  }
+}
+
 function buildSecurityArgs(security: SecurityConfig): string[] {
-  const args: string[] = ["--dangerously-skip-permissions"];
+  const permissionMode = getPermissionMode();
+  const args: string[] = permissionMode === "bypassPermissions"
+    ? ["--dangerously-skip-permissions"]
+    : ["--permission-mode", permissionMode];
 
   switch (security.level) {
     case "locked":

--- a/src/statusline.ts
+++ b/src/statusline.ts
@@ -12,6 +12,10 @@ export interface StateData {
     lastResult?: "ok" | "error" | "skipped";
     /** Unix timestamp (ms) of the most recent completion. Absent until first run. */
     lastRanAt?: number;
+    /** Number of consecutive failures since last success. Present only while retrying. */
+    failCount?: number;
+    /** Unix timestamp (ms) when the next retry fires. Present only while retrying. */
+    retryAt?: number;
   }[];
   security: string;
   telegram: boolean;

--- a/src/whisper.ts
+++ b/src/whisper.ts
@@ -5,7 +5,7 @@ import { basename, extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getSettings } from "./config";
 
-const WHISPER_MODEL = "base.en";
+const DEFAULT_WHISPER_MODEL = "base.en";
 const WHISPER_ROOT = join(process.cwd(), ".claude", "claudeclaw", "whisper");
 const BIN_DIR = join(WHISPER_ROOT, "bin");
 const LIB_DIR = join(WHISPER_ROOT, "lib");
@@ -14,7 +14,18 @@ const TMP_FOLDER = join(WHISPER_ROOT, "tmp");
 const OGG_MJS_CONVERTER = fileURLToPath(new URL("./ogg.mjs", import.meta.url));
 const PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
-const MODEL_URL = `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${WHISPER_MODEL}.bin`;
+function getWhisperModel(): string {
+  try {
+    const m = getSettings().telegram.whisperModel?.trim();
+    return m || DEFAULT_WHISPER_MODEL;
+  } catch {
+    return DEFAULT_WHISPER_MODEL;
+  }
+}
+
+function getModelUrl(model: string): string {
+  return `https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-${model}.bin`;
+}
 
 interface BinarySource {
   url: string;
@@ -60,7 +71,7 @@ function getWhisperBinaryPath(): string {
 }
 
 function getModelPath(): string {
-  return join(MODEL_FOLDER, `ggml-${WHISPER_MODEL}.bin`);
+  return join(MODEL_FOLDER, `ggml-${getWhisperModel()}.bin`);
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -221,18 +232,19 @@ async function downloadAndExtractBinary(): Promise<void> {
 }
 
 async function downloadModel(): Promise<void> {
+  const model = getWhisperModel();
   const modelPath = getModelPath();
   if (await fileExists(modelPath)) return;
 
   await mkdir(MODEL_FOLDER, { recursive: true });
-  console.log(`whisper: downloading model ${WHISPER_MODEL}...`);
-  await downloadFile(MODEL_URL, modelPath);
+  console.log(`whisper: downloading model ${model}...`);
+  await downloadFile(getModelUrl(model), modelPath);
   console.log("whisper: model ready");
 }
 
 async function prepareWhisperAssets(printOutput: boolean): Promise<void> {
   const startedAt = Date.now();
-  console.log(`whisper warmup: start root=${WHISPER_ROOT} model=${WHISPER_MODEL}`);
+  console.log(`whisper warmup: start root=${WHISPER_ROOT} model=${getWhisperModel()}`);
   await mkdir(WHISPER_ROOT, { recursive: true });
   await mkdir(TMP_FOLDER, { recursive: true });
 


### PR DESCRIPTION
## Summary
- Cherry-picks #197 job retry state into `state.json` / statusline data.
- Cherry-picks #198 configurable local Whisper model via `telegram.whisperModel`.
- Ports the intended #199 `/mode` Telegram command onto current `master` as a maintainer commit because the source PR branch is stale and conflicts with current `runner.ts` / `telegram.ts`.
- Applies one combined plugin/marketplace metadata bump to `1.0.31`.

## Attribution
The #197 and #198 cherry-picked commits retain the original author metadata for @Nibbler1250.

#199 could not be safely cherry-picked as-is: its current branch tip conflicts with current `master` and contains an obsolete tree that would remove many files if merged directly. The intended feature was small, so it has been ported in maintainer commit `34fa655` with the PR and issue context noted here.

Cherry-picked commits:
- ed9a96c feat(jobs): expose failCount and retryAt in StateData (from #197)
- afa66ef feat(jobs): include retry state in updateState() writes (from #197)
- 6c5e201 fix(jobs): use local retryState var in updateState() instead of triple get() (from #197)
- 276e7e3 feat(telegram): configurable whisper model via settings (from #198)
- 7a76717 feat(config): add telegram.whisperModel setting (from #198)

Maintainer port:
- 34fa655 feat(telegram): port mode command for bulk merge (from #199 / #181 intent)

Refs #197.
Refs #198.
Refs #199.
Closes #176.
Closes #181.

## Review notes
- #197: no code findings; suitable for bulk merge.
- #198: no blocking findings; suitable for bulk merge.
- #199: not suitable to merge directly due stale branch conflicts, but the intended `/mode` feature is minor and has been ported onto current master. The port also ensures `.claude/claudeclaw` exists before writing `permission-mode.json`.

## Validation
- `git diff --check origin/master...HEAD`
- `git diff --check`
- `bun install`
- `bun test`
- `bunx tsc --noEmit --pretty false`