### PR TITLE
feat(dashboard): add session usage monitoring tab

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -935,8 +935,10 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     // ── Chat ──
     const tabDashboardBtn = $("tab-dashboard");
     const tabChatBtn = $("tab-chat");
+    const tabUsageBtn = $("tab-usage");
     const dashboardPanel = $("dashboard-panel");
     const chatPanel = $("chat-panel");
+    const usagePanel = $("usage-panel");
     const chatMessages = $("chat-messages");
     const chatForm = $("chat-form");
     const chatInput = $("chat-input");
@@ -1055,8 +1057,8 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     })();
 
     function setActiveTab(tab) {
-      const allBtns = [tabDashboardBtn, tabChatBtn];
-      const allPanels = [dashboardPanel, chatPanel];
+      const allBtns = [tabDashboardBtn, tabChatBtn, tabUsageBtn];
+      const allPanels = [dashboardPanel, chatPanel, usagePanel];
       allBtns.forEach(b => { if (b) { b.classList.remove("tab-btn-active"); b.setAttribute("aria-selected", "false"); } });
       allPanels.forEach(p => { if (p) p.hidden = true; });
 
@@ -1064,6 +1066,11 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         tabDashboardBtn && tabDashboardBtn.classList.add("tab-btn-active");
         tabDashboardBtn && tabDashboardBtn.setAttribute("aria-selected", "true");
         if (dashboardPanel) dashboardPanel.hidden = false;
+      } else if (tab === "usage") {
+        tabUsageBtn && tabUsageBtn.classList.add("tab-btn-active");
+        tabUsageBtn && tabUsageBtn.setAttribute("aria-selected", "true");
+        if (usagePanel) usagePanel.hidden = false;
+        fetchUsage();
       } else {
         tabChatBtn && tabChatBtn.classList.add("tab-btn-active");
         tabChatBtn && tabChatBtn.setAttribute("aria-selected", "true");
@@ -1074,6 +1081,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
 
     if (tabDashboardBtn) tabDashboardBtn.addEventListener("click", () => setActiveTab("dashboard"));
     if (tabChatBtn) tabChatBtn.addEventListener("click", function() { setActiveTab("chat"); loadSessions(); });
+    if (tabUsageBtn) tabUsageBtn.addEventListener("click", function() { setActiveTab("usage"); });
 
     // --- Session browser ---
 
@@ -1516,4 +1524,85 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         var elapsedEl = chatMessages.querySelector(".chat-msg-elapsed");
         if (elapsedEl) elapsedEl.textContent = fmtElapsed(Date.now() - chatStartedAt);
       }
