### PR TITLE
feat(web-ui): file attachments in chat

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -941,6 +941,106 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     const chatForm = $("chat-form");
     const chatInput = $("chat-input");
     const chatSend = $("chat-send");
+    const chatAttachBtn = $("chat-attach");
+    const chatFileInput = $("chat-file-input");
+    const chatAttachmentsEl = $("chat-attachments");
+
+    // Attachment state
+    var pendingAttachments = []; // Array of { name, type, data } where data is base64
+
+    function renderAttachmentChips() {
+      if (!chatAttachmentsEl) return;
+      if (pendingAttachments.length === 0) {
+        chatAttachmentsEl.hidden = true;
+        chatAttachmentsEl.innerHTML = "";
+        return;
+      }
+      chatAttachmentsEl.hidden = false;
+      chatAttachmentsEl.innerHTML = pendingAttachments.map(function(att, idx) {
+        return (
+          '<span class="attach-chip">' +
+            '<span class="attach-chip-name" title="' + escAttr(att.name) + '">' + esc(att.name) + '</span>' +
+            '<button class="attach-chip-remove" type="button" data-attach-index="' + idx + '" aria-label="Remove ' + escAttr(att.name) + '">×</button>' +
+          '</span>'
+        );
+      }).join("");
+    }
+
+    function readFileAsBase64(file) {
+      return new Promise(function(resolve, reject) {
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          var result = e.target.result;
+          // Strip the data URL prefix: "data:<type>;base64,<data>"
+          var base64 = typeof result === "string" ? result.split(",")[1] || "" : "";
+          resolve(base64);
+        };
+        reader.onerror = function() { reject(new Error("Failed to read file")); };
+        reader.readAsDataURL(file);
+      });
+    }
+
+    if (chatAttachBtn && chatFileInput) {
+      chatAttachBtn.addEventListener("click", function() {
+        if (chatBusy) return;
+        chatFileInput.click();
+      });
+    }
+
+    if (chatFileInput) {
+      chatFileInput.addEventListener("change", async function() {
+        var files = chatFileInput.files;
+        if (!files || !files.length) return;
+        var warnEl = $("chat-attach-warn");
+        if (warnEl) warnEl.remove();
+
+        for (var i = 0; i < files.length; i++) {
+          var file = files[i];
+          if (pendingAttachments.length >= 5) {
+            var warn = document.createElement("div");
+            warn.id = "chat-attach-warn";
+            warn.className = "attach-warn";
+            warn.textContent = "Max 5 attachments allowed.";
+            if (chatAttachmentsEl && chatAttachmentsEl.parentNode) {
+              chatAttachmentsEl.parentNode.insertBefore(warn, chatAttachmentsEl.nextSibling);
+            }
+            break;
+          }
+          if (file.size > 10 * 1024 * 1024) {
+            var warnSize = document.createElement("div");
+            warnSize.id = "chat-attach-warn";
+            warnSize.className = "attach-warn";
+            warnSize.textContent = '"' + file.name + '" exceeds 10 MB limit.';
+            if (chatAttachmentsEl && chatAttachmentsEl.parentNode) {
+              chatAttachmentsEl.parentNode.insertBefore(warnSize, chatAttachmentsEl.nextSibling);
+            }
+            continue;
+          }
+          try {
+            var base64 = await readFileAsBase64(file);
+            pendingAttachments.push({ name: file.name, type: file.type || "application/octet-stream", data: base64 });
+          } catch (_) {}
+        }
+        // Reset so same file can be re-selected if removed
+        chatFileInput.value = "";
+        renderAttachmentChips();
+      });
+    }
+
+    // Remove chip on click (delegated)
+    if (chatAttachmentsEl) {
+      chatAttachmentsEl.addEventListener("click", function(event) {
+        var target = event.target;
+        if (!(target instanceof HTMLElement)) return;
+        var btn = target.closest("[data-attach-index]");
+        if (!btn || !(btn instanceof HTMLElement)) return;
+        var idx = parseInt(btn.getAttribute("data-attach-index") || "-1", 10);
+        if (idx >= 0 && idx < pendingAttachments.length) {
+          pendingAttachments.splice(idx, 1);
+          renderAttachmentChips();
+        }
+      });
+    }
 
     var CHAT_STORAGE_KEY = "claudeclaw.chat.history";
     let chatBusy = false;
@@ -1136,6 +1236,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
       var cancelBtn = $("chat-cancel");
       if (chatSend) chatSend.disabled = busy;
       if (cancelBtn) cancelBtn.hidden = !busy;
