### PR TITLE
fix(slack): cancel proactive reconnect timer on close and stop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.1.1",
+      "version": "1.0.38",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.1.1",
+  "version": "1.0.38",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -116,6 +116,7 @@ let ws: WebSocket | null = null;
 let running = true;
 let slackDebug = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let proactiveReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Dedup: track recently processed message timestamps to avoid handling both message + app_mention
 const recentlyProcessed = new Map<string, number>();
@@ -1611,6 +1612,7 @@ function openSocket(url: string, appToken: string): void {
   ws.onclose = (event) => {
     debugLog(`WebSocket closed: code=${event.code} reason=${event.reason}`);
     ws = null;
+    if (proactiveReconnectTimer) { clearTimeout(proactiveReconnectTimer); proactiveReconnectTimer = null; }
     if (!running) return;
     console.log("[Slack] Connection closed, reconnecting...");
     scheduleReconnect(appToken);
@@ -1623,7 +1625,9 @@ function openSocket(url: string, appToken: string): void {
   // Slack Socket Mode connections rotate every ~30 minutes.
   // We reconnect proactively at ~29 minutes to avoid forced disconnects.
   const RECONNECT_MS = 29 * 60 * 1000;
-  setTimeout(() => {
+  if (proactiveReconnectTimer) clearTimeout(proactiveReconnectTimer);
+  proactiveReconnectTimer = setTimeout(() => {
+    proactiveReconnectTimer = null;
     if (!running) return;
     debugLog("Proactive reconnect (30-min rotation)");
     ws?.close(1000, "Proactive reconnect");
@@ -1660,6 +1664,10 @@ export function stopSlack(): void {
   if (reconnectTimer) {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
+  }
+  if (proactiveReconnectTimer) {
+    clearTimeout(proactiveReconnectTimer);
+    proactiveReconnectTimer = null;
   }
   if (ws) {
     try {


### PR DESCRIPTION
Fixes #219.

## Problem

`openSocket` schedules a 29-minute proactive reconnect timer but discards the return value of `setTimeout`, so the timer can never be cancelled. On each reconnect (Socket Mode rotates every ~30 min) a new timer is created while old ones keep running. After a few cycles they stack up and start firing seconds apart — each one closes the socket, triggers another reconnect, and spawns yet another timer. The process eventually dies.

## Fix

Store the timer in a module-level `proactiveReconnectTimer` variable, matching the existing pattern for `reconnectTimer`:

- Cancel any existing timer before setting a new one in `openSocket`
- Clear it in `ws.onclose` (socket closed before the timer fired)
- Clear it in `stopSlack` (shutdown cleanup)

Same three-line pattern already used for `reconnectTimer` — the proactive one just missed the same treatment.

## Test plan

- [ ] Let the bot run through two or more 30-minute Socket Mode rotations and confirm "Proactive reconnect" fires once per cycle, not repeatedly
- [ ] Confirm the service stays alive across multiple reconnects
- [ ] `stopSlack()` / restart clears the timer cleanly with no dangling callbacks