### PR TITLE
fix(discord): ignore thread recap system messages (#230)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -79,6 +79,12 @@ interface DiscordMessage {
   type: number;
 }
 
+const enum DiscordMessageType {
+  Default = 0,
+  Reply = 19,
+  ThreadCreated = 18,
+}
+
 interface DiscordInteraction {
   id: string;
   type: number; // 2=APPLICATION_COMMAND, 3=MESSAGE_COMPONENT
@@ -739,6 +745,10 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
 
   // Ignore bot messages
   if (message.author.bot) return;
+
+  // Ignore system message types (thread creation recap, pins, etc.) — only process
+  // regular messages (0) and replies (19) to avoid spurious prompts on the parent channel.
+  if (message.type !== DiscordMessageType.Default && message.type !== DiscordMessageType.Reply) return;
 
   const userId = message.author.id;
   const channelId = message.channel_id;


### PR DESCRIPTION
## Summary

Fixes #230.

Discord emits system messages (e.g. type 18 thread-creation recap) on the parent channel when a thread is created. Those were routed through `handleMessageCreate` and could trigger spurious Claude prompts.

Only process regular messages (type 0) and replies (type 19). Bump plugin/marketplace version to 1.0.40 per contributor guidelines.

**Note:** #235 implements the same filter; this PR is rebased on current `master` from `rudi193-cmd` in case maintainers prefer a fresh branch. Happy to close in favor of #235 if that lands first.

## Test plan

- [ ] Create a Discord thread in a listened channel — parent channel should not get a Claude prompt from the recap message
- [ ] Normal messages and replies in threads still work

Made with [Cursor](https://cursor.com)