-    }, 1000);`;
+    }, 1000);
+
+    // --- Usage monitoring ---
+    var usageWrap = $("usage-table-wrap");
+
+    function fmtTokens(n) {
+      if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+      if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+      return String(n);
+    }
+
+    function fmtCost(usd) {
+      if (usd <= 0) return "$0.00";
+      if (usd < 0.01) return "<$0.01";
+      return "$" + usd.toFixed(2);
+    }
+
+    function fmtRelative(iso) {
+      if (!iso) return "—";
+      var delta = Date.now() - new Date(iso).getTime();
+      var s = Math.floor(delta / 1000);
+      if (s < 60) return s + "s ago";
+      var m = Math.floor(s / 60);
+      if (m < 60) return m + "m ago";
+      var h = Math.floor(m / 60);
+      if (h < 24) return h + "h ago";
+      return Math.floor(h / 24) + "d ago";
+    }
+
+    function renderUsageTable(sessions) {
+      if (!usageWrap) return;
+      if (!sessions || sessions.length === 0) {
+        usageWrap.innerHTML = '<div class="usage-loading">No active sessions found.</div>';
+        return;
+      }
+      var maxCost = sessions.reduce(function(m, s) { return Math.max(m, s.estimatedCostUsd); }, 0);
+      var rows = sessions.map(function(s) {
+        var barPct = maxCost > 0 ? Math.round((s.estimatedCostUsd / maxCost) * 100) : 0;
+        var channelIcon = s.channel === "discord" ? "🎮" : s.channel === "web" ? "🌐" : "❓";
+        return "<tr>" +
+          "<td class='usage-td usage-td-label'>" + channelIcon + " " + esc(s.label) + "</td>" +
+          "<td class='usage-td usage-td-num'>" + fmtTokens(s.inputTokens) + "</td>" +
+          "<td class='usage-td usage-td-num'>" + fmtTokens(s.outputTokens) + "</td>" +
+          "<td class='usage-td usage-td-num'>" + fmtTokens(s.cacheReadTokens) + "</td>" +
+          "<td class='usage-td usage-td-num'>" + s.cacheHitPct + "%</td>" +
+          "<td class='usage-td usage-td-cost'>" +
+            "<div class='usage-cost-wrap'>" +
+              "<div class='usage-cost-bar' style='width:" + barPct + "%'></div>" +
+              "<span class='usage-cost-label'>~" + fmtCost(s.estimatedCostUsd) + "</span>" +
+            "</div>" +
+          "</td>" +
+          "<td class='usage-td usage-td-num usage-td-turns'>" + s.turnCount + "</td>" +
+          "<td class='usage-td usage-td-age'>" + fmtRelative(s.lastUsedAt) + "</td>" +
+          "</tr>";
+      }).join("");
+      usageWrap.innerHTML =
+        "<table class='usage-table'>" +
+        "<thead><tr>" +
+        "<th class='usage-th'>Session</th>" +
+        "<th class='usage-th usage-th-num'>Input</th>" +
+        "<th class='usage-th usage-th-num'>Output</th>" +
+        "<th class='usage-th usage-th-num'>Cache Read</th>" +
+        "<th class='usage-th usage-th-num'>Cache Hit</th>" +
+        "<th class='usage-th'>Est. Cost</th>" +
+        "<th class='usage-th usage-th-num'>Turns</th>" +
+        "<th class='usage-th'>Last Active</th>" +
+        "</tr></thead>" +
+        "<tbody>" + rows + "</tbody>" +
+        "</table>";
+    }
+
+    function fetchUsage() {
+      fetch("/api/usage")
+        .then(function(r) { return r.json(); })
+        .then(function(data) { renderUsageTable(Array.isArray(data) ? data : []); })
+        .catch(function() {
+          if (usageWrap) usageWrap.innerHTML = '<div class="usage-loading">Failed to load usage data.</div>';
+        });
+    }
+
+    fetchUsage();
+    setInterval(fetchUsage, 60_000);`;

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1631,4 +1631,66 @@ export const pageStyles = String.raw`    :root {
       color: #ffc276;
       padding: 2px 4px;
     }
+
+/* --- Usage section --- */
+.usage-section {
+  margin-top: 24px;
+  border: 1px solid #ffffff22;
+  border-radius: 16px;
+  background:
+    radial-gradient(120% 100% at 100% 0%, #7dc5ff1a, transparent 55%),
+    linear-gradient(180deg, #0e1a2a88 0%, #0a1220a8 100%);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 14px 34px #00000045;
+  padding: 18px 20px;
+}
+.usage-head { margin-bottom: 14px; }
+.usage-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.usage-sub { font-size: 11px; color: var(--fg-dim); margin-top: 2px; }
+.usage-loading { font-size: 12px; color: var(--fg-dim); padding: 8px 0; }
+.usage-table-wrap { overflow-x: auto; }
+.usage-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.usage-th {
+  text-align: left;
+  color: var(--fg-dim);
+  font-weight: 500;
+  padding: 4px 10px 8px 0;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.usage-th-num { text-align: right; }
+.usage-td {
+  padding: 7px 10px 7px 0;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.usage-td-num, .usage-td-turns { text-align: right; color: var(--fg-dim); font-variant-numeric: tabular-nums; }
+.usage-td-label { color: var(--fg); font-weight: 500; max-width: 160px; overflow: hidden; text-overflow: ellipsis; }
+.usage-td-age { color: var(--fg-dim); font-size: 11px; }
+.usage-td-cost { min-width: 120px; }
+.usage-cost-wrap { position: relative; height: 18px; display: flex; align-items: center; }
+.usage-cost-bar {
+  position: absolute; left: 0; top: 0; height: 100%;
+  background: rgba(99, 179, 237, 0.18);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+.usage-cost-label { position: relative; padding-left: 6px; font-variant-numeric: tabular-nums; color: var(--fg); }
+
+@media (max-width: 640px) {
+  .tab-btn { padding: 0 12px; font-size: 10px; }
+  .usage-table th:nth-child(2), .usage-table td:nth-child(2),
+  .usage-table th:nth-child(3), .usage-table td:nth-child(3),
+  .usage-table th:nth-child(4), .usage-table td:nth-child(4),
+  .usage-table th:nth-child(5), .usage-table td:nth-child(5) { display: none; }
+  .usage-td-label { max-width: 110px; }
+  .usage-td-cost { min-width: 80px; }
+}
 `;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -115,6 +115,7 @@ ${pageStyles}
     <nav class="tab-nav" role="tablist" aria-label="Main navigation">
       <button class="tab-btn tab-btn-active" id="tab-dashboard" type="button" role="tab" aria-selected="true" aria-controls="dashboard-panel">Dashboard</button>
       <button class="tab-btn" id="tab-chat" type="button" role="tab" aria-selected="false" aria-controls="chat-panel">Chat</button>
