### PR TITLE
fix(install-skill): use skills.sh search API instead of scraping HTML

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/skills/install-skill/search.mjs
+++ b/skills/install-skill/search.mjs
@@ -1,6 +1,10 @@
 // Search skills.sh and return JSON results
 // Usage: node search.mjs <query>
 // Works with Node 18+, Bun, Deno
+//
+// Uses the skills.sh search API. The old approach (scraping embedded JSON
+// out of the homepage HTML) broke when skills.sh moved to a Next.js app
+// that loads results client-side.
 
 const query = process.argv[2];
 if (!query) {
@@ -9,33 +13,21 @@ if (!query) {
 }
 
 try {
-  const res = await fetch(`https://skills.sh/?q=${encodeURIComponent(query)}`);
-  const html = await res.text();
-
-  const skills = [];
-  const esc = `\\\\?"`;  // matches both \" and "
-  const pattern = new RegExp(
-    `\\{${esc}source${esc}:${esc}([^"\\\\]+)${esc},${esc}skillId${esc}:${esc}([^"\\\\]+)${esc},${esc}name${esc}:${esc}([^"\\\\]+)${esc},${esc}installs${esc}:(\\d+)\\}`,
-    "g"
+  const res = await fetch(
+    `https://www.skills.sh/api/search?q=${encodeURIComponent(query)}`
   );
-  let match;
-  while ((match = pattern.exec(html)) !== null) {
-    skills.push({
-      source: match[1],
-      id: match[2],
-      name: match[3],
-      installs: parseInt(match[4]),
-    });
-  }
+  if (!res.ok) throw new Error(`skills.sh API returned HTTP ${res.status}`);
+  const data = await res.json();
 
-  const q = query.toLowerCase();
-  let filtered = skills.filter(
-    (s) => s.name.toLowerCase().includes(q) || s.source.toLowerCase().includes(q)
-  );
-  if (filtered.length === 0) filtered = skills.slice(0, 20);
+  const skills = (data.skills ?? []).map((s) => ({
+    source: s.source,
+    id: s.skillId,
+    name: s.name,
+    installs: s.installs ?? 0,
+  }));
 
-  filtered.sort((a, b) => b.installs - a.installs);
-  console.log(JSON.stringify(filtered.slice(0, 15), null, 2));
+  skills.sort((a, b) => b.installs - a.installs);
+  console.log(JSON.stringify(skills.slice(0, 15), null, 2));
 } catch (e) {
   console.log(JSON.stringify({ error: e.message }));
   process.exit(1);


### PR DESCRIPTION
## Problem

`skills/install-skill/search.mjs` scrapes the skills.sh homepage HTML for embedded JSON (`{\"source\":...,\"skillId\":...}` patterns). skills.sh has since moved to a Next.js app (`www.skills.sh`) that renders search results client-side, so the regex never matches and **every search returns `[]`**, making `/claudeclaw:install-skill` search unusable.

## Fix

Switch to the JSON endpoint at `https://www.skills.sh/api/search?q=<query>`, which returns the same fields directly:

```json
{"query":"...","searchType":"fuzzy","skills":[{"id":"...","skillId":"...","name":"...","installs":123,"source":"owner/repo"}]}
```

The script's output shape (`[{source, id, name, installs}]`) is unchanged, so `SKILL.md` instructions and `install.mjs` need no changes. Server-side fuzzy search also replaces the old client-side filtering.

## Testing

Verified on-device (Node 18, Linux arm64):

- `node search.mjs "substack"` → 13 results, sorted by installs
- `node search.mjs "mcp"` → 15 results (top: `mcp-builder` from anthropics/skills)
- `node search.mjs "notion"` → results led by `notion-api` (52k installs)
- Before the patch, all of the above returned `[]`

Includes the required `bump:plugin-version` / `bump:marketplace-version` runs (1.0.40 → 1.0.41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)