### PR TITLE
fix(telegram): queue messages received while Claude is busy instead of dropping them

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1449,9 +1449,13 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
     let streamMsgId: number | null = null;
     let hadToolLines = false;
     if (busy) {
-      await sendMessage(config.token, chatId, "Claude is busy — try again in a moment, or use /fork for a quick parallel task.", threadId);
-      return;
-    } else {
+      // Don't drop the message — queue it behind the in-flight run. runUserMessage
+      // routes through enqueue(), which serializes per-thread (keyed by sessionKey),
+      // so messages from this chat run in order instead of being silently lost.
+      // Let the user know it's waiting rather than pretending nothing happened.
+      await sendMessage(config.token, chatId, "⏳ Claude is busy — your message is queued and will run after the current one finishes. Use /fork for a quick parallel task, or /kill to cancel what's running.", threadId);
+    }
+    {
       const stream = makeStreamCallback(config.token, chatId, threadId, { verbose });
       result = await runUserMessage("telegram", prefixedPrompt, sessionKey, undefined, stream.onChunk, stream.onToolEvent, modelOverride);
       const streamResult = await stream.waitForStreamMsg();


### PR DESCRIPTION
## Problem

When a Telegram message arrives while a main-queue run is already in flight, `handleMessage()` replies **"Claude is busy — try again in a moment"** and `return`s early — **silently dropping the message**. The user has to notice the reply and manually resend, and any message they'd already typed is lost.

```ts
// src/commands/telegram.ts
if (busy) {
  await sendMessage(config.token, chatId, "Claude is busy — try again in a moment, ...", threadId);
  return;   // <-- message discarded here
} else {
  result = await runUserMessage("telegram", prefixedPrompt, sessionKey, ...);
  ...
}
```

## Why the queue was already there

The runner already serializes work **per thread**: `runUserMessage()` routes through `enqueue()` in `src/runner.ts`, keyed by `sessionKey`, so messages from the same chat run in order:

```ts
function enqueue<T>(fn, threadId) {
  if (threadId) {
    const current = threadQueues.get(threadId) ?? Promise.resolve();
    const task = current.then(fn, fn);
    threadQueues.set(threadId, task.then(() => {}, () => {}));
    return task;
  }
  ...
}
```

The `busy` branch was short-circuiting **before** ever reaching that queue.

## Fix

Remove the early `return` so a busy-time message falls through into the existing per-thread queue and runs after the current task finishes.

- The user still gets an **immediate heads-up** that their message is queued (plus a pointer to `/fork` and `/kill`), so nothing looks silently swallowed.
- The typing indicator is already started before this point (`setInterval(... sendTyping ...)`, "Keep typing indicator alive while queued/running") and stays alive across the queued wait, so the chat no longer looks frozen.
- **No new concurrency**: per-thread serialization is unchanged. This only stops *dropping* the enqueued work — messages from one chat still run strictly in order.

Discord (`src/commands/discord.ts`) has no such busy-check and already flows straight into the queue, so this brings Telegram in line with Discord's behavior.

## Testing

- `bunx tsc --noEmit` passes clean.
- Manual: sending two messages back-to-back on Telegram now queues the second and answers it after the first, instead of dropping it.
- `bun test`: the only failures are pre-existing `sessionFiles`/`sessions` tests that assume POSIX path formats and fail on a Windows dev box — unrelated to this change (there are no Telegram tests, and this diff only touches `telegram.ts`).

## Version

Bumped `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` to `1.0.41` per CONTRIBUTING (shipped `src/` change).
