### PR TITLE
Bulk merge Discord streaming, thread recovery, and Slack daemon wiring

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 <p align="center"><b>A lightweight, open-source OpenClaw version built into your Claude Code.</b></p>
 
-ClaudeClaw turns your Claude Code into a personal assistant that never sleeps. It runs as a background daemon, executing tasks on a schedule, responding to messages on Telegram and Discord, transcribing voice commands, and integrating with any service you need.
+ClaudeClaw turns your Claude Code into a personal assistant that never sleeps. It runs as a background daemon, executing tasks on a schedule, responding to messages on Telegram, Discord, and Slack, transcribing voice commands, and integrating with any service you need.
 
 > Note: Please don't use ClaudeClaw for hacking any bank system or doing any illegal activities. Thank you.
 
@@ -55,7 +55,7 @@ Then open a Claude Code session and run:
 ```
 /claudeclaw:start
 ```
-The setup wizard walks you through model, heartbeat, Telegram, Discord, and security, then your daemon is live with a web dashboard.
+The setup wizard walks you through model, heartbeat, Telegram, Discord, Slack, and security, then your daemon is live with a web dashboard.
 
 ### Contributor Note: Plugin Version Metadata
 
@@ -90,6 +90,7 @@ Docs-only and other non-shipped changes do not require these bumps.
 ### Communication
 - **Telegram:** Text, image, and voice support.
 - **Discord:** DMs, server mentions/replies, slash commands, voice messages, and image attachments.
+- **Slack:** Socket Mode bot — DMs, channel mentions, threads, voice messages, and file attachments. Configure `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` in your environment or `settings.json`.
 - **Time Awareness:** Message time prefixes help the agent understand delays and daily patterns.
 
 ### Multi-Session Threads (Discord)
@@ -113,7 +114,7 @@ See [docs/MULTI_SESSION.md](docs/MULTI_SESSION.md) for technical details.
   <summary><strong>Can ClaudeClaw do &lt;something&gt;?</strong></summary>
   <p>
     If Claude Code can do it, ClaudeClaw can do it too. ClaudeClaw adds cron jobs,
-    heartbeats, and Telegram/Discord bridges on top. You can also give your ClaudeClaw new
+    heartbeats, and Telegram/Discord/Slack bridges on top. You can also give your ClaudeClaw new
     skills and teach it custom workflows.
   </p>
 </details>

--- a/prompts/BOOTSTRAP.md
+++ b/prompts/BOOTSTRAP.md
@@ -76,13 +76,36 @@ Write it cleanly. Future-you will read this cold every session.
 
 ## Connect (Optional)
 
-Ask how they want to reach you:
+Ask how they want to reach you — one platform at a time, don't list them all upfront:
 