+      if (chatAttachBtn) chatAttachBtn.disabled = busy;
       if (busy) {
         chatStartedAt = Date.now();
         chatElapsedTimer = setInterval(function() {
@@ -1280,13 +1381,20 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     async function sendChat() {
       if (chatBusy || !chatInput) return;
       var message = (chatInput.value || "").trim();
-      if (!message) return;
+      var attachmentsToSend = pendingAttachments.slice();
+      if (!message && attachmentsToSend.length === 0) return;
 
       chatInput.value = "";
       autoResizeChatInput();
+
+      // Clear pending attachments and hide chip area
+      pendingAttachments = [];
+      renderAttachmentChips();
+
       setChatBusy(true);
 
-      chatHistory.push({ role: "user", text: message });
+      var userText = message || ("(" + attachmentsToSend.length + " attachment" + (attachmentsToSend.length !== 1 ? "s" : "") + ")");
+      chatHistory.push({ role: "user", text: userText });
       var assistantIdx = chatHistory.length;
       chatHistory.push({ role: "assistant", text: "", streaming: true });
       renderChatHistory();
@@ -1297,7 +1405,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         var res = await fetch("/api/chat", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ message: message }),
+          body: JSON.stringify({ message: message, attachments: attachmentsToSend }),
           signal: chatAbortController.signal,
         });
 

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1221,6 +1221,7 @@ export const pageStyles = String.raw`    :root {
     }
     .chat-form {
       display: flex;
+      flex-wrap: wrap;
       align-items: flex-end;
       gap: 8px;
       border: 1px solid #ffffff2e;
@@ -1548,4 +1549,86 @@ export const pageStyles = String.raw`    :root {
   .chat-layout { flex-direction: column; }
   .chat-sidebar { width: 100%; min-width: 100%; max-height: 180px; border-right: none; border-bottom: 1px solid var(--border); }
 }
+
+    /* ── File attachment UI ── */
+    .chat-attach {
+      flex-shrink: 0;
+      height: 34px;
+      width: 34px;
+      padding: 0;
+      border-radius: 999px;
+      border: 1px solid #ffffff2a;
+      background: #ffffff09;
+      color: #c8d8f0;
+      font-size: 15px;
+      line-height: 1;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 0.16s ease, background 0.16s ease, border-color 0.16s ease, opacity 0.16s ease;
+    }
+    .chat-attach:hover {
+      transform: translateY(-1px);
+      background: #ffffff18;
+      border-color: #ffffff44;
+    }
+    .chat-attach:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+      transform: none;
+    }
+    .chat-attachments {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding: 0 0 4px;
+      width: 100%;
+      flex-basis: 100%;
+      border-bottom: 1px solid #ffffff14;
+      margin-bottom: 2px;
+    }
+    .attach-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 8px 3px 10px;
+      border-radius: 999px;
+      background: #0e1e34cc;
+      border: 1px solid #ffffff22;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 11px;
+      color: #c8d8f0;
+      max-width: 220px;
+    }
+    .attach-chip-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 150px;
+    }
+    .attach-chip-remove {
+      flex-shrink: 0;
+      border: none;
+      background: transparent;
+      color: #8aaccc;
+      font-size: 14px;
+      line-height: 1;
+      padding: 0 2px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: color 0.14s ease;
+    }
+    .attach-chip-remove:hover {
+      color: #ff9b9b;
+    }
+    .attach-warn {
+      width: 100%;
+      font-family: "JetBrains Mono", monospace;
+      font-size: 11px;
+      color: #ffc276;
+      padding: 2px 4px;
+    }
 `;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -205,6 +205,13 @@ ${pageStyles}
           <div id="chat-messages" class="chat-messages"></div>
           <div class="chat-input-area">
             <form id="chat-form" class="chat-form">
+              <input
+                type="file"
+                id="chat-file-input"
+                multiple
+                style="display:none"
+                accept="text/plain,text/html,text/css,text/javascript,text/typescript,text/x-python,text/csv,text/xml,text/markdown,application/json,application/yaml,application/toml,image/jpeg,image/png,image/gif,image/webp,.js,.ts,.py,.json,.yaml,.yml,.md,.txt,.csv,.xml,.sh,.sql,.toml,.ini,.env,.log"
+              />
               <textarea
                 id="chat-input"
                 class="chat-input"
@@ -212,6 +219,8 @@ ${pageStyles}
                 rows="1"
                 autocomplete="off"
               ></textarea>
+              <div id="chat-attachments" class="chat-attachments" hidden></div>
+              <button id="chat-attach" class="chat-attach" type="button" title="Attach files">📎</button>
               <button id="chat-cancel" class="chat-cancel" type="button" hidden>Cancel</button>
               <button id="chat-send" class="chat-send" type="submit">Send</button>
             </form>

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -8,6 +8,8 @@ import { createQuickJob, deleteJob } from "./services/jobs";
 import { readLogs } from "./services/logs";
 import { listSessions, readSessionMessages, listAgents } from "./services/sessions";
 import { runUserMessage } from "../runner";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
 
 export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
   const server = Bun.serve({
@@ -209,7 +211,74 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
         try {
           const body = await req.json();
           const message = String(body?.message ?? "").trim();
-          if (!message) return json({ ok: false, error: "message required" });
+
+          interface Attachment {
+            name: string;
+            type: string;
+            data: string; // base64
+          }
+
+          const rawAttachments = Array.isArray(body?.attachments) ? (body.attachments as unknown[]) : [];
+
+          // Validate attachments
+          if (rawAttachments.length > 5) {
+            return json({ ok: false, error: "too many attachments (max 5)" }, 400);
+          }
+
+          const attachments: Attachment[] = [];
+          for (const raw of rawAttachments) {
+            if (!raw || typeof raw !== "object") continue;
+            const att = raw as Record<string, unknown>;
+            const name = String(att.name ?? "");
+            const type = String(att.type ?? "");
+            const data = String(att.data ?? "");
+            // base64 decoded size approximation
+            const decodedSize = data.length * 0.75;
+            if (decodedSize > 10 * 1024 * 1024) {
+              return json({ ok: false, error: `attachment "${name}" exceeds 10 MB limit` }, 400);
+            }
+            attachments.push({ name, type, data });
+          }
+
+          if (!message && attachments.length === 0) {
+            return json({ ok: false, error: "message required" });
+          }
+
+          const TEXT_EXTENSIONS = new Set([
+            "js", "ts", "py", "json", "yaml", "yml", "md", "txt", "csv",
+            "xml", "sh", "sql", "toml", "ini", "env", "log",
+          ]);
+
+          const tempImagePaths: string[] = [];
+          const attachmentBlocks: string[] = [];
+
+          for (const att of attachments) {
+            const ext = att.name.includes(".") ? att.name.split(".").pop()!.toLowerCase() : "";
+            if (att.type.startsWith("text/") || TEXT_EXTENSIONS.has(ext)) {
+              const content = Buffer.from(att.data, "base64").toString("utf-8");
+              attachmentBlocks.push(
+                `[Attached file: ${att.name}]\n\`\`\`${ext}\n${content}\n\`\`\``
+              );
+            } else if (att.type.startsWith("image/")) {
+              const uploadDir = `${tmpdir()}/claudeclaw-uploads`;
+              await import("fs/promises").then(({ mkdir }) => mkdir(uploadDir, { recursive: true })).catch(() => {});
+              const filePath = `${uploadDir}/${randomUUID()}.${ext || "bin"}`;
+              const buffer = Buffer.from(att.data, "base64");
+              await Bun.write(filePath, buffer);
+              tempImagePaths.push(filePath);
+              attachmentBlocks.push(
+                `[Attached image: ${att.name} — file saved at ${filePath}, you can read it with your Read tool]`
+              );
+            } else {
+              attachmentBlocks.push(
+                `[Attached file: ${att.name} — unsupported type, content not included]`
+              );
+            }
+          }
+
+          const enrichedMessage = attachmentBlocks.length > 0
+            ? attachmentBlocks.join("\n\n") + (message ? "\n\n" + message : "")
+            : message;
 
           const encoder = new TextEncoder();
           const onChat = opts.onChat;
