### PR TITLE
fix(telegram): include the replied-to / quoted message in the prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.43",
+      "version": "1.0.44",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.40",
+      "version": "1.0.43",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.40",
+  "version": "1.0.43",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -88,7 +88,8 @@ interface TelegramUser {
 interface TelegramMessage {
   message_id: number;
   from?: TelegramUser;
-  reply_to_message?: { message_id?: number; from?: TelegramUser };
+  reply_to_message?: { message_id?: number; from?: TelegramUser; text?: string; caption?: string };
+  quote?: { text?: string };
   chat: { id: number; type: string };
   message_thread_id?: number;
   text?: string;
@@ -1385,6 +1386,18 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
     const promptParts = [`[Telegram from ${label}]`];
     if (threadId) promptParts.push(`[thread:${threadId}]`);
+    // Include the message being replied to / quoted so Claude has the context.
+    // Telegram puts the full original in reply_to_message; quote.text holds the
+    // specific highlighted excerpt when the user quotes only part of a message.
+    const repliedText = message.reply_to_message?.text ?? message.reply_to_message?.caption;
+    const quotedExcerpt = message.quote?.text;
+    if (quotedExcerpt || repliedText) {
+      const fromBot = botId != null && message.reply_to_message?.from?.id === botId;
+      const who = fromBot
+        ? "your own earlier message"
+        : `a message from ${message.reply_to_message?.from?.first_name ?? "someone"}`;
+      promptParts.push(`In reply to ${who}: ${wrapUntrusted("replied-message", quotedExcerpt ?? repliedText!, 2000)}`);
+    }
     if (skillContext) {
       // Strip the slash command from the message text and pass remaining args
       const args = text.trim().slice(command!.length).trim();


### PR DESCRIPTION
## Problem

When a user **replies to** or **quotes** a message in Telegram, Claude never sees the quoted content — it responds as if the reply context didn't exist.

The Telegram API delivers the original message in `reply_to_message` (and, for partial highlights, a top-level `quote` field). But `handleMessage()` only captured the id and sender:

```ts
reply_to_message?: { message_id?: number; from?: TelegramUser };
```

…and the prompt builder only ever added the user's *new* message:

```ts
const promptParts = [`[Telegram from ${label}]`];
...
} else if (text.trim()) {
  promptParts.push(`Message: ${wrapUntrusted("user-message", text)}`);
}
```

So the replied-to/quoted text was silently dropped before Claude ever ran.

## Fix

- Extend the `TelegramMessage` type to include `reply_to_message.text` / `.caption` and a `quote.text` field.
- When present, prepend the quoted context to the prompt as untrusted input (capped at 2000 chars, consistent with voice transcripts and other external content):

```ts
const repliedText = message.reply_to_message?.text ?? message.reply_to_message?.caption;
const quotedExcerpt = message.quote?.text;
if (quotedExcerpt || repliedText) {
  const fromBot = botId != null && message.reply_to_message?.from?.id === botId;
  const who = fromBot
    ? "your own earlier message"
    : `a message from ${message.reply_to_message?.from?.first_name ?? "someone"}`;
  promptParts.push(`In reply to ${who}: ${wrapUntrusted("replied-message", quotedExcerpt ?? repliedText!, 2000)}`);
}
```

`quote.text` (the highlighted excerpt when a user quotes only part of a message) takes precedence over the full `reply_to_message` body; the `from`-vs-bot check makes the phrasing natural in both DMs (replying to the bot) and groups (quoting another user).

## Behavior

- **Before:** "reply to a message + ask about it" → Claude answers without the quoted text.
- **After:** the quoted text is included as context, so Claude can act on it.
- Media-only replies with no text/caption are unaffected (nothing to include — this covers text and captions, not re-reading an old attachment's bytes).

## Testing

- `bunx tsc --noEmit` clean.
- `bun test`: only the pre-existing `sessionFiles`/`sessions` POSIX-path tests fail on a Windows dev box — unrelated to this change.

## Notes

Independent of #250 (queue-on-busy) and #251 (argv-limit); any merge order works. Version bumped to `1.0.43` to avoid clashing with those PRs — happy to renumber/rebase if you'd prefer.
