### PR TITLE
feat(discord): channel-scoped allowlist for guild messages

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.42",
+      "version": "1.0.43",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/allowlist.ts
+++ b/src/allowlist.ts
@@ -1,3 +1,20 @@
 export function isAllowed<T>(userId: T | undefined, allowedUserIds: T[]): boolean {
   return userId !== undefined && allowedUserIds.length > 0 && allowedUserIds.includes(userId);
 }
+
+/**
+ * Discord authorization check: the global allowlist grants access everywhere (DMs + all
+ * guild channels). A channel-scoped allowlist entry only grants access to guild messages
+ * in that specific channel — it never applies to DMs, even for the same user ID.
+ */
+export function isDiscordAuthorized(
+  userId: string | undefined,
+  isGuild: boolean,
+  channelId: string,
+  allowedUserIds: string[],
+  channelAllowedUserIds: Record<string, string[]> | undefined,
+): boolean {
+  if (isAllowed(userId, allowedUserIds)) return true;
+  if (isGuild && isAllowed(userId, channelAllowedUserIds?.[channelId] ?? [])) return true;
+  return false;
+}

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,6 +1,6 @@
 import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { wrapUntrusted } from "../prompt-safety";
-import { isAllowed } from "../allowlist";
+import { isAllowed, isDiscordAuthorized } from "../allowlist";
 import { extractErrorDetail } from "../messaging";
 import { loadPendingResume } from "../pending-resume";
 import { getSettings, loadSettings, DEFAULT_IMAGE_OUTPUT_ROOT } from "../config";
@@ -784,8 +784,9 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
     `Handle message channel=${channelId} from=${userId} reason=${triggerReason} text="${content.slice(0, 80)}"`,
   );
 
-  // Authorization check
-  if (!isAllowed(userId, config.allowedUserIds)) {
+  // Authorization check — global allowlist works everywhere; channel-scoped allowlist only
+  // grants access to guild messages in that specific channel, never DMs.
+  if (!isDiscordAuthorized(userId, isGuild, channelId, config.allowedUserIds, config.channelAllowedUserIds)) {
     if (isDM) {
       await sendMessage(config.token, channelId, "Unauthorized.");
     } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,6 +132,7 @@ export interface DiscordConfig {
   channelNames?: Record<string, string>; // channelId -> friendly name for system prompt context
   imageOutputRoots: string[]; // Absolute path prefixes from which image uploads are permitted
   streaming?: boolean; // When true, POST a live preview while Claude is working. Default: false.
+  channelAllowedUserIds?: Record<string, string[]>; // channelId -> extra user IDs allowed in that guild channel only (never DMs)
 }
 
 export interface SlackConfig {
@@ -371,6 +372,13 @@ function parseSettings(
         ? raw.discord.imageOutputRoots.filter((r: unknown) => typeof r === "string" && isAbsolute(r))
         : [],
       streaming: raw.discord?.streaming === true,
+      channelAllowedUserIds: raw.discord?.channelAllowedUserIds && typeof raw.discord.channelAllowedUserIds === "object"
+        ? Object.fromEntries(
+            Object.entries(raw.discord.channelAllowedUserIds as Record<string, unknown>)
+              .filter(([, v]) => Array.isArray(v))
+              .map(([k, v]) => [String(k), (v as unknown[]).map(String)]),
+          )
+        : undefined,
     },
     slack: {
       botToken: process.env.SLACK_BOT_TOKEN?.trim() || (typeof raw.slack?.botToken === "string" ? raw.slack.botToken.trim() : ""),

--- a/tests/allowlist.test.ts
+++ b/tests/allowlist.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { isAllowed } from "../src/allowlist";
+import { isAllowed, isDiscordAuthorized } from "../src/allowlist";
 
 test("empty allowlist denies everything", () => {
   expect(isAllowed(123, [])).toBe(false);
@@ -9,4 +9,29 @@ test("missing userId denied", () => {
 });
 test("allowlisted user permitted", () => {
   expect(isAllowed(123, [123, 456])).toBe(true);
+});
+
+// --- isDiscordAuthorized ---
+
+test("global allowlist grants access in DMs", () => {
+  expect(isDiscordAuthorized("u1", false, "chan1", ["u1"], undefined)).toBe(true);
+});
+test("global allowlist grants access in any guild channel", () => {
+  expect(isDiscordAuthorized("u1", true, "chan1", ["u1"], { chan2: ["u1"] })).toBe(true);
+});
+test("channel-scoped user is authorized in their listed channel", () => {
+  expect(isDiscordAuthorized("u2", true, "chan1", [], { chan1: ["u2"] })).toBe(true);
+});
+test("channel-scoped user is NOT authorized in a different channel", () => {
+  expect(isDiscordAuthorized("u2", true, "chan2", [], { chan1: ["u2"] })).toBe(false);
+});
+test("channel-scoped user is NOT authorized via DM even for their allowed channel's ID", () => {
+  expect(isDiscordAuthorized("u2", false, "chan1", [], { chan1: ["u2"] })).toBe(false);
+});
+test("unlisted user is denied everywhere", () => {
+  expect(isDiscordAuthorized("u3", true, "chan1", ["u1"], { chan1: ["u2"] })).toBe(false);
+  expect(isDiscordAuthorized("u3", false, "chan1", ["u1"], { chan1: ["u2"] })).toBe(false);
+});
+test("missing channelAllowedUserIds config does not throw", () => {
+  expect(isDiscordAuthorized("u1", true, "chan1", [], undefined)).toBe(false);
 });


### PR DESCRIPTION
## Summary

- Adds `discord.channelAllowedUserIds` config (`channelId -> user IDs[]`) — grants a user access to one specific guild channel without adding them to the global `allowedUserIds` list
- Channel-scoped access **never** applies to DMs, even for the same user ID — the global `allowedUserIds` list remains the only path to DM access
- Extracted the composed auth check into `isDiscordAuthorized()` in `allowlist.ts` so it's unit-testable independent of the Discord message-handling flow

## Why

Previously `allowedUserIds` was all-or-nothing: a user was either allowed to reach Sage everywhere (DMs + every guild channel), or blocked everywhere. No way to grant someone scoped access to a single project channel.

## Testing

- 7 new unit tests in `tests/allowlist.test.ts` covering: global allowlist access in DMs and guild channels, channel-scoped access in the correct channel, explicit denial in other channels, explicit denial via DM (the key leak this feature must avoid), denial for unlisted users, and no-throw on missing config
- Full suite: 117/117 passing, no regressions
- `tsc --noEmit`: no new errors introduced
- Manually verified live against Discord: a channel-scoped test user got real responses in their assigned channel, no response in other guild channels, and an explicit "Unauthorized." on DM — while the existing globally-allowed user was unaffected in all contexts