+      <button class="tab-btn" id="tab-usage" type="button" role="tab" aria-selected="false" aria-controls="usage-panel">Usage</button>
     </nav>
     <div id="dashboard-panel">
     <section class="hero">
@@ -183,6 +184,17 @@ ${pageStyles}
         </div>
       </form>
     </section>
+    </div>
+    <div id="usage-panel" hidden>
+      <section class="usage-section" id="usage-section">
+        <div class="usage-head">
+          <div class="usage-title">Session Usage</div>
+          <div class="usage-sub">Token consumption and estimated cost per session · refreshes every 60s</div>
+        </div>
+        <div class="usage-table-wrap" id="usage-table-wrap">
+          <div class="usage-loading">Loading usage data...</div>
+        </div>
+      </section>
     </div>
     <div id="chat-panel" class="chat-panel" hidden>
       <div class="chat-layout">

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -7,6 +7,7 @@ import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/setti
 import { createQuickJob, deleteJob } from "./services/jobs";
 import { readLogs } from "./services/logs";
 import { listSessions, readSessionMessages, listAgents } from "./services/sessions";
+import { getSessionUsage } from "./services/usage";
 import { runUserMessage } from "../runner";
 import { tmpdir } from "os";
 import { randomUUID } from "crypto";
@@ -157,6 +158,15 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       if (url.pathname === "/api/sessions" && req.method === "GET") {
         try {
           return json(await listSessions());
+        } catch (err) {
+          return json({ ok: false, error: String(err) });
+        }
+      }
+
+      if (url.pathname === "/api/usage" && req.method === "GET") {
+        try {
+          const channelNames = opts.getSnapshot().settings.discord?.channelNames;
+          return json(await getSessionUsage(channelNames));
         } catch (err) {
           return json({ ok: false, error: String(err) });
         }

--- a/src/ui/services/usage.ts
+++ b/src/ui/services/usage.ts
@@ -1,0 +1,149 @@
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Pricing per million tokens (Sonnet 4.6 defaults)
+const PRICING = { input: 3.0, output: 15.0, cacheRead: 0.30, cacheWrite: 3.75 };
+
+export interface SessionUsage {
+  sessionId: string;
+  label: string;
+  channel: "discord" | "web" | "unknown";
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  estimatedCostUsd: number;
+  cacheHitPct: number;
+  turnCount: number;
+  lastUsedAt: string;
+}
+
+function getProjectDir(): string {
+  const sanitized = process.cwd().replace(/[/\\.]/g, "-");
+  return join(homedir(), ".claude", "projects", sanitized);
+}
+
+function calcCost(tokens: Pick<SessionUsage, "inputTokens" | "outputTokens" | "cacheReadTokens" | "cacheWriteTokens">): number {
+  return (
+    tokens.inputTokens * PRICING.input +
+    tokens.outputTokens * PRICING.output +
+    tokens.cacheReadTokens * PRICING.cacheRead +
+    tokens.cacheWriteTokens * PRICING.cacheWrite
+  ) / 1_000_000;
+}
+
+async function parseJSONLUsage(sessionId: string): Promise<Pick<SessionUsage, "inputTokens" | "outputTokens" | "cacheReadTokens" | "cacheWriteTokens">> {
+  const zero = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+  if (!UUID_RE.test(sessionId)) return zero;
+
+  const filePath = join(getProjectDir(), `${sessionId}.jsonl`);
+  if (!existsSync(filePath)) return zero;
+
+  const result = { ...zero };
+  const seenIds = new Set<string>();
+  try {
+    const content = await readFile(filePath, "utf-8");
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (entry.type !== "assistant") continue;
+        const msgId: string | undefined = entry.message?.id;
+        if (msgId) {
+          if (seenIds.has(msgId)) continue;
+          seenIds.add(msgId);
+        }
+        const u = entry.message?.usage;
+        if (!u) continue;
+        result.inputTokens += u.input_tokens ?? 0;
+        result.outputTokens += u.output_tokens ?? 0;
+        result.cacheReadTokens += u.cache_read_input_tokens ?? 0;
+        result.cacheWriteTokens += u.cache_creation_input_tokens ?? 0;
+      } catch {}
+    }
+  } catch {}
+
+  return result;
+}
+
+function buildEntry(
+  sessionId: string,
+  label: string,
+  channel: SessionUsage["channel"],
+  turnCount: number,
+  lastUsedAt: string,
+  tokens: Pick<SessionUsage, "inputTokens" | "outputTokens" | "cacheReadTokens" | "cacheWriteTokens">,
+): SessionUsage {
+  const totalIn = tokens.inputTokens + tokens.cacheReadTokens + tokens.cacheWriteTokens;
+  return {
+    sessionId,
+    label,
+    channel,
+    ...tokens,
+    estimatedCostUsd: calcCost(tokens),
+    cacheHitPct: totalIn > 0 ? Math.round((tokens.cacheReadTokens / totalIn) * 100) : 0,
+    turnCount,
+    lastUsedAt,
+  };
+}
+
+let usageCache: { data: SessionUsage[]; ts: number } | null = null;
+const CACHE_TTL_MS = 60_000;
+
+export async function getSessionUsage(channelNames?: Record<string, string>): Promise<SessionUsage[]> {
+  if (usageCache && Date.now() - usageCache.ts < CACHE_TTL_MS) {
+    return usageCache.data;
+  }
+
+  const cwd = process.cwd();
+  const sessions: SessionUsage[] = [];
+
+  // Global web session
+  const sessionFile = join(cwd, ".claude", "claudeclaw", "session.json");
+  try {
+    if (existsSync(sessionFile)) {
+      const data = JSON.parse(await readFile(sessionFile, "utf-8"));
+      if (UUID_RE.test(data.sessionId)) {
+        const tokens = await parseJSONLUsage(data.sessionId);
+        sessions.push(buildEntry(
+          data.sessionId, "global", "web",
+          data.turnCount ?? 0,
+          data.lastUsedAt || data.createdAt,
+          tokens,
+        ));
+      }
+    }
+  } catch {}
+
+  // Per-channel Discord sessions
+  const sessionsFile = join(cwd, ".claude", "claudeclaw", "sessions.json");
+  try {
+    if (existsSync(sessionsFile)) {
+      const data = JSON.parse(await readFile(sessionsFile, "utf-8"));
+      for (const [threadId, thread] of Object.entries(data.threads ?? {})) {
+        const t = thread as any;
+        if (!UUID_RE.test(t.sessionId)) continue;
+        const label = channelNames?.[threadId] ?? `#${threadId}`;
+        const tokens = await parseJSONLUsage(t.sessionId);
+        sessions.push(buildEntry(
+          t.sessionId, label, "discord",
+          t.turnCount ?? 0,
+          t.lastUsedAt || t.createdAt,
+          tokens,
+        ));
+      }
+    }
+  } catch {}
+
+  sessions.sort((a, b) => b.estimatedCostUsd - a.estimatedCostUsd);
+  usageCache = { data: sessions, ts: Date.now() };
+  return sessions;
+}
+
+export function invalidateUsageCache(): void {
+  usageCache = null;
+}


