### PR TITLE
feat(discord): add /kill and /stop to interrupt a running agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw",
       "source": "./",
       "description": "Cron-like daemon that runs Claude prompts on a schedule",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw",
-  "version": "1.0.44",
+  "version": "1.0.45",
   "description": "Cron-like daemon that runs Claude prompts on a schedule"
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -978,6 +978,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
     const command = cleanContent.startsWith("/") ? cleanContent.trim().split(/\s+/, 1)[0].toLowerCase() : null;
 
     if (command === "/kill" || command === "/stop") {
+      // killActive() is global: it kills every in-flight main run across all
+      // Discord channels/threads, not just the caller's. Combined with the
+      // channel-scoped allowlist (#248), a user authorized in one channel can
+      // kill runs in channels they aren't authorized for. Matches Telegram's
+      // existing /kill contract (not a regression); thread-scoped kill is
+      // tracked separately (see #237).
       const killed = killActive();
       await sendMessage(config.token, channelId, killed ? "Killed active agent." : "No active agent running.");
       return;

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -498,7 +498,7 @@ Rules:
     const { execSync } = await import("node:child_process");
     const input = `${systemPrompt}\n\n---\nUser message: ${text}`;
     const result = execSync(
-      `claude --model claude-sonnet-4-20250514 --print --output-format text`,
+      `claude --model claude-sonnet-5 --print --output-format text`,
       {
         input,
         encoding: "utf-8",

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1,4 +1,4 @@
-import { ensureProjectClaudeMd, run, runUserMessage, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
+import { ensureProjectClaudeMd, run, runUserMessage, killActive, compactCurrentSession, compactCurrentThreadSession, agentDirKey } from "../runner";
 import { wrapUntrusted } from "../prompt-safety";
 import { isAllowed } from "../allowlist";
 import { extractErrorDetail } from "../messaging";
@@ -975,6 +975,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
 
     // Skill routing: detect slash commands and resolve to SKILL.md prompts
     const command = cleanContent.startsWith("/") ? cleanContent.trim().split(/\s+/, 1)[0].toLowerCase() : null;
+
+    if (command === "/kill" || command === "/stop") {
+      const killed = killActive();
+      await sendMessage(config.token, channelId, killed ? "Killed active agent." : "No active agent running.");
+      return;
+    }
 
     let skillContext: string | null = null;
     if (command) {


### PR DESCRIPTION
## Problem

Telegram gained `/kill` in #184 (`feat(telegram): live streaming, /verbose tool display, /fork, /kill`), but Discord never got the equivalent.

`killActive()` and the `mainActiveProcs` registry already exist in `runner.ts` and are transport-agnostic — Discord just never imported them. The result is that a Discord user has **no way to stop a run in flight**. If the agent goes off the rails, the only recourse is killing the daemon process.

## Change

Wire the existing `killActive()` into the Discord message handler:

- `/kill` (and `/stop` as an alias) kills all main-queue `claude` subprocesses and confirms in-channel.
- Dispatched immediately after the command is parsed, **before** skill routing and before `runUserMessage()` — so it takes effect right away instead of queueing behind the run it is meant to cancel. This works because Discord's gateway message handler is event-driven and runs concurrently with an in-flight run.
- Fork runs are untouched: `mainActiveProcs` deliberately excludes them, per the existing contract in `runner.ts`.

## Known limitation: kill is global, not caller-scoped

`killActive()` terminates every in-flight main run across all Discord channels and threads, not just the caller's. Two consequences worth stating plainly:

- On a multi-channel server, a `/kill` in one channel cancels runs other people started elsewhere.
- Combined with the channel-scoped allowlist (#248), a user authorized in only one channel can terminate runs in channels they are not authorized for.

This matches Telegram's existing `/kill` contract (#184), so it is not a regression introduced here, and this PR deliberately does not change it. Thread/channel-scoped kill is tracked separately — the same concern is raised on #237. The limitation is also documented at the call site.

## Version

`plugin.json` and `marketplace.json` bumped to **1.0.45**. The review asked for 1.0.44, but upstream `master` consumed 1.0.44 via a merged PR in the interim, so 1.0.45 is the next free version.

## Also included

`chore(discord): update fallback model to claude-sonnet-5` — an unrelated one-line model-string update that was sitting in the same working tree. Kept as its own commit so it can be dropped independently if you would rather it ship separately.

## Testing

- `bun build src/index.ts` — clean.
- `bun test` — **131 pass, 6 fail**. The same 6 fail on a clean `master` on this machine (pre-existing: `plugins.test.ts`, and `jobs.test.ts` asserting `toContain("/.claude/")` against Windows backslash paths). No change in results.
- **Demonstrated end-to-end on a live Discord daemon.** `/kill` typed in a real channel against an in-flight run returned `Killed active agent.` and the run stopped. The terminated subprocess then surfaced `Error (exit 1): Unknown error` in-channel — that is the killed process's abnormal exit travelling the normal error path, and is corroborating evidence that the process really was terminated rather than allowed to finish. Suppressing that message when the exit was a deliberate kill is worth a follow-up.

Branch is synced with upstream `master` via a merge commit (no force-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
