### PR TITLE
Fix for discord threads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -79,6 +79,12 @@ interface DiscordMessage {
   type: number;
 }
 
+const enum DiscordMessageType {
+  Default = 0,
+  Reply = 19,
+  ThreadCreated = 18,
+}
+
 interface DiscordInteraction {
   id: string;
   type: number; // 2=APPLICATION_COMMAND, 3=MESSAGE_COMPONENT
@@ -739,6 +745,10 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
 
   // Ignore bot messages
   if (message.author.bot) return;
+
+  // Ignore system message types (thread creation recap, pins, etc.) — only process
+  // regular messages (0) and replies (19) to avoid spurious prompts on the parent channel.
+  if (message.type !== DiscordMessageType.Default && message.type !== DiscordMessageType.Reply) return;
 
   const userId = message.author.id;
   const channelId = message.channel_id;


### PR DESCRIPTION
## Summary

ClaudeClaw will now ignore system messages (like thread creation) and only listen to messages and replies.

Fixes: #230 


## Validation

- [x] I ran the relevant checks locally
- [ ] I updated any docs or setup guidance affected by this change - not needed I believe

## Plugin Versioning

Versions bumped.

Run as needed:

```bash
bun run bump:plugin-version
bun run bump:marketplace-version
```

Typical rule:
- bump `.claude-plugin/plugin.json` when shipped plugin content changes
- bump `.claude-plugin/marketplace.json` when marketplace metadata should reflect the new shipped version

Docs-only and other non-shipped changes do not require these bumps.