### PR DESCRIPTION
## Summary

- Adds a **Usage** tab to the dashboard showing per-session token consumption and estimated cost
- New `src/ui/services/usage.ts` service reads Claude Code JSONL session files and aggregates token usage across the web global session and all Discord per-channel sessions
- Deduplicates assistant messages by `message.id` to prevent 2–4x inflation caused by multi-step tool call events writing repeated usage entries
- `/api/usage` endpoint with 60s in-memory cache
- Table columns: Session, Input, Output, Cache Read, Cache Hit %, Est. Cost (with bar chart), Turns, Last Active
- Frosted glass panel styling matching other dashboard cards
- Responsive: collapses token detail columns on screens ≤640px, shrinks tab buttons to fit three tabs on mobile

## Pricing

Uses Sonnet 4.6 rates (configurable in `usage.ts`):
- Input: \$3.00 / MTok
- Output: \$15.00 / MTok
- Cache read: \$0.30 / MTok
- Cache write: \$3.75 / MTok

## Test plan

- [ ] Restart daemon and open dashboard — Usage tab appears in nav
- [ ] Click Usage tab — table loads with per-session data
- [ ] Costs are positive and reflect deduplicated token counts
- [ ] On mobile (≤640px) — only Session, Est. Cost, Turns, Last Active columns visible
- [ ] Table refreshes every 60s automatically; also refreshes immediately on tab switch