### PR TITLE
feat(slack): add allowBots option for per-channel bot message pass-through

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.36",
+      "version": "1.0.37",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -1066,7 +1066,7 @@ async function handleMessage(event: SlackMessage): Promise<void> {
     }, 20_000);
 
     const agentName = sessionThreadId
-      ? (() => { try { return agentDirKey(`slack-${channelId}`, event.thread_ts!); } catch { return undefined; } })()
+      ? (() => { try { return agentDirKey(`slack-${channelId}`, replyThreadTs); } catch { return undefined; } })()
       : undefined;
 
     let result;

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -64,6 +64,8 @@ interface SlackMessage {
   text: string;
   user?: string;
   bot_id?: string;
+  username?: string;
+  bot_profile?: { name?: string };
   channel: string;
   ts: string;
   thread_ts?: string;     // set on thread replies; equals ts for the first reply
@@ -835,7 +837,10 @@ async function handleMessage(event: SlackMessage): Promise<void> {
   const config = getSettings().slack;
 
   const allowBots = config.allowBots ?? [];
-  const isBotAllowed = !!event.bot_id && allowBots.includes(event.channel);
+  const allowBotIds = config.allowBotIds ?? [];
+  const channelAllowed = !!event.bot_id && allowBots.includes(event.channel);
+  const botIdAllowed = allowBotIds.length === 0 || (!!event.bot_id && allowBotIds.includes(event.bot_id));
+  const isBotAllowed = channelAllowed && botIdAllowed;
 
   if (event.bot_id) {
     if (event.user === botUserId) return; // never respond to our own messages
@@ -850,7 +855,7 @@ async function handleMessage(event: SlackMessage): Promise<void> {
     return;
   }
 
-  const userId = event.user ?? event.bot_id;
+  const userId = event.user ?? event.bot_profile?.name ?? event.username ?? event.bot_id;
   const channelId = event.channel;
   const isDirectMessage = isDM(event);
   const isListenChannel = config.listenChannels.includes(channelId);
@@ -873,11 +878,11 @@ async function handleMessage(event: SlackMessage): Promise<void> {
     return;
   }
 
-  // Strip mention from text
   let cleanText = event.text;
   if (botUserId) {
     cleanText = cleanText.replace(new RegExp(`<@${botUserId}>`, "g"), "").trim();
   }
+  if (isBotAllowed) cleanText = sanitizeUserInput(cleanText);
 
   const files = event.files ?? [];
   const imageFiles = files.filter(isImageFile);
@@ -902,8 +907,14 @@ async function handleMessage(event: SlackMessage): Promise<void> {
     // For the root message of a thread it equals event.ts.
     // We use it to key per-thread sessions; non-thread messages go to global session.
     const inThread = !!event.thread_ts;
-    const replyThreadTs = event.thread_ts ?? event.ts; // reply in same thread
-    const sessionThreadId = inThread ? slackThreadId(channelId, event.thread_ts!) : undefined;
+    const replyThreadTs = event.thread_ts ?? event.ts;
+    // Bot alerts not in a thread each get an isolated session keyed by ts,
+    // so two different bots in the same allowBots channel don't share context.
+    const sessionThreadId = inThread
+      ? slackThreadId(channelId, event.thread_ts!)
+      : isBotAllowed
+        ? slackThreadId(channelId, event.ts)
+        : undefined;
 
     // Recover lost thread from sessions.json if needed
     if (inThread && sessionThreadId) {

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -834,10 +834,15 @@ function isDM(event: SlackMessage): boolean {
 async function handleMessage(event: SlackMessage): Promise<void> {
   const config = getSettings().slack;
 
-  // Ignore bot's own messages and other bot messages
-  if (event.bot_id || !event.user) return;
-  // Skip subtype messages (edits, joins, etc.) unless they are file_share
-  if (event.subtype && event.subtype !== "file_share") return;
+  const allowBots = config.allowBots ?? [];
+  const isBotAllowed = !!event.bot_id && allowBots.includes(event.channel);
+
+  if (event.bot_id) {
+    if (event.user === botUserId) return; // never respond to our own messages
+    if (!isBotAllowed) return;
+  }
+  if (!event.bot_id && !event.user) return;
+  if (event.subtype && event.subtype !== "file_share" && !(isBotAllowed && event.subtype === "bot_message")) return;
 
   // Deduplicate: Slack sends both message + app_mention for @mentions
   if (isDuplicate(event.channel, event.ts)) {
@@ -845,7 +850,7 @@ async function handleMessage(event: SlackMessage): Promise<void> {
     return;
   }
 
-  const userId = event.user;
+  const userId = event.user ?? event.bot_id;
   const channelId = event.channel;
   const isDirectMessage = isDM(event);
   const isListenChannel = config.listenChannels.includes(channelId);
@@ -855,13 +860,13 @@ async function handleMessage(event: SlackMessage): Promise<void> {
   const isAssistantThread = event.thread_ts
     ? assistantThreadKeys.has(assistantKey(channelId, event.thread_ts))
     : false;
-  if (!isDirectMessage && !mentioned && !isListenChannel && !isAssistantThread) {
+  if (!isDirectMessage && !mentioned && !isListenChannel && !isAssistantThread && !isBotAllowed) {
     debugLog(`Skip channel=${channelId} user=${userId} text="${event.text.slice(0, 40)}"`);
     return;
   }
 
-  // Authorization check
-  if (config.allowedUserIds.length > 0 && !config.allowedUserIds.includes(userId)) {
+  // Authorization check — bot messages in allowBots channels bypass user-level auth
+  if (!isBotAllowed && config.allowedUserIds.length > 0 && !config.allowedUserIds.includes(userId ?? "")) {
     if (isDirectMessage) {
       await sendMessage(config.botToken, channelId, "Unauthorized.");
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ const DEFAULT_SETTINGS: Settings = {
   },
   telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true, dmIsolation: "shared" },
   discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [], streaming: false },
-  slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [] },
+  slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [], allowBots: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
@@ -138,6 +138,7 @@ export interface SlackConfig {
   appToken: string;       // xapp-... Socket Mode token
   allowedUserIds: string[];
   listenChannels: string[]; // Channel IDs where bot responds without @mention
+  allowBots: string[];    // Channel IDs where bot-posted messages are passed through
 }
 
 export type SecurityLevel =
@@ -371,6 +372,7 @@ function parseSettings(
       appToken: process.env.SLACK_APP_TOKEN?.trim() || (typeof raw.slack?.appToken === "string" ? raw.slack.appToken.trim() : ""),
       allowedUserIds: Array.isArray(raw.slack?.allowedUserIds) ? raw.slack.allowedUserIds.map(String) : [],
       listenChannels: Array.isArray(raw.slack?.listenChannels) ? raw.slack.listenChannels.map(String) : [],
+      allowBots: Array.isArray(raw.slack?.allowBots) ? raw.slack.allowBots.map(String) : [],
     },
     security: {
       level,

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ const DEFAULT_SETTINGS: Settings = {
   },
   telegram: { token: "", allowedUserIds: [], listenChats: [], receiveEnabled: true, dmIsolation: "shared" },
   discord: { token: "", allowedUserIds: [], listenChannels: [], listenGuilds: [], imageOutputRoots: [], streaming: false },
-  slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [], allowBots: [] },
+  slack: { botToken: "", appToken: "", allowedUserIds: [], listenChannels: [], allowBots: [], allowBotIds: [] },
   security: { level: "moderate", allowedTools: [], disallowedTools: [] },
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
@@ -139,6 +139,7 @@ export interface SlackConfig {
   allowedUserIds: string[];
   listenChannels: string[]; // Channel IDs where bot responds without @mention
   allowBots: string[];    // Channel IDs where bot-posted messages are passed through
+  allowBotIds: string[];  // Optional: Slack app/bot IDs (B...) that may post; empty = any bot in allowBots channel
 }
 
 export type SecurityLevel =
@@ -373,6 +374,7 @@ function parseSettings(
       allowedUserIds: Array.isArray(raw.slack?.allowedUserIds) ? raw.slack.allowedUserIds.map(String) : [],
       listenChannels: Array.isArray(raw.slack?.listenChannels) ? raw.slack.listenChannels.map(String) : [],
       allowBots: Array.isArray(raw.slack?.allowBots) ? raw.slack.allowBots.map(String) : [],
+      allowBotIds: Array.isArray(raw.slack?.allowBotIds) ? raw.slack.allowBotIds.map(String) : [],
     },
     security: {
       level,


### PR DESCRIPTION
Closes #210.

## Problem

The bot filter in `handleMessage` unconditionally drops all events where `event.bot_id` is set:

```ts
if (event.bot_id || !event.user) return;
```

This makes it impossible to react to messages from monitoring tools (Gatus, Grafana, PagerDuty, etc.) in dedicated alert channels, even when that is the intended use case.

## Solution

Add an optional `allowBots` array to the Slack config listing channel IDs where bot-posted messages should pass through:

```json
"slack": {
  "botToken": "xoxb-...",
  "appToken": "xapp-...",
  "listenChannels": ["C123456"],
  "allowBots": ["C123456"]
}
```

The guard becomes allowBots-aware:

```ts
const isBotAllowed = !!event.bot_id && allowBots.includes(event.channel);

if (event.bot_id) {
  if (event.user === botUserId) return; // never respond to our own messages
  if (!isBotAllowed) return;
}
```

The self-exclusion check (`event.user === botUserId`) prevents ClaudeClaw from responding to its own messages and looping indefinitely.

Bot messages in `allowBots` channels also bypass user-level auth (no human `userId` to check against `allowedUserIds`) and allow the `bot_message` subtype through alongside the existing `file_share` exception.

## Changes

- `src/config.ts`: add `allowBots: string[]` to `SlackConfig`, default, and parser
- `src/commands/slack.ts`: replace blanket bot guard with `allowBots`-aware logic

## Test plan

- [ ] Bot message in a channel listed in `allowBots` triggers a response
- [ ] Bot message in a channel not in `allowBots` is still dropped
- [ ] ClaudeClaw does not respond to its own messages (no loop)
- [ ] Normal user messages in all channel types unchanged
- [ ] `allowBots` omitted from config defaults to `[]` (existing behaviour preserved)

Verified locally against real Gatus DOWN/RESOLVED alerts.