### PR TITLE
feat: auto-compact resumed sessions when turn count crosses threshold

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.37",
+      "version": "1.0.38",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, runFork, killActive, isMainBusy, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt, getPermissionMode, setPermissionMode, type PermissionMode } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, runFork, killActive, isMainBusy, compactCurrentSession, compactCurrentThreadSession, isRateLimited, getRateLimitResetAt, getPermissionMode, setPermissionMode, onCompactEvent, type PermissionMode } from "../runner";
 import { extractErrorDetail } from "../messaging";
 import { loadPendingResume } from "../pending-resume";
 import { getSettings, loadSettings } from "../config";
@@ -1692,11 +1692,58 @@ async function runPendingResumeTelegram(): Promise<void> {
 }
 
 /** Start polling in-process (called by start.ts when token is configured) */
+/**
+ * Subscribe to runner compact events and forward user-relevant ones to
+ * the first allowed Telegram user. The runner emits compact events
+ * regardless of which surface initiated the underlying message. We
+ * only DM the warn + auto-compact-by-turns events: the timeout-driven
+ * auto-compact happens silently because the user is mid-retry and
+ * shouldn't be interrupted.
+ */
+let compactListenerRegistered = false;
+function ensureCompactNotifier(): void {
+  if (compactListenerRegistered) return;
+  compactListenerRegistered = true;
+  onCompactEvent(async (event) => {
+    const config = getSettings().telegram;
+    const recipient = config.allowedUserIds?.[0];
+    if (!config.token || !recipient) return;
+    try {
+      if (event.type === "warn") {
+        await sendMessage(
+          config.token,
+          recipient,
+          `⚠️ Session context is getting large (turn ${event.turnCount}). Auto-compact will fire at the configured threshold; you can also send /compact now.`
+        );
+      } else if (event.type === "auto-compact-by-turns-start") {
+        await sendMessage(
+          config.token,
+          recipient,
+          `🧹 Auto-compacting session (turn ${event.turnCount} ≥ ${event.threshold}). One moment…`
+        );
+      } else if (event.type === "auto-compact-by-turns-done") {
+        await sendMessage(
+          config.token,
+          recipient,
+          event.success
+            ? `✅ Auto-compact complete. Turn counter reset; next message starts at baseline cost.`
+            : `❌ Auto-compact failed at turn ${event.turnCount}. Try /compact manually.`
+        );
+      }
+    } catch (err) {
+      console.error(
+        `[Telegram] Compact notifier failed: ${err instanceof Error ? err.message : err}`
+      );
+    }
+  });
+}
+
 export function startPolling(debug = false): void {
   if (isPolling) return;
   running = true;
   isPolling = true;
   telegramDebug = debug;
+  ensureCompactNotifier();
   const gen = ++pollingGeneration;
   (async () => {
     await ensureProjectClaudeMd();

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,7 @@ const DEFAULT_SETTINGS: Settings = {
   timeouts: { telegram: 5, heartbeat: 15, job: 30, default: 5 },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
+  autoCompact: { enabled: true, threshold: 100 },
   plugins: {},
 };
 
@@ -185,7 +186,27 @@ export interface Settings {
   watchdog: WatchdogSettings;
   plugins: Record<string, PluginEntry>;
   session: SessionConfig;
+  autoCompact: AutoCompactConfig;
   jobsDir?: string;
+}
+
+/**
+ * Controls the automatic /compact invoked by the runner when a resumed
+ * session crosses a turn-count threshold. Without auto-compact,
+ * long-lived sessions (e.g. ones the daemon resumes across days of
+ * Telegram messages) accumulate the full transcript on every turn, so
+ * each new prompt costs the input tokens for hundreds of prior turns.
+ * Hitting the plan's rolling-window limit becomes a matter of time.
+ */
+export interface AutoCompactConfig {
+  /** Master switch. Default: true. */
+  enabled: boolean;
+  /**
+   * Auto-compact fires after a successful turn pushes turnCount to this
+   * value or higher. Default: 100. Setting to 0 or a value <=
+   * COMPACT_WARN_THRESHOLD (25) effectively disables the trigger.
+   */
+  threshold: number;
 }
 
 
@@ -413,6 +434,13 @@ function parseSettings(
       maxMessages: Number.isFinite(raw.session?.maxMessages) ? Number(raw.session.maxMessages) : 50,
       maxAgeHours: Number.isFinite(raw.session?.maxAgeHours) ? Number(raw.session.maxAgeHours) : 24,
       summaryPath: typeof raw.session?.summaryPath === "string" ? raw.session.summaryPath.trim() : "",
+    },
+    autoCompact: {
+      enabled: typeof raw.autoCompact?.enabled === "boolean" ? raw.autoCompact.enabled : true,
+      threshold:
+        Number.isFinite(raw.autoCompact?.threshold) && Number(raw.autoCompact.threshold) > 0
+          ? Math.floor(Number(raw.autoCompact.threshold))
+          : 100,
     },
     apiToken: typeof raw.apiToken === "string" && raw.apiToken.trim() ? raw.apiToken.trim() : undefined,
     ...(typeof raw.jobsDir === "string" && raw.jobsDir.trim() ? { jobsDir: raw.jobsDir.trim() } : {}),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,6 +8,7 @@ import {
   resetSession,
   incrementTurn,
   markCompactWarned,
+  resetTurnTracking,
   getFallbackSession,
   createFallbackSession,
   resetFallbackSession,
@@ -23,6 +24,7 @@ import {
   removeThreadSession,
   incrementThreadTurn,
   markThreadCompactWarned,
+  resetThreadTurnTracking,
 } from "./sessionManager";
 import { getSettings, DEFAULT_SESSION_TIMEOUT_MS, type ModelConfig, type SecurityConfig } from "./config";
 import { buildClockPromptPrefix } from "./timezone";
@@ -122,7 +124,9 @@ export type CompactEvent =
   | { type: "warn"; turnCount: number }
   | { type: "auto-compact-start" }
   | { type: "auto-compact-done"; success: boolean }
-  | { type: "auto-compact-retry"; success: boolean; stdout: string; stderr: string; exitCode: number };
+  | { type: "auto-compact-retry"; success: boolean; stdout: string; stderr: string; exitCode: number }
+  | { type: "auto-compact-by-turns-start"; turnCount: number; threshold: number }
+  | { type: "auto-compact-by-turns-done"; success: boolean; turnCount: number };
 
 type CompactEventListener = (event: CompactEvent) => void;
 const compactListeners: CompactEventListener[] = [];
@@ -1417,6 +1421,53 @@ async function execClaude(
         await markCompactWarned(agentName);
       }
       emitCompactEvent({ type: "warn", turnCount });
+    }
+
+    // --- Auto-compact on turn-count threshold ---
+    // Long-lived sessions (e.g. Telegram threads the daemon resumes for
+    // weeks) accumulate the full transcript on every turn, so a 600-turn
+    // session pays the input-token cost of 600 prior turns for every new
+    // prompt. The plan's rolling window hits its cap and Claude returns
+    // "Credit balance is too low". Auto-compact keeps the running cost
+    // bounded: after the threshold, fire one /compact, reset the turn
+    // counter, and the next prompt starts back at baseline. The user
+    // gets a notification via the existing compact event channel.
+    const autoCompact = settings.autoCompact;
+    if (
+      autoCompact?.enabled &&
+      autoCompact.threshold > 0 &&
+      turnCount >= autoCompact.threshold &&
+      existing &&
+      primaryConfig
+    ) {
+      emitCompactEvent({
+        type: "auto-compact-by-turns-start",
+        turnCount,
+        threshold: autoCompact.threshold,
+      });
+      console.log(
+        `[${new Date().toLocaleTimeString()}] Auto-compact: turn ${turnCount} >= threshold ${autoCompact.threshold}`
+      );
+      const compactOk = await runCompact(
+        existing.sessionId,
+        primaryConfig.model,
+        primaryConfig.api,
+        baseEnv,
+        securityArgs,
+        timeoutMs
+      );
+      if (compactOk) {
+        if (threadId) {
+          await resetThreadTurnTracking(threadId);
+        } else {
+          await resetTurnTracking(agentName);
+        }
+      }
+      emitCompactEvent({
+        type: "auto-compact-by-turns-done",
+        success: compactOk,
+        turnCount,
+      });
     }
   }
 

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -97,6 +97,17 @@ export async function markThreadCompactWarned(threadId: string): Promise<void> {
   await saveSessions(data);
 }
 
+/** Reset turn-tracking state for a thread session after a successful
+ *  compact. Mirrors resetTurnTracking() in sessions.ts. */
+export async function resetThreadTurnTracking(threadId: string): Promise<void> {
+  const data = await loadSessions();
+  const session = data.threads[threadId];
+  if (!session) return;
+  session.turnCount = 0;
+  session.compactWarned = false;
+  await saveSessions(data);
+}
+
 /** List all active thread sessions. */
 export async function listThreadSessions(): Promise<ThreadSession[]> {
   const data = await loadSessions();

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -103,6 +103,21 @@ export async function markCompactWarned(agentName?: string): Promise<void> {
   await saveSession(existing, agentName);
 }
 
+/**
+ * Reset turn-tracking state after a successful compact. The Claude
+ * session ID is preserved (compact happens server-side inside the same
+ * session), but its in-memory turn count and the one-shot
+ * `compactWarned` flag should restart so the auto-compact threshold
+ * doesn't fire again on the very next turn.
+ */
+export async function resetTurnTracking(agentName?: string): Promise<void> {
+  const existing = await loadSession(agentName);
+  if (!existing) return;
+  existing.turnCount = 0;
+  existing.compactWarned = false;
+  await saveSession(existing, agentName);
+}
+
 export async function resetSession(agentName?: string): Promise<void> {
   if (!agentName) current = null;
   try {


### PR DESCRIPTION
## The problem

ClaudeClaw resumes the same Claude session across every Telegram (or Discord/Slack) message it receives, which is the right behavior for continuity — but the runner currently only warns once at `COMPACT_WARN_THRESHOLD` (25 turns) and otherwise lets sessions grow forever.

On my deployment, the daemon's Telegram session sat at **677 turns over 20 days**. Every new "What's the error?" prompt was paying the input-token cost for all 677 prior turns, and the account's rolling-window cap started returning `Credit balance is too low` on every single message. Meanwhile a fresh, interactive Claude Code session on the same account worked perfectly — exactly because its context wasn't 677 turns deep. The user never sees this in their Claude usage dashboard because per-account limits aggregate; they just see the daemon stop responding.

The existing `compactWarned: true` in `session.json` confirms the runner had already noticed and warned, but no consumer wired up `onCompactEvent` to surface the warning, and there was no automatic mitigation.

## The fix

Add an automatic `/compact` triggered after a successful turn once `turnCount` crosses a configurable threshold (default **100**):

- **`AutoCompactConfig` in `Settings`** (`autoCompact: { enabled, threshold }`). Defaults to `{ enabled: true, threshold: 100 }`; existing `settings.json` files keep working because the parser falls back to defaults when fields are missing.
- **`resetTurnTracking()` / `resetThreadTurnTracking()`** helpers in `sessions.ts` and `sessionManager.ts` that zero `turnCount` and clear the one-shot `compactWarned` flag after a successful compact, so the threshold doesn't immediately re-fire on the next turn.
- **Two new `CompactEvent` variants** (`auto-compact-by-turns-start`, `auto-compact-by-turns-done`) so any surface can notify the user — they're distinct from the existing timeout-driven `auto-compact-{start,done}` events.
- **Telegram listener** in `commands/telegram.ts` that DMs the first allowed user on `warn` + `auto-compact-by-turns-{start,done}` events. (Discord and Slack can hook up the same pattern in a follow-up — I didn't touch those because I don't run them and didn't want to ship untested code.)
- **Plugin + marketplace version bumped** `1.0.37 → 1.0.38`.

The timeout-driven auto-compact path (`COMPACT_TIMEOUT_ENABLED`, exit 124) is untouched.

## How to verify

```bash
# In settings.json, set a low threshold so it fires quickly:
"autoCompact": { "enabled": true, "threshold": 5 }
```

Send 5-6 Telegram messages. After the 5th successful turn:
- `daemon.log` shows `Auto-compact: turn 5 >= threshold 5`
- Telegram DM arrives: "🧹 Auto-compacting session…" then "✅ Auto-compact complete."
- `.claude/claudeclaw/session.json` shows `turnCount: 0` and `compactWarned: false`
- Same `sessionId` — the Claude session continues, just with a compacted transcript

To disable entirely:
```json
"autoCompact": { "enabled": false, "threshold": 100 }
```

## What I didn't do (would love feedback)

- I kept the default at 100 conservatively. Real cost-vs-continuity sweet spot probably varies by usage pattern.
- Discord + Slack don't subscribe to the new events yet — happy to add in this PR if you'd like, or a follow-up.
- Considered adding a `lastCompactedAt` field but the existing `compactWarned` flag plus `turnCount` reset gives us enough state for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)