### PR TITLE
feat(slack): wire Slack into daemon start and plugin wizard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 <p align="center"><b>A lightweight, open-source OpenClaw version built into your Claude Code.</b></p>
 
-ClaudeClaw turns your Claude Code into a personal assistant that never sleeps. It runs as a background daemon, executing tasks on a schedule, responding to messages on Telegram and Discord, transcribing voice commands, and integrating with any service you need.
+ClaudeClaw turns your Claude Code into a personal assistant that never sleeps. It runs as a background daemon, executing tasks on a schedule, responding to messages on Telegram, Discord, and Slack, transcribing voice commands, and integrating with any service you need.
 
 > Note: Please don't use ClaudeClaw for hacking any bank system or doing any illegal activities. Thank you.
 
@@ -55,7 +55,7 @@ Then open a Claude Code session and run:
 ```
 /claudeclaw:start
 ```
-The setup wizard walks you through model, heartbeat, Telegram, Discord, and security, then your daemon is live with a web dashboard.
+The setup wizard walks you through model, heartbeat, Telegram, Discord, Slack, and security, then your daemon is live with a web dashboard.
 
 ### Contributor Note: Plugin Version Metadata
 
@@ -90,6 +90,7 @@ Docs-only and other non-shipped changes do not require these bumps.
 ### Communication
 - **Telegram:** Text, image, and voice support.
 - **Discord:** DMs, server mentions/replies, slash commands, voice messages, and image attachments.
+- **Slack:** Socket Mode bot — DMs, channel mentions, threads, voice messages, and file attachments. Configure `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` in your environment or `settings.json`.
 - **Time Awareness:** Message time prefixes help the agent understand delays and daily patterns.
 
 ### Multi-Session Threads (Discord)
@@ -113,7 +114,7 @@ See [docs/MULTI_SESSION.md](docs/MULTI_SESSION.md) for technical details.
   <summary><strong>Can ClaudeClaw do &lt;something&gt;?</strong></summary>
   <p>
     If Claude Code can do it, ClaudeClaw can do it too. ClaudeClaw adds cron jobs,
-    heartbeats, and Telegram/Discord bridges on top. You can also give your ClaudeClaw new
+    heartbeats, and Telegram/Discord/Slack bridges on top. You can also give your ClaudeClaw new
     skills and teach it custom workflows.
   </p>
 </details>

--- a/prompts/BOOTSTRAP.md
+++ b/prompts/BOOTSTRAP.md
@@ -76,13 +76,36 @@ Write it cleanly. Future-you will read this cold every session.
 
 ## Connect (Optional)
 
-Ask how they want to reach you:
+Ask how they want to reach you — one platform at a time, don't list them all upfront:
 
