### PR TITLE
fix(slack): extract text from blocks/attachments when event.text is empty

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -921,6 +921,7 @@ async function handleMessage(event: SlackMessage): Promise<void> {
   if (botUserId) {
     cleanText = cleanText.replace(new RegExp(`<@${botUserId}>`, "g"), "").trim();
   }
+  cleanText = sanitizeUserInput(cleanText);
 
   const files = event.files ?? [];
   const imageFiles = files.filter(isImageFile);

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -58,6 +58,21 @@ interface SlackFile {
   filetype?: string;
 }
 
+interface SlackAttachment {
+  text?: string;
+  fallback?: string;
+  pretext?: string;
+  title?: string;
+  fields?: Array<{ title: string; value: string }>;
+}
+
+interface SlackBlock {
+  type: string;
+  text?: { type: string; text: string };
+  fields?: Array<{ type: string; text: string }>;
+  elements?: Array<{ type: string; text?: { type: string; text: string } }>;
+}
+
 interface SlackMessage {
   type: string;
   subtype?: string;
@@ -68,6 +83,8 @@ interface SlackMessage {
   ts: string;
   thread_ts?: string;     // set on thread replies; equals ts for the first reply
   files?: SlackFile[];
+  blocks?: SlackBlock[];
+  attachments?: SlackAttachment[];
   channel_type?: string;  // "im" | "mpim" | "channel" | "group"
 }
 
@@ -802,6 +819,24 @@ function sanitizeUserInput(text: string): string {
     .replace(/\[\[slack_select:[^\]]*\]\]/gi, "[select removed]");
 }
 
+function extractBlockText(blocks: SlackBlock[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block.text?.text) parts.push(block.text.text);
+    if (block.fields) {
+      for (const f of block.fields) {
+        if (f.text) parts.push(f.text);
+      }
+    }
+    if (block.elements) {
+      for (const el of block.elements) {
+        if (el.text?.text) parts.push(el.text.text);
+      }
+    }
+  }
+  return parts.filter(Boolean).join("\n");
+}
+
 // --- Trigger check ---
 
 function isImageFile(f: SlackFile): boolean {
@@ -868,8 +903,21 @@ async function handleMessage(event: SlackMessage): Promise<void> {
     return;
   }
 
-  // Strip mention from text
-  let cleanText = event.text;
+  // Strip mention from text; fall back to blocks/attachments if text is empty.
+  let cleanText = event.text
+    || (event.blocks?.length ? extractBlockText(event.blocks) : "")
+    || (event.attachments?.length
+      ? event.attachments.map((a) =>
+          [
+            a.pretext,
+            a.title,
+            a.text,
+            ...(a.fields?.map((f) => `${f.title}:\n${f.value}`) ?? []),
+          ]
+            .filter(Boolean)
+            .join("\n")
+        ).join("\n")
+      : "");
   if (botUserId) {
     cleanText = cleanText.replace(new RegExp(`<@${botUserId}>`, "g"), "").trim();
   }


### PR DESCRIPTION
Fixes #211.

## Problem

When a Slack bot posts using the legacy **attachments** format (Gatus, Grafana, PagerDuty, etc.), `event.text` is `""`. The handler falls through to:

```ts
if (!cleanText.trim() && !hasImage && !hasVoice && !hasDoc) return;
```

…and silently drops the event with no error logged. The same issue affects Block Kit messages without a plain-text fallback.

## Fix

Fall back through a chain of text sources before discarding the message:

1. `event.text` — existing behaviour, unchanged
2. Block Kit `blocks[]` — walks `block.text.text`, `block.fields[].text`, and `block.elements[].text.text`
3. Legacy `attachments[]` — joins `pretext`, `title`, `text`, and `fields[].title`/`value`

Adds `SlackAttachment` and `SlackBlock` TypeScript interfaces, `blocks?`/`attachments?` fields to `SlackMessage`, and an `extractBlockText()` helper.

## Test plan

- [ ] Message with `text: ""` + `attachments[]` to a listened channel — confirm response (previously silent drop)
- [ ] Block Kit message with no plain-text fallback — confirm content extracted from blocks
- [ ] Normal text messages unchanged
- [ ] Messages with no text, blocks, or attachments still dropped (existing behaviour)

Verified against real Gatus DOWN/RESOLVED alerts using the Slack attachments format.