### PR TITLE
feat(web): surface tool activity in /api/chat SSE stream

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -474,13 +474,16 @@ export async function start(args: string[] = []) {
             updateState();
             console.log(`[${ts()}] Jobs reloaded from Web UI`);
           },
-          onChat: async (message, onChunk, onUnblock) => {
+          onChat: async (message, sinks) => {
             const wizardCtx = { iface: "web" as const, scopeId: "default" };
             if (isWizardTrigger(message) || hasActiveWizard(wizardCtx)) {
-              onChunk(await handleWizardInput(wizardCtx, message));
+              sinks.onChunk(await handleWizardInput(wizardCtx, message));
               return;
             }
-            await streamUserMessage("chat", message, onChunk, onUnblock);
+            await streamUserMessage("chat", message, sinks.onChunk, sinks.onUnblock, {
+              onToolUse: sinks.onToolUse,
+              onToolResult: sinks.onToolResult,
+            });
           },
         });
       } catch (err) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -794,11 +794,26 @@ export async function run(
   return enqueue(() => execClaude(name, prompt, threadId, modelOverride, timeoutMs, agentName), threadId);
 }
 
+/**
+ * Optional sinks for structured stream-json events. UIs that render tool
+ * activity (HQ chat, etc.) wire `onToolUse` / `onToolResult`; CLI consumers
+ * that only care about text leave them undefined.
+ */
+export interface StreamToolSinks {
+  onToolUse?: (toolUseId: string, name: string, input: unknown) => void;
+  onToolResult?: (
+    toolUseId: string,
+    output: unknown,
+    opts?: { isError?: boolean },
+  ) => void;
+}
+
 async function streamClaude(
   name: string,
   prompt: string,
   onChunk: (text: string) => void,
-  onUnblock: () => void
+  onUnblock: () => void,
+  toolSinks?: StreamToolSinks,
 ): Promise<void> {
   await mkdir(LOGS_DIR, { recursive: true });
 
@@ -879,7 +894,13 @@ async function streamClaude(
           }
         } else if (event.type === "assistant") {
           // Text and tool_use blocks from the assistant
-          type ContentBlock = { type: string; text?: string; id?: string; name?: string; input?: Record<string, unknown> };
+          type ContentBlock = {
+            type: string;
+            text?: string;
+            id?: string;
+            name?: string;
+            input?: Record<string, unknown>;
+          };
           const msg = event.message as { content?: ContentBlock[] } | undefined;
           const blocks = msg?.content ?? [];
           let hasActivity = false;
@@ -889,12 +910,50 @@ async function streamClaude(
               textEmitted = true;
               hasActivity = true;
             } else if (block.type === "tool_use") {
+              if (toolSinks?.onToolUse && block.id && block.name) {
+                try {
+                  toolSinks.onToolUse(block.id, block.name, block.input ?? {});
+                } catch {}
+              }
               hasActivity = true;
             }
           }
           if (hasActivity) maybeUnblock();