-- **Just here** — terminal/web chat only
-- **WhatsApp** — link their personal account (you'll show a QR code)
-- **Telegram** — set up a bot via BotFather
+- **Just here** — terminal/web chat only, no further setup
+- **Telegram** — bot via BotFather
+- **Discord** — bot via Discord Developer Portal
+- **Slack** — bot via Slack API with Socket Mode
 
-Guide them through whichever they pick.
+If they pick **Telegram**:
+1. Tell them to open [@BotFather](https://t.me/BotFather), send `/newbot`, follow the prompts, and paste the token here.
+2. Once you have the token, write it into `.claude/claudeclaw/settings.json` under `telegram.token`.
+3. Get their Telegram user ID (send them to [@userinfobot](https://t.me/userinfobot) or similar) and add it to `telegram.allowedUserIds`.
+4. Restart the daemon with `claudeclaw start --trigger`.
+
+If they pick **Discord**:
+1. Tell them to go to [discord.com/developers/applications](https://discord.com/developers/applications), create a new application, add a Bot, enable **Message Content Intent** and **Server Members Intent** under Privileged Gateway Intents, then copy the bot token.
+2. Write the token into `settings.json` under `discord.token`.
+3. Invite the bot to their server using the OAuth2 URL with `bot` + `applications.commands` scopes and `Send Messages`, `Read Message History`, `Add Reactions` permissions.
+4. Add their Discord user ID to `discord.allowedUserIds` (right-click their name in Discord → Copy User ID with Developer Mode on).
+5. Add the channel IDs they want the bot to listen in to `discord.listenChannels`.
+6. Restart with `claudeclaw start --trigger`.
+
+If they pick **Slack**:
+1. Tell them to go to [api.slack.com/apps](https://api.slack.com/apps), create a new app **from scratch**, enable **Socket Mode** (generates an App-Level Token — copy it, that's the `appToken`).
+2. Under **OAuth & Permissions**, add bot scopes: `chat:write`, `im:history`, `im:read`, `im:write`, `channels:history`, `channels:read`, `files:read`. Install the app to the workspace and copy the **Bot User OAuth Token** (that's the `botToken`).
+3. Under **Event Subscriptions**, enable events and subscribe to `message.im` and `message.channels` (or `app_mention` if they prefer mention-only in channels).
+4. Write both tokens into `settings.json` under `slack.botToken` and `slack.appToken`.
+5. Add their Slack member ID to `slack.allowedUserIds` (click profile → ⋮ → Copy member ID).
+6. Restart with `claudeclaw start --trigger`.
+
+After setup, send a test message from their phone to confirm the connection is live before moving on.
 
 ---
 

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -7,7 +7,7 @@ const WIZARD_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const TRIGGER_COMMANDS = new Set(["/plugin", "/claudeclaw:plugin"]);
 
 export interface WizardContext {
-  iface: "discord" | "telegram" | "web";
+  iface: "discord" | "telegram" | "web" | "slack";
   scopeId: string;
   agentName?: string; // recorded for Phase 2 per-agent scoping
 }

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -5,6 +5,7 @@ import { extractErrorDetail } from "../messaging";
 import { listThreadSessions, peekThreadSession, removeThreadSession } from "../sessionManager";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
+import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 import { mkdir, realpath } from "node:fs/promises";
 import { extname, join, resolve, isAbsolute, sep } from "node:path";
 import { existsSync } from "node:fs";
@@ -972,6 +973,15 @@ async function handleMessage(event: SlackMessage): Promise<void> {
           console.error(`[Slack] Failed to download doc: ${err instanceof Error ? err.message : err}`);
         }
       }
+    }
+
+    // Plugin wizard intercept — /plugin and /claudeclaw:plugin are handled here, not by Claude
+    const wizardCtx = { iface: "slack" as const, scopeId: channelId };
+    const firstWord = cleanText.trim().split(/\s+/, 1)[0].toLowerCase();
+    if ((cleanText.trim().startsWith("/") && isWizardTrigger(firstWord)) || hasActiveWizard(wizardCtx)) {
+      const reply = await handleWizardInput(wizardCtx, cleanText.trim());
+      await sendMessage(config.botToken, channelId, reply, replyThreadTs);
+      return;
     }
 
     // Skill routing

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -219,6 +219,7 @@ export async function start(args: string[] = []) {
   let hasTriggerFlag = false;
   let telegramFlag = false;
   let discordFlag = false;
+  let slackFlag = false;
   let debugFlag = false;
   let webFlag = false;
   let replaceExistingFlag = false;
@@ -235,6 +236,8 @@ export async function start(args: string[] = []) {
       telegramFlag = true;
     } else if (arg === "--discord") {
       discordFlag = true;
+    } else if (arg === "--slack") {
+      slackFlag = true;
     } else if (arg === "--debug") {
       debugFlag = true;
     } else if (arg === "--web") {
@@ -260,7 +263,7 @@ export async function start(args: string[] = []) {
   }
   const payload = payloadParts.join(" ").trim();
   if (hasPromptFlag && !payload) {
-    console.error("Usage: claudeclaw start --prompt <prompt> [--trigger] [--telegram] [--discord] [--debug] [--web] [--web-port <port>] [--replace-existing]");
+    console.error("Usage: claudeclaw start --prompt <prompt> [--trigger] [--telegram] [--discord] [--slack] [--debug] [--web] [--web-port <port>] [--replace-existing]");
     process.exit(1);
   }
   if (!hasPromptFlag && payload) {
@@ -273,6 +276,10 @@ export async function start(args: string[] = []) {
   }
   if (discordFlag && !hasTriggerFlag) {
     console.error("`--discord` with `start` requires `--trigger`.");
+    process.exit(1);
+  }
+  if (slackFlag && !hasTriggerFlag) {
+    console.error("`--slack` with `start` requires `--trigger`.");
     process.exit(1);
   }
   if (hasPromptFlag && !hasTriggerFlag && (webFlag || webPortFlag !== null)) {
@@ -337,6 +344,7 @@ export async function start(args: string[] = []) {
   await writePidFile();
   let web: WebServerHandle | null = null;
   let discordStopGateway: (() => void) | null = null;
+  let slackStopFn: (() => void) | null = null;
 
   // Plugin system — initialize before gateway start
   const pluginManager = new PluginManager(process.cwd());
@@ -349,6 +357,7 @@ export async function start(args: string[] = []) {
     await pluginManager.stopServices();
     setPluginManager(null);
     if (discordStopGateway) discordStopGateway();
+    if (slackStopFn) slackStopFn();
     if (web) web.stop();
     await teardownStatusline();
     await cleanupPidFile();
@@ -434,6 +443,31 @@ export async function start(args: string[] = []) {
 
   await initDiscord(currentSettings.discord.token);
   if (!discordToken) console.log("  Discord: not configured");
+
+  // --- Slack ---
+  let slackSendToUser: ((userId: string, text: string) => Promise<void>) | null = null;
+  let slackBotToken = "";
+
+  async function initSlack(botToken: string, appToken: string) {
+    if (botToken && appToken && botToken !== slackBotToken) {
+      const { startSlack, sendMessageToUser: slackSend, stopSlack } = await import("./slack");
+      if (slackBotToken) stopSlack();
+      startSlack(debugFlag);
+      slackStopFn = stopSlack;
+      slackSendToUser = (userId, text) => slackSend(botToken, userId, text);
+      slackBotToken = botToken;
+      console.log(`[${ts()}] Slack: enabled`);
+    } else if ((!botToken || !appToken) && slackBotToken) {
+      if (slackStopFn) slackStopFn();
+      slackStopFn = null;
+      slackSendToUser = null;
+      slackBotToken = "";
+      console.log(`[${ts()}] Slack: disabled`);
+    }
+  }
+
+  await initSlack(currentSettings.slack.botToken, currentSettings.slack.appToken);
+  if (!slackBotToken) console.log("  Slack: not configured");
 
   // Wire channel senders into plugin runtime so plugins can send messages
   if (pluginManager.hasPlugins) {
@@ -738,6 +772,9 @@ export async function start(args: string[] = []) {
 
       // Discord changes
       await initDiscord(newSettings.discord.token);
+
+      // Slack changes
+      await initSlack(newSettings.slack.botToken, newSettings.slack.appToken);
     } catch (err) {
       console.error(`[${ts()}] Hot-reload error:`, err);
     }


### PR DESCRIPTION
## Summary

Slack has a full implementation (\`src/commands/slack.ts\`, 1684 lines) but was only accessible as a standalone \`claudeclaw slack\` CLI command — it wasn't wired into the main daemon startup path and wasn't integrated with the plugin wizard or the bootstrap conversation. This PR closes all those gaps.

### Changes

**\`src/commands/start.ts\`**
- Add \`--slack\` flag (requires \`--trigger\`, mirrors \`--discord\`)
- Add \`initSlack(botToken, appToken)\` that dynamically imports \`startSlack\` / \`stopSlack\` / \`sendMessageToUser\` from \`slack.ts\`
- Wire Slack into the 30s settings hot-reload loop so config changes take effect without a restart
- Wire Slack into the shutdown handler so the Socket Mode connection closes cleanly on SIGTERM/SIGINT

**\`src/commands/slack.ts\`**
- Import \`isWizardTrigger\`, \`hasActiveWizard\`, \`handleWizardInput\` from \`plugin-wizard.ts\`
- Intercept \`/plugin\` and \`/claudeclaw:plugin\` commands in \`handleMessage\` before skill routing — matches the pattern in \`discord.ts\`

**\`src/commands/plugin-wizard.ts\`**
- Add \`"slack"\` to the \`WizardContext.iface\` union type so wizard sessions initiated from Slack are correctly keyed and routed

**\`prompts/BOOTSTRAP.md\`**
- The Connect section previously only listed Telegram and WhatsApp
- Add step-by-step conversational guidance for Telegram, Discord, and Slack: token acquisition, \`settings.json\` config, daemon restart — so Claude can walk users through any platform without them having to read external docs

**\`README.md\`**
- Add Slack to the feature overview, Getting Started description, and FAQ blurb

### Configuration

Slack requires two tokens in \`settings.json\` or environment:
\`\`\`json
"slack": {
  "botToken": "xoxb-...",
  "appToken": "xapp-...",
  "allowedUserIds": [],
  "listenChannels": []
}
\`\`\`
Or via environment variables: \`SLACK_BOT_TOKEN\` and \`SLACK_APP_TOKEN\`.

The Slack app must have Socket Mode enabled with \`connections:write\` scope on the app token, and \`chat:write\`, \`im:history\`, \`channels:history\` (at minimum) on the bot token.

## Validation

- [ ] \`claudeclaw start --trigger --slack\` starts daemon and connects Socket Mode
- [ ] \`/plugin\` in a Slack DM opens the plugin wizard
- [ ] Settings hot-reload picks up \`slack.botToken\` / \`slack.appToken\` changes
- [ ] SIGTERM cleanly closes the Slack WebSocket
- [ ] Fresh bootstrap: Claude walks through Discord/Slack token setup conversationally