-- **Just here** — terminal/web chat only
-- **WhatsApp** — link their personal account (you'll show a QR code)
-- **Telegram** — set up a bot via BotFather
+- **Just here** — terminal/web chat only, no further setup
+- **Telegram** — bot via BotFather
+- **Discord** — bot via Discord Developer Portal
+- **Slack** — bot via Slack API with Socket Mode
 
-Guide them through whichever they pick.
+If they pick **Telegram**:
+1. Tell them to open [@BotFather](https://t.me/BotFather), send `/newbot`, follow the prompts, and paste the token here.
+2. Once you have the token, write it into `.claude/claudeclaw/settings.json` under `telegram.token`.
+3. Get their Telegram user ID (send them to [@userinfobot](https://t.me/userinfobot) or similar) and add it to `telegram.allowedUserIds`.
+4. Restart the daemon with `claudeclaw start --trigger`.
+
+If they pick **Discord**:
+1. Tell them to go to [discord.com/developers/applications](https://discord.com/developers/applications), create a new application, add a Bot, enable **Message Content Intent** and **Server Members Intent** under Privileged Gateway Intents, then copy the bot token.
+2. Write the token into `settings.json` under `discord.token`.
+3. Invite the bot to their server using the OAuth2 URL with `bot` + `applications.commands` scopes and `Send Messages`, `Read Message History`, `Add Reactions` permissions.
+4. Add their Discord user ID to `discord.allowedUserIds` (right-click their name in Discord → Copy User ID with Developer Mode on).
+5. Add the channel IDs they want the bot to listen in to `discord.listenChannels`.
+6. Restart with `claudeclaw start --trigger`.
+
+If they pick **Slack**:
+1. Tell them to go to [api.slack.com/apps](https://api.slack.com/apps), create a new app **from scratch**, enable **Socket Mode** (generates an App-Level Token — copy it, that's the `appToken`).
+2. Under **OAuth & Permissions**, add bot scopes: `chat:write`, `im:history`, `im:read`, `im:write`, `channels:history`, `channels:read`, `files:read`. Install the app to the workspace and copy the **Bot User OAuth Token** (that's the `botToken`).
+3. Under **Event Subscriptions**, enable events and subscribe to `message.im` and `message.channels` (or `app_mention` if they prefer mention-only in channels).
+4. Write both tokens into `settings.json` under `slack.botToken` and `slack.appToken`.
+5. Add their Slack member ID to `slack.allowedUserIds` (click profile → ⋮ → Copy member ID).
+6. Restart with `claudeclaw start --trigger`.
+
+After setup, send a test message from their phone to confirm the connection is live before moving on.
 
 ---
 

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -655,30 +655,25 @@ function makeDiscordStreamCallback(token: string, channelId: string): DiscordStr
     if (streamMsgId) scheduleEdit();
   };
 
-  const finalize = async (): Promise<void> => {
-    // Cancel any pending edit
-    if (editTimer) {
-      clearTimeout(editTimer);
-      editTimer = null;
-    }
-    // If placeholder was never posted, nothing to delete
-    if (!streamMsgId) return;
-    try {
-      await discordApi(
-        token,
-        "DELETE",
-        `/channels/${channelId}/messages/${streamMsgId}`,
-      );
-    } catch (err) {
-      debugLog(`Stream finalize delete failed: ${err instanceof Error ? err.message : err}`);
-    }
-  };
-
   const waitForStreamMsg = (): Promise<{ msgId: string } | null> => {
     if (streamMsgSettled) return Promise.resolve(streamMsgResult);
     return new Promise<{ msgId: string } | null>((resolve) => {
       streamMsgResolvers.push(resolve);
     });
+  };
+
+  const finalize = async (): Promise<void> => {
+    if (editTimer) { clearTimeout(editTimer); editTimer = null; }
+    // If no placeholder was ever triggered, nothing to clean up
+    if (!placeholderPosted) return;
+    // Wait for the in-flight POST to resolve (already done if streamMsgId is set)
+    const result = await waitForStreamMsg();
+    if (!result?.msgId) return;
+    try {
+      await discordApi(token, "DELETE", `/channels/${channelId}/messages/${result.msgId}`);
+    } catch (err) {
+      debugLog(`Stream finalize delete failed: ${err instanceof Error ? err.message : err}`);
+    }
   };
 
   return { onChunk, onToolEvent, finalize, waitForStreamMsg };
@@ -1011,9 +1006,6 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
     );
 
     if (streamCb) {
-      // Wait for the placeholder to be posted before deleting it (handles races where
-      // the tool event fires but the POST hasn't resolved yet).
-      await streamCb.waitForStreamMsg();
       await streamCb.finalize();
     }
 

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -566,6 +566,124 @@ async function respondToInteraction(
   );
 }
 
+// --- Discord streaming callback ---
+
+const STREAM_EDIT_INTERVAL_MS = 1500;
+const STREAM_CONTENT_MAX = DISCORD_MAX_MESSAGE_LEN - 10; // room for italic markers
+
+function escapeItalic(text: string): string {
+  return text.replace(/_/g, "\\_");
+}
+
+interface DiscordStreamCallbacks {
+  onChunk: (text: string) => void;
+  onToolEvent: (line: string) => void;
+  finalize: () => Promise<void>;
+  waitForStreamMsg: () => Promise<{ msgId: string } | null>;
+}
+
+function makeDiscordStreamCallback(token: string, channelId: string): DiscordStreamCallbacks {
+  let accumulated = "";
+  let streamMsgId: string | null = null;
+  let editTimer: ReturnType<typeof setTimeout> | null = null;
+  let placeholderPosted = false;
+
+  // Resolvers for waitForStreamMsg
+  let streamMsgResolvers: Array<(v: { msgId: string } | null) => void> = [];
+  let streamMsgSettled = false;
+  let streamMsgResult: { msgId: string } | null = null;
+
+  function notifyStreamMsgWaiters(result: { msgId: string } | null): void {
+    streamMsgSettled = true;
+    streamMsgResult = result;
+    for (const resolve of streamMsgResolvers) resolve(result);
+    streamMsgResolvers = [];
+  }
+
+  async function postPlaceholder(): Promise<void> {
+    if (placeholderPosted) return;
+    placeholderPosted = true;
+    try {
+      const msg = await discordApi<{ id: string }>(
+        token,
+        "POST",
+        `/channels/${channelId}/messages`,
+        { content: "⏳" },
+      );
+      streamMsgId = msg.id;
+      notifyStreamMsgWaiters({ msgId: msg.id });
+    } catch (err) {
+      console.error(`[Discord][stream] Failed to post placeholder: ${err instanceof Error ? err.message : err}`);
+      notifyStreamMsgWaiters(null);
+    }
+  }
+
+  function scheduleEdit(): void {
+    if (editTimer) return;
+    editTimer = setTimeout(async () => {
+      editTimer = null;
+      if (!streamMsgId) return;
+      const snippet = accumulated.slice(-STREAM_CONTENT_MAX);
+      const escaped = escapeItalic(snippet);
+      const content = `_${escaped}_`;
+      try {
+        await discordApi(
+          token,
+          "PATCH",
+          `/channels/${channelId}/messages/${streamMsgId}`,
+          { content },
+        );
+      } catch (err) {
+        debugLog(`Stream edit failed: ${err instanceof Error ? err.message : err}`);
+      }
+    }, STREAM_EDIT_INTERVAL_MS);
+  }
+
+  const onChunk = (text: string): void => {
+    accumulated += text;
+    if (streamMsgId) scheduleEdit();
+  };
+
+  const onToolEvent = (line: string): void => {
+    // Post the placeholder on the first tool event
+    if (!placeholderPosted) {
+      postPlaceholder().catch((err) =>
+        console.error(`[Discord][stream] postPlaceholder error: ${err instanceof Error ? err.message : err}`),
+      );
+    }
+    accumulated += (accumulated ? "\n" : "") + line;
+    if (streamMsgId) scheduleEdit();
+  };
+
+  const finalize = async (): Promise<void> => {
+    // Cancel any pending edit
+    if (editTimer) {
+      clearTimeout(editTimer);
+      editTimer = null;
+    }
+    // If placeholder was never posted, nothing to delete
+    if (!streamMsgId) return;
+    try {
+      await discordApi(
+        token,
+        "DELETE",
+        `/channels/${channelId}/messages/${streamMsgId}`,
+      );
+    } catch (err) {
+      debugLog(`Stream finalize delete failed: ${err instanceof Error ? err.message : err}`);
+    }
+  };
+
+  const waitForStreamMsg = (): Promise<{ msgId: string } | null> => {
+    if (streamMsgSettled) return Promise.resolve(streamMsgResult);
+    return new Promise<{ msgId: string } | null>((resolve) => {
+      streamMsgResolvers.push(resolve);
+    });
+  };
+
+  return { onChunk, onToolEvent, finalize, waitForStreamMsg };
+}
+
 // --- Message handler ---
 
 // Pending forwards: when Discord delivers a forward with empty content, hold it briefly
@@ -878,7 +996,26 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
         );
       }
     }
-    const result = await runUserMessage("discord", prefixedPrompt, sessionKey, threadInfo?.agentName);
+    let streamCb: DiscordStreamCallbacks | undefined;
+    if (config.streaming) {
+      streamCb = makeDiscordStreamCallback(config.token, channelId);
+    }
+
+    const result = await runUserMessage(
+      "discord",
+      prefixedPrompt,
+      sessionKey,
+      threadInfo?.agentName,
+      streamCb?.onChunk,
+      streamCb?.onToolEvent,
+    );
+
+    if (streamCb) {
+      // Wait for the placeholder to be posted before deleting it (handles races where
+      // the tool event fires but the POST hasn't resolved yet).
+      await streamCb.waitForStreamMsg();
+      await streamCb.finalize();
+    }
 
     if (result.exitCode !== 0) {
       await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -130,6 +130,10 @@ let readyGuildIds: Set<string> | null = null;
 // Track known thread channel IDs and their parent channel IDs for multi-session support
 const knownThreads = new Map<string, { parentId: string; agentName?: string }>();
 
+function isDiscordThreadType(type: number | undefined): boolean {
+  return type === 10 || type === 11 || type === 12;
+}
+
 // Upsert knownThreads, preserving any existing agentName when a new one is not supplied.
 // The agentName key is "<slug>-<threadId>" to guarantee uniqueness across threads whose
 // display names would otherwise map to the same slug.
@@ -385,36 +389,49 @@ async function rejoinThreads(
   }
 
   // GUILD_CREATE path
-  const config = getSettings().discord;
-  const listenInfra = infra.filter((ts) =>
-    config.listenChannels.includes(knownThreads.get(ts.threadId)?.parentId ?? ""),
-  );
   console.log(
-    `[Discord][REJOIN] trigger=GUILD_CREATE threads=${listenInfra.length} session=${sessionShort}`,
+    `[Discord][REJOIN] trigger=GUILD_CREATE sessions=${infra.length} session=${sessionShort}`,
   );
+  let rejoinedCount = 0;
+  let skippedNonThreads = 0;
 
   for (const ts of infra) {
     const isMember = memberThreadIds?.has(ts.threadId) ?? false;
     try {
+      let threadInfo = knownThreads.get(ts.threadId);
+      if (!threadInfo) {
+        const ch = await discordApi<{ parent_id?: string; name?: string; type?: number }>(token, "GET", `/channels/${ts.threadId}`);
+        if (!isDiscordThreadType(ch.type)) {
+          skippedNonThreads += 1;
+          debugLog(`[Discord][REJOIN] skip non-thread session ${ts.threadId} type=${ch.type ?? "unknown"}`);
+          continue;
+        }
+        if (!ch.parent_id) {
+          skippedNonThreads += 1;
+          debugLog(`[Discord][REJOIN] skip thread session ${ts.threadId} without parent_id`);
+          continue;
+        }
+        upsertThread(ts.threadId, ch.parent_id, ch.name);
+        threadInfo = knownThreads.get(ts.threadId);
+      }
+      if (!threadInfo) continue;
+
       if (!isMember) {
         // Not in GUILD_CREATE member list — force full rejoin to reset gateway subscription
         await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       }
       await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
+      rejoinedCount += 1;
       console.log(
         `[Discord][REJOIN] thread=${ts.threadId} GUILD_CREATE=${isMember ? "member" : "non-member"} rejoined`,
       );
-      if (!knownThreads.has(ts.threadId)) {
-        const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
-        if (ch.parent_id) knownThreads.set(ts.threadId, { parentId: ch.parent_id });
-      }
     } catch (err) {
       console.error(`[Discord] Failed to rejoin thread ${ts.threadId}: ${err}`);
     }
   }
 
   if (infra.length > 0) {
-    console.log(`[Discord][REJOIN] done. knownThreads size=${knownThreads.size}`);
+    console.log(`[Discord][REJOIN] done. rejoined=${rejoinedCount} skippedNonThreads=${skippedNonThreads} knownThreads size=${knownThreads.size}`);
   }
 }
 
@@ -732,8 +749,8 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
     const persisted = await peekThreadSession(channelId);
     if (persisted) {
       try {
-        const ch = await discordApi<{ parent_id?: string; name?: string }>(config.token, "GET", `/channels/${channelId}`);
-        if (ch.parent_id) {
+        const ch = await discordApi<{ parent_id?: string; name?: string; type?: number }>(config.token, "GET", `/channels/${channelId}`);
+        if (isDiscordThreadType(ch.type) && ch.parent_id) {
           upsertThread(channelId, ch.parent_id, ch.name);
           debugLog(`Thread recovered from sessions.json: ${channelId} (parent: ${ch.parent_id} name: ${ch.name ?? "unknown"})`);
         }
@@ -828,6 +845,7 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
 
   // Typing indicator loop (Discord typing lasts 10s, fire every 8s)
   const typingInterval = setInterval(() => sendTyping(config.token, channelId), 8000);
+  let streamCb: DiscordStreamCallbacks | undefined;
 
   try {
     await sendTyping(config.token, channelId);
@@ -1021,23 +1039,27 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
         );
       }
     }
-    let streamCb: DiscordStreamCallbacks | undefined;
     if (config.streaming) {
       streamCb = makeDiscordStreamCallback(config.token, channelId);
     }
 
-    const result = await runUserMessage(
-      "discord",
-      prefixedPrompt,
-      sessionKey,
-      threadInfo?.agentName,
-      streamCb?.onChunk,
-      streamCb?.onToolEvent,
-    );
-
-    if (streamCb) {
-      await streamCb.finalize();
-    }
+    const result = await (async () => {
+      try {
+        return await runUserMessage(
+          "discord",
+          prefixedPrompt,
+          sessionKey,
+          threadInfo?.agentName,
+          streamCb?.onChunk,
+          streamCb?.onToolEvent,
+        );
+      } finally {
+        if (streamCb) {
+          await streamCb.finalize();
+          streamCb = undefined;
+        }
+      }
+    })();
 
     if (result.exitCode !== 0) {
       await sendMessage(config.token, channelId, `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`);
@@ -1060,6 +1082,9 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
     console.error(`[Discord] Error for ${label}: ${errMsg}`);
     await sendMessage(config.token, channelId, `Error: ${errMsg}`);
   } finally {
+    if (streamCb) {
+      await streamCb.finalize();
+    }
     clearInterval(typingInterval);
   }
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -641,6 +641,11 @@ function makeDiscordStreamCallback(token: string, channelId: string): DiscordStr
 
   const onChunk = (text: string): void => {
     accumulated += text;
+    if (!placeholderPosted) {
+      postPlaceholder().catch((err) =>
+        console.error(`[Discord][stream] postPlaceholder error: ${err instanceof Error ? err.message : err}`),
+      );
+    }
     if (streamMsgId) scheduleEdit();
   };
 

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -400,18 +400,14 @@ async function rejoinThreads(
         // Not in GUILD_CREATE member list — force full rejoin to reset gateway subscription
         await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       }
-      const putRes = await fetch(`${DISCORD_API}/channels/${ts.threadId}/thread-members/@me`, {
-        method: "PUT",
-        headers: { Authorization: `Bot ${token}` },
-      });
+      await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
       console.log(
-        `[Discord][REJOIN] thread=${ts.threadId} GUILD_CREATE=${isMember ? "member" : "non-member"} PUT=${putRes.status}`,
+        `[Discord][REJOIN] thread=${ts.threadId} GUILD_CREATE=${isMember ? "member" : "non-member"} rejoined`,
       );
       if (!knownThreads.has(ts.threadId)) {
         const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
         if (ch.parent_id) knownThreads.set(ts.threadId, { parentId: ch.parent_id });
       }
-      console.log(`[Discord] Rejoined thread: ${ts.threadId}`);
     } catch (err) {
       console.error(`[Discord] Failed to rejoin thread ${ts.threadId}: ${err}`);
     }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -365,31 +365,60 @@ async function uploadImageMessage(
 }
 
 // --- Thread rejoin helper ---
-async function rejoinThreads(token: string): Promise<void> {
+// trigger='RESUMED': skip all REST calls — session is intact, delivery should be live.
+// trigger='GUILD_CREATE': PUT-only for threads listed as member=yes; DELETE+PUT for others.
+async function rejoinThreads(
+  token: string,
+  trigger: "GUILD_CREATE" | "RESUMED",
+  memberThreadIds?: Set<string>,
+): Promise<void> {
   const threadSessions = await listThreadSessions();
-  let rejoinedCount = 0;
-  for (const ts of threadSessions) {
-    // Skip non-snowflake keys (e.g. job names); they are not Discord channel IDs.
-    if (!/^\d{17,19}$/.test(ts.threadId)) continue;
+  const sessionShort = gatewaySessionId?.slice(0, 8) ?? "?";
+  const infra = threadSessions.filter((ts) => /^\d{17,19}$/.test(ts.threadId));
+
+  if (trigger === "RESUMED") {
+    console.log(`[Discord][REJOIN] trigger=RESUMED threads=${infra.length} session=${sessionShort}`);
+    for (const ts of infra) {
+      console.log(`[Discord][REJOIN] thread=${ts.threadId} RESUMED=skip (session intact)`);
+    }
+    return;
+  }
+
+  // GUILD_CREATE path
+  const config = getSettings().discord;
+  const listenInfra = infra.filter((ts) =>
+    config.listenChannels.includes(knownThreads.get(ts.threadId)?.parentId ?? ""),
+  );
+  console.log(
+    `[Discord][REJOIN] trigger=GUILD_CREATE threads=${listenInfra.length} session=${sessionShort}`,
+  );
+
+  for (const ts of infra) {
+    const isMember = memberThreadIds?.has(ts.threadId) ?? false;
     try {
-      const ch = await discordApi<{ parent_id?: string; name?: string; type?: number }>(token, "GET", `/channels/${ts.threadId}`);
-      const isThread = ch.type === 10 || ch.type === 11 || ch.type === 12;
-      if (!isThread) continue;
-
-      if (ch.parent_id && !knownThreads.has(ts.threadId)) {
-        upsertThread(ts.threadId, ch.parent_id, ch.name);
+      if (!isMember) {
+        // Not in GUILD_CREATE member list — force full rejoin to reset gateway subscription
+        await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
       }
-
-      await discordApi(token, "DELETE", `/channels/${ts.threadId}/thread-members/@me`).catch(() => {});
-      await discordApi(token, "PUT", `/channels/${ts.threadId}/thread-members/@me`);
-      rejoinedCount += 1;
+      const putRes = await fetch(`${DISCORD_API}/channels/${ts.threadId}/thread-members/@me`, {
+        method: "PUT",
+        headers: { Authorization: `Bot ${token}` },
+      });
+      console.log(
+        `[Discord][REJOIN] thread=${ts.threadId} GUILD_CREATE=${isMember ? "member" : "non-member"} PUT=${putRes.status}`,
+      );
+      if (!knownThreads.has(ts.threadId)) {
+        const ch = await discordApi<{ parent_id?: string }>(token, "GET", `/channels/${ts.threadId}`);
+        if (ch.parent_id) knownThreads.set(ts.threadId, { parentId: ch.parent_id });
+      }
       console.log(`[Discord] Rejoined thread: ${ts.threadId}`);
     } catch (err) {
       console.error(`[Discord] Failed to rejoin thread ${ts.threadId}: ${err}`);
     }
   }
-  if (rejoinedCount > 0) {
-    console.log(`[Discord] Rejoined ${rejoinedCount} thread(s) from sessions.json`);
+
+  if (infra.length > 0) {
+    console.log(`[Discord][REJOIN] done. knownThreads size=${knownThreads.size}`);
   }
 }
 
@@ -1382,8 +1411,8 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       break;
 
     case "RESUMED":
-      console.log("[Discord] Session resumed — rejoining threads");
-      rejoinThreads(token).catch((err) =>
+      console.log("[Discord] Session resumed — skipping REST rejoin (session intact)");
+      rejoinThreads(token, "RESUMED").catch((err) =>
         console.error(`[Discord] Failed to rejoin threads on RESUMED: ${err}`),
       );
       break;
@@ -1401,25 +1430,31 @@ function handleDispatch(token: string, eventName: string, data: any): void {
       );
       break;
 
-    case "GUILD_CREATE":
-      // Cache active threads for multi-session support
+    case "GUILD_CREATE": {
+      // Cache active threads and collect member status for targeted rejoin
+      const memberThreadIds = new Set<string>();
       if (data.threads) {
         console.log(`[Discord] GUILD_CREATE: ${data.threads.length} active threads in guild ${data.id}`);
         for (const thread of data.threads) {
           upsertThread(thread.id, thread.parent_id, thread.name);
-          console.log(`[Discord]   thread: ${thread.id} name="${thread.name}" parent=${thread.parent_id}`);
+          const memberStatus = thread.member ? "yes" : "no";
+          console.log(
+            `[Discord]   thread: ${thread.id} name="${thread.name}" parent=${thread.parent_id} member=${memberStatus}`,
+          );
+          if (thread.member) memberThreadIds.add(thread.id);
         }
       } else {
         console.log(`[Discord] GUILD_CREATE: no active threads in guild ${data.id}`);
       }
-      // Rejoin all known threads from sessions.json so gateway sends MESSAGE_CREATE
-      rejoinThreads(token).catch((err) =>
+      // Rejoin threads: PUT-only for member=yes, DELETE+PUT for others
+      rejoinThreads(token, "GUILD_CREATE", memberThreadIds).catch((err) =>
         console.error(`[Discord] Failed to rejoin threads: ${err}`),
       );
       handleGuildCreate(token, data).catch((err) =>
         console.error(`[Discord] GUILD_CREATE unhandled: ${err}`),
       );
       break;
+    }
 
     case "THREAD_CREATE":
       if (data.id && data.parent_id) {
@@ -1491,24 +1526,23 @@ function handleGatewayPayload(token: string, payload: GatewayPayload): void {
       break;
 
     case GatewayOp.RECONNECT:
-      debugLog("Gateway requested reconnect");
+      console.log("[Discord][GW] op=RECONNECT — gateway requested reconnect");
       ws?.close(4000, "Reconnect requested");
       break;
 
     case GatewayOp.INVALID_SESSION: {
       const resumable = payload.d;
-      debugLog(`Invalid session, resumable=${resumable}`);
-      if (!resumable) {
+      console.log(`[Discord][GW] op=INVALID_SESSION resumable=${resumable}`);
+      if (resumable && gatewaySessionId) {
+        setTimeout(() => sendResume(token), 1000 + Math.random() * 4000);
+      } else {
+        // Close the ws so onclose opens a fresh connection and sends IDENTIFY from scratch.
+        // Sending IDENTIFY on the same ws that just failed RESUME causes Discord to not
+        // restore thread message delivery for the new session.
         gatewaySessionId = null;
         lastSequence = null;
+        ws?.close(4000, "Non-resumable INVALID_SESSION — reconnecting fresh");
       }
-      setTimeout(() => {
-        if (resumable && gatewaySessionId) {
-          sendResume(token);
-        } else {
-          sendIdentify(token);
-        }
-      }, 1000 + Math.random() * 4000);
       break;
     }
 

--- a/src/commands/plugin-wizard.ts
+++ b/src/commands/plugin-wizard.ts
@@ -7,7 +7,7 @@ const WIZARD_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const TRIGGER_COMMANDS = new Set(["/plugin", "/claudeclaw:plugin"]);
 
 export interface WizardContext {
-  iface: "discord" | "telegram" | "web";
+  iface: "discord" | "telegram" | "web" | "slack";
   scopeId: string;
   agentName?: string; // recorded for Phase 2 per-agent scoping
 }

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -5,6 +5,7 @@ import { extractErrorDetail } from "../messaging";
 import { listThreadSessions, peekThreadSession, removeThreadSession } from "../sessionManager";
 import { transcribeAudioToText } from "../whisper";
 import { resolveSkillPrompt } from "../skills";
+import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 import { mkdir, realpath } from "node:fs/promises";
 import { extname, join, resolve, isAbsolute, sep } from "node:path";
 import { existsSync } from "node:fs";
@@ -972,6 +973,15 @@ async function handleMessage(event: SlackMessage): Promise<void> {
           console.error(`[Slack] Failed to download doc: ${err instanceof Error ? err.message : err}`);
         }
       }
+    }
+
+    // Plugin wizard intercept — /plugin and /claudeclaw:plugin are handled here, not by Claude
+    const wizardCtx = { iface: "slack" as const, scopeId: channelId };
+    const firstWord = cleanText.trim().split(/\s+/, 1)[0].toLowerCase();
+    if ((cleanText.trim().startsWith("/") && isWizardTrigger(firstWord)) || hasActiveWizard(wizardCtx)) {
+      const reply = await handleWizardInput(wizardCtx, cleanText.trim());
+      await sendMessage(config.botToken, channelId, reply, replyThreadTs);
+      return;
     }
 
     // Skill routing

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -219,6 +219,7 @@ export async function start(args: string[] = []) {
   let hasTriggerFlag = false;
   let telegramFlag = false;
   let discordFlag = false;
+  let slackFlag = false;
   let debugFlag = false;
   let webFlag = false;
   let replaceExistingFlag = false;
@@ -235,6 +236,8 @@ export async function start(args: string[] = []) {
       telegramFlag = true;
     } else if (arg === "--discord") {
       discordFlag = true;
+    } else if (arg === "--slack") {
+      slackFlag = true;
     } else if (arg === "--debug") {
       debugFlag = true;
     } else if (arg === "--web") {
@@ -260,7 +263,7 @@ export async function start(args: string[] = []) {
   }
   const payload = payloadParts.join(" ").trim();
   if (hasPromptFlag && !payload) {
-    console.error("Usage: claudeclaw start --prompt <prompt> [--trigger] [--telegram] [--discord] [--debug] [--web] [--web-port <port>] [--replace-existing]");
+    console.error("Usage: claudeclaw start --prompt <prompt> [--trigger] [--telegram] [--discord] [--slack] [--debug] [--web] [--web-port <port>] [--replace-existing]");
     process.exit(1);
   }
   if (!hasPromptFlag && payload) {
@@ -273,6 +276,10 @@ export async function start(args: string[] = []) {
   }
   if (discordFlag && !hasTriggerFlag) {
     console.error("`--discord` with `start` requires `--trigger`.");
+    process.exit(1);
+  }
+  if (slackFlag && !hasTriggerFlag) {
+    console.error("`--slack` with `start` requires `--trigger`.");
     process.exit(1);
   }
   if (hasPromptFlag && !hasTriggerFlag && (webFlag || webPortFlag !== null)) {
@@ -337,6 +344,7 @@ export async function start(args: string[] = []) {
   await writePidFile();
   let web: WebServerHandle | null = null;
   let discordStopGateway: (() => void) | null = null;
+  let slackStopFn: (() => void) | null = null;
 
   // Plugin system — initialize before gateway start
   const pluginManager = new PluginManager(process.cwd());
@@ -349,6 +357,7 @@ export async function start(args: string[] = []) {
     await pluginManager.stopServices();
     setPluginManager(null);
     if (discordStopGateway) discordStopGateway();
+    if (slackStopFn) slackStopFn();
     if (web) web.stop();
     await teardownStatusline();
     await cleanupPidFile();
@@ -434,6 +443,31 @@ export async function start(args: string[] = []) {
 
   await initDiscord(currentSettings.discord.token);
   if (!discordToken) console.log("  Discord: not configured");
+
+  // --- Slack ---
+  let slackSendToUser: ((userId: string, text: string) => Promise<void>) | null = null;
+  let slackBotToken = "";
+
+  async function initSlack(botToken: string, appToken: string) {
+    if (botToken && appToken && botToken !== slackBotToken) {
+      const { startSlack, sendMessageToUser: slackSend, stopSlack } = await import("./slack");
+      if (slackBotToken) stopSlack();
+      startSlack(debugFlag);
+      slackStopFn = stopSlack;
+      slackSendToUser = (userId, text) => slackSend(botToken, userId, text);
+      slackBotToken = botToken;
+      console.log(`[${ts()}] Slack: enabled`);
+    } else if ((!botToken || !appToken) && slackBotToken) {
+      if (slackStopFn) slackStopFn();
+      slackStopFn = null;
+      slackSendToUser = null;
+      slackBotToken = "";
+      console.log(`[${ts()}] Slack: disabled`);
+    }
+  }
+
+  await initSlack(currentSettings.slack.botToken, currentSettings.slack.appToken);
+  if (!slackBotToken) console.log("  Slack: not configured");
 
   // Wire channel senders into plugin runtime so plugins can send messages
   if (pluginManager.hasPlugins) {
@@ -738,6 +772,9 @@ export async function start(args: string[] = []) {
 
       // Discord changes
       await initDiscord(newSettings.discord.token);
+
+      // Slack changes
+      await initSlack(newSettings.slack.botToken, newSettings.slack.appToken);
     } catch (err) {
       console.error(`[${ts()}] Hot-reload error:`, err);
     }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -447,21 +447,24 @@ export async function start(args: string[] = []) {
   // --- Slack ---
   let slackSendToUser: ((userId: string, text: string) => Promise<void>) | null = null;
   let slackBotToken = "";
+  let slackAppToken = "";
 
   async function initSlack(botToken: string, appToken: string) {
-    if (botToken && appToken && botToken !== slackBotToken) {
+    if (botToken && appToken && (botToken !== slackBotToken || appToken !== slackAppToken)) {
       const { startSlack, sendMessageToUser: slackSend, stopSlack } = await import("./slack");
-      if (slackBotToken) stopSlack();
+      if (slackBotToken || slackAppToken) stopSlack();
       startSlack(debugFlag);
       slackStopFn = stopSlack;
       slackSendToUser = (userId, text) => slackSend(botToken, userId, text);
       slackBotToken = botToken;
+      slackAppToken = appToken;
       console.log(`[${ts()}] Slack: enabled`);
-    } else if ((!botToken || !appToken) && slackBotToken) {
+    } else if ((!botToken || !appToken) && (slackBotToken || slackAppToken)) {
       if (slackStopFn) slackStopFn();
       slackStopFn = null;
       slackSendToUser = null;
       slackBotToken = "";
+      slackAppToken = "";
       console.log(`[${ts()}] Slack: disabled`);
     }
   }
@@ -481,6 +484,10 @@ export async function start(args: string[] = []) {
         sendMessageDiscord: discordSendToUser
           ? (userId: string, text: string) => discordSendToUser!(userId, text)
           : () => Promise.resolve(),
+      },
+      slack: {
+        sendMessageSlack: (userId: string, text: string) =>
+          slackSendToUser ? slackSendToUser(userId, text) : Promise.resolve(),
       },
     });
     await pluginManager.startServices();
@@ -619,6 +626,18 @@ export async function start(args: string[] = []) {
     }
   }
 
+  function forwardToSlack(label: string, result: { exitCode: number; stdout: string; stderr: string }) {
+    if (!slackSendToUser || currentSettings.slack.allowedUserIds.length === 0) return;
+    const text = result.exitCode === 0
+      ? `${label ? `[${label}]\n` : ""}${result.stdout || "(empty)"}`
+      : `${label ? `[${label}] ` : ""}error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown"}`;
+    for (const userId of currentSettings.slack.allowedUserIds) {
+      slackSendToUser(userId, text).catch((err) =>
+        console.error(`[Slack] Failed to forward to ${userId}: ${err}`)
+      );
+    }
+  }
+
   // --- Heartbeat scheduling ---
   function scheduleHeartbeat() {
     if (heartbeatTimer) clearTimeout(heartbeatTimer);
@@ -707,6 +726,7 @@ export async function start(args: string[] = []) {
     console.log(triggerResult.stdout);
     if (telegramFlag) forwardToTelegram("", triggerResult);
     if (discordFlag) forwardToDiscord("", triggerResult);
+    if (slackFlag) forwardToSlack("", triggerResult);
     if (triggerResult.exitCode !== 0) {
       console.error(`[${ts()}] Startup trigger failed (exit ${triggerResult.exitCode}). Daemon will continue running.`);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,7 +79,7 @@ const DEFAULT_SETTINGS: Settings = {
     forwardToTelegram: true,
   },
   telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true, dmIsolation: "shared" },
-  discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [] },
+  discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [], streaming: false },
   slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
@@ -130,6 +130,7 @@ export interface DiscordConfig {
   listenGuilds: string[]; // Guild IDs where bot responds to all messages in any channel/thread
   channelNames?: Record<string, string>; // channelId -> friendly name for system prompt context
   imageOutputRoots: string[]; // Absolute path prefixes from which image uploads are permitted
+  streaming?: boolean; // When true, POST a live preview while Claude is working. Default: false.
 }
 
 export interface SlackConfig {
@@ -363,6 +364,7 @@ function parseSettings(
       imageOutputRoots: Array.isArray(raw.discord?.imageOutputRoots)
         ? raw.discord.imageOutputRoots.filter((r: unknown) => typeof r === "string" && isAbsolute(r))
         : [],
+      streaming: raw.discord?.streaming === true,
     },
     slack: {
       botToken: process.env.SLACK_BOT_TOKEN?.trim() || (typeof raw.slack?.botToken === "string" ? raw.slack.botToken.trim() : ""),


### PR DESCRIPTION
## Summary

Cherry-picked and combined the merge-ready parts of:

- #202 by @squirblej: Discord incremental response preview streaming
- #203 by @squirblej: Discord thread delivery recovery on gateway reconnects
- #208 by @TerrysPOV: Slack daemon startup wiring, Slack plugin wizard routing, and connect-flow docs

The original commits are preserved in the branch history so author attribution is retained. I skipped the stale individual version bump commits from #202/#203 and kept the combined plugin/marketplace version bump to 1.0.35 from #208.

## Maintainer fixes

- Completed the new `start --trigger --slack` path so startup trigger output is forwarded to configured Slack allowed users.
- Restart Slack on hot reload when either `slack.botToken` or `slack.appToken` changes.
- Exposed `runtime.channel.slack.sendMessageSlack` for plugins and kept it hot-reload aware.

## Not included

- #185 is intentionally not included. It is broad security hardening, currently conflicts with master, and the branch contains committed conflict markers in `.claude-plugin/marketplace.json` and `src/commands/telegram.ts`, so it should be handled as a separate security PR after cleanup.

## Verification

- `git diff --check origin/master...HEAD`
- `rg -n "<<<<<<<|=======|>>>>>>>" .` returned no matches
- `bun test` (96 tests)
- `bunx tsc --noEmit --pretty false`