+        } else if (event.type === "user") {
+          // tool_result blocks come back as user-role messages — Claude feeding
+          // each tool's output into the next turn. Forward them so UIs can
+          // close out the matching tool_use card.
+          type ResultBlock = {
+            type: string;
+            tool_use_id?: string;
+            content?: unknown;
+            is_error?: boolean;
+          };
+          const msg = event.message as { content?: ResultBlock[] } | undefined;
+          const blocks = msg?.content ?? [];
+          for (const block of blocks) {
+            if (block.type === "tool_result" && block.tool_use_id) {
+              if (toolSinks?.onToolResult) {
+                try {
+                  toolSinks.onToolResult(block.tool_use_id, block.content, {
+                    isError: block.is_error === true,
+                  });
+                } catch {}
+              }
+            }
+          }
         } else if (event.type === "tool_use") {
           // Top-level tool_use event (some stream-json versions) — unblock the UI
+          if (toolSinks?.onToolUse) {
+            const id = event.id as string | undefined;
+            const toolName = event.name as string | undefined;
+            const input = event.input;
+            if (id && toolName) {
+              try {
+                toolSinks.onToolUse(id, toolName, input ?? {});
+              } catch {}
+            }
+          }
           maybeUnblock();
         } else if (event.type === "result") {
           // Final result event — emit text as fallback if no assistant text was seen
@@ -919,9 +978,12 @@ export async function streamUserMessage(
   name: string,
   prompt: string,
   onChunk: (text: string) => void,
-  onUnblock: () => void
+  onUnblock: () => void,
+  toolSinks?: StreamToolSinks,
 ): Promise<void> {
-  return enqueue(() => streamClaude(name, prefixUserMessageWithClock(prompt), onChunk, onUnblock));
+  return enqueue(() =>
+    streamClaude(name, prefixUserMessageWithClock(prompt), onChunk, onUnblock, toolSinks),
+  );
 }
 
 function prefixUserMessageWithClock(prompt: string): string {

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,2 +1,7 @@
 export { startWebUi } from "./server";
-export type { StartWebUiOptions, WebServerHandle, WebSnapshot } from "./types";
+export type {
+  ChatStreamSinks,
+  StartWebUiOptions,
+  WebServerHandle,
+  WebSnapshot,
+} from "./types";

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -1,6 +1,6 @@
 import { htmlPage } from "./page/html";
 import { clampInt, json } from "./http";
-import type { StartWebUiOptions, WebServerHandle } from "./types";
+import type { ChatStreamSinks, StartWebUiOptions, WebServerHandle } from "./types";
 import { buildState, buildTechnicalInfo, sanitizeSettings } from "./services/state";
 import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/settings";
 import { createQuickJob, deleteJob } from "./services/jobs";
@@ -163,12 +163,21 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
               const send = (data: object) => {
                 controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
               };
+              const sinks: ChatStreamSinks = {
+                onChunk: (chunk) => send({ type: "chunk", text: chunk }),
+                onUnblock: () => send({ type: "unblock" }),
+                onToolUse: (toolUseId, name, input) =>
+                  send({ type: "tool_use", id: toolUseId, name, input }),
+                onToolResult: (toolUseId, output, opts) =>
+                  send({
+                    type: "tool_result",
+                    id: toolUseId,
+                    output,
+                    isError: opts?.isError === true,
+                  }),
+              };
               try {
-                await onChat(
-                  message,
-                  (chunk) => send({ type: "chunk", text: chunk }),
-                  () => send({ type: "unblock" })
-                );
+                await invokeOnChat(onChat, message, sinks);
                 send({ type: "done" });
               } catch (err) {
                 send({ type: "error", message: String(err) });
@@ -200,4 +209,28 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
     host: opts.host,
     port: server.port,
   };
+}
+
+/**
+ * Bridges the new sinks-object onChat signature with the legacy
+ * `(message, onChunk, onUnblock)` form. Looks at `Function.length` to decide
+ * which form the consumer registered — three positional params means legacy.
+ */
+async function invokeOnChat(
+  fn: NonNullable<StartWebUiOptions["onChat"]>,
+  message: string,
+  sinks: ChatStreamSinks,
+): Promise<void> {
+  if (fn.length >= 3) {
+    // Legacy: (message, onChunk, onUnblock) — accepted at runtime so older
+    // host code still works; public type only advertises the sinks form.
+    const legacy = fn as unknown as (
+      message: string,
+      onChunk: (text: string) => void,
+      onUnblock: () => void,
+    ) => Promise<void>;
+    await legacy(message, sinks.onChunk, sinks.onUnblock);
+    return;
+  }
+  await fn(message, sinks);
 }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -15,6 +15,23 @@ export interface WebServerHandle {
   port: number;
 }
 
+/**
+ * Sinks the `/api/chat` SSE handler hands to `onChat`. Consumers that only
+ * care about the assistant's visible reply use `onChunk` + `onUnblock`; the
+ * tool sinks are optional and let UIs render structured tool activity (name,
+ * arguments, result) alongside the text stream.
+ */
+export interface ChatStreamSinks {
+  onChunk: (text: string) => void;
+  onUnblock: () => void;
+  onToolUse?: (toolUseId: string, name: string, input: unknown) => void;
+  onToolResult?: (
+    toolUseId: string,
+    output: unknown,
+    opts?: { isError?: boolean },
+  ) => void;
+}
+
 export interface StartWebUiOptions {
   host: string;
   port: number;
@@ -27,9 +44,17 @@ export interface StartWebUiOptions {
     excludeWindows?: Array<{ days?: number[]; start: string; end: string }>;
   }) => void | Promise<void>;
   onJobsChanged?: () => void | Promise<void>;
-  onChat?: (
-    message: string,
-    onChunk: (text: string) => void,
-    onUnblock: () => void
-  ) => Promise<void>;
+  /**
+   * Invoked once per POST /api/chat. The implementation pushes text deltas
+   * through `sinks.onChunk`, signals "first activity" through
+   * `sinks.onUnblock`, and (optionally) surfaces structured tool activity
+   * through `sinks.onToolUse` / `sinks.onToolResult` so the SSE stream can
+   * carry per-tool start/end events for clients that render them.
+   *
+   * The legacy three-argument form `(message, onChunk, onUnblock)` is
+   * still accepted at runtime for backwards compatibility (see
+   * `invokeOnChat()` in `ui/server.ts`), but is no longer in the public
+   * type — new code should use the sinks form.
+   */
+  onChat?: (message: string, sinks: ChatStreamSinks) => Promise<void>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,2 +1,7 @@
 export { startWebUi } from "./ui";
-export type { StartWebUiOptions, WebServerHandle, WebSnapshot } from "./ui";
+export type {
+  ChatStreamSinks,
+  StartWebUiOptions,
+  WebServerHandle,
+  WebSnapshot,
+} from "./ui";


### PR DESCRIPTION
## Summary

The web UI's `/api/chat` SSE handler previously forwarded only the assistant's text deltas (`chunk`) plus a generic `unblock` pulse. The runner already parses `tool_use` blocks from the underlying `claude -p --output-format stream-json` output — it just uses them internally to fire `maybeUnblock()` and then drops them. That makes it impossible for downstream UIs (e.g. an embedded chat panel that wants per-tool activity cards) to render anything more specific than "the assistant is doing… something".

This PR lifts those events through to the SSE consumer without touching how text is streamed today.

## What changes

**Two new SSE event types** on `/api/chat`, on top of the existing `chunk` / `unblock` / `done` / `error`:

```
event: tool_use
data: { "type":"tool_use", "id":"toolu_...", "name":"Bash", "input":{...} }

event: tool_result
data: { "type":"tool_result", "id":"toolu_...", "output":<string|array>, "isError":false }
```

`id` is the stream-json `tool_use_id`, stable across the pair, so a client can match each `tool_result` to its `tool_use` to render a single "spinner → green/red" card with name + arguments + result.

**`runner.ts`** — `streamClaude()` and `streamUserMessage()` accept an optional `StreamToolSinks` object (`onToolUse`, `onToolResult`). The stream-json parser forwards each `tool_use` block from `assistant` events and each `tool_result` block from `user` events. Callers that don't supply sinks see zero behavioural change.

**`ui/types.ts`** — new `ChatStreamSinks` interface; `StartWebUiOptions.onChat` now takes `(message, sinks)`. The legacy three-arg form `(message, onChunk, onUnblock)` is still accepted at runtime through a `Function.length` check in `invokeOnChat()` (`ui/server.ts`), so existing hosts that haven't migrated their `onChat` keep working.

**`commands/start.ts`** — `onChat` switched to the sinks form and passes the new callbacks through to `streamUserMessage`.

## Verified

- `bunx tsc --noEmit` — only the pre-existing unrelated errors in `whisper.ts` / `bun-types` / DOM lib remain; no new errors introduced.
- Live smoke test against a patched daemon on port 4634 (live daemon on 4632 was untouched). Full captured stream:

```
$ curl -sN -X POST http://127.0.0.1:4634/api/chat \
    -H 'content-type: application/json' \
    -d '{"message":"Use the Bash tool to run `ls`, then summarise."}'

data: {"type":"tool_use","id":"toolu_012yAcr6e8EdGPcMiNRRcLL4","name":"Bash","input":{"command":"ls","description":"List files in current directory"}}

data: {"type":"unblock"}

data: {"type":"tool_result","id":"toolu_012yAcr6e8EdGPcMiNRRcLL4","output":"bun.lock\nCLAUDE.md\ncommands\ndocs\nhooks\nimages\nLICENSE\nMULTI_SESSION_SPEC.md\nnode_modules\npackage.json\nprompts\nREADME.md\nscripts\nskills\nsrc\nTASK.md\ntsconfig.json","isError":false}

data: {"type":"chunk","text":"standard bun/TS project layout — source in `src/`, plus commands, hooks, skills, docs, and a couple of spec/task markdown files at the root."}

data: {"type":"done"}
```

A baseline curl against an unpatched daemon for the same prompt only yields `chunk` + `unblock` + `done` — no tool info — confirming the change is purely additive.

## Compatibility

- **Pure addition on the wire.** Existing SSE consumers that only switch on `chunk` / `unblock` / `done` / `error` ignore the new event types and continue to work.
- **Source-level**: the `onChat` public type changed from `(message, onChunk, onUnblock) => Promise<void>` to `(message, ChatStreamSinks) => Promise<void>`. TypeScript callers that defined a host `onChat` with the legacy signature will see a type error; they still work at runtime through the `Function.length` adapter in `invokeOnChat()`. Migration is a one-line shape change.

## Why I want this

Building a chat UI on top of ClaudeClaw — without these events, the best the UI can do is show a generic "tool ran" pulse on `unblock`, which doesn't tell the user *what* ran. With this patch the UI can render per-tool cards with name + arguments + result, which is the standard pattern users expect from agent UIs.

Happy to iterate on event naming or shape if you'd prefer (e.g. `tool_use_start` / `tool_use_end` rather than the current `tool_use` / `tool_result` that mirror Anthropic's stream-json blocks).