@@ -220,7 +289,7 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
               };
               try {
                 await onChat(
-                  message,
+                  enrichedMessage,
                   (chunk) => send({ type: "chunk", text: chunk }),
                   () => send({ type: "unblock" }),
                   (ev) => send({ type: ev.type === "spawn" ? "agent_spawn" : "agent_done", id: ev.id, description: ev.description, result: ev.result })
@@ -230,6 +299,14 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
                 send({ type: "error", message: String(err) });
               } finally {
                 controller.close();
+                // Fire-and-forget cleanup of temp image files
+                for (const p of tempImagePaths) {
+                  Bun.file(p).exists().then((exists) => {
+                    if (exists) {
+                      import("fs").then(({ unlink }) => unlink(p, () => {})).catch(() => {});
+                    }
+                  }).catch(() => {});
+                }
               }
             },
           });


### PR DESCRIPTION
## Summary

Adds file attachment support to the web UI chat panel. Resolves #204.

A 📎 button sits next to the send button. Selecting files shows removable chips below the textarea. On send, attachments are processed server-side and prepended to the message before it reaches Claude.

**What's supported:**
- **Text/code files** (js, ts, py, json, yaml, md, txt, csv, xml, sh, sql, toml, ini, env, log, and `text/*` MIME types): content is embedded as a fenced code block in the prompt
- **Images** (jpg, png, gif, webp): decoded and written to a session-scoped temp directory; Claude is told the path and can read it with its Read tool. Files are deleted fire-and-forget after the stream closes.
- **Other types**: noted in the prompt but content not included

**Limits:** max 5 attachments, max 10 MB each — validated both client-side (inline warning) and server-side (400 response).

**API change:** `POST /api/chat` accepts an optional `attachments` field:
```ts
attachments?: Array<{ name: string; type: string; data: string /* base64 */ }>
```
Existing callers that send only `{ message }` are unaffected.

## Changes

| File | What changed |
|---|---|
| `src/ui/server.ts` | Decode attachments, build enriched prompt, temp file cleanup |
| `src/ui/page/template.ts` | File input (hidden), attachment chip area, 📎 button |
| `src/ui/page/script.ts` | File selection, chip rendering, base64 read, submit wiring |
| `src/ui/page/styles.ts` | Chip pill styles, attach button, warning text |

## Validation

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test` — all 96 tests pass
- [x] Plugin version bumped (1.0.31 → 1.